### PR TITLE
Remove redundant getIsInstructor

### DIFF
--- a/equed-lms/Classes/Domain/Model/UserProfile.php
+++ b/equed-lms/Classes/Domain/Model/UserProfile.php
@@ -312,10 +312,6 @@ final class UserProfile extends AbstractEntity
         return $this->isInstructor;
     }
 
-    public function getIsInstructor(): bool
-    {
-        return $this->isInstructor();
-    }
 
     public function setIsInstructor(bool $isInstructor): void
     {

--- a/equed-lms/Classes/Service/UserProfileService.php
+++ b/equed-lms/Classes/Service/UserProfileService.php
@@ -26,7 +26,7 @@ final class UserProfileService
     public function getInstructorProfile(int $userId): ?UserProfile
     {
         $profile = $this->userProfileRepository->findByUserId($userId);
-        return ($profile !== null && $profile->getIsInstructor()) ? $profile : null;
+        return ($profile !== null && $profile->isInstructor()) ? $profile : null;
     }
 
     /**

--- a/equed-lms/Classes/ViewHelpers/UserRoleViewHelper.php
+++ b/equed-lms/Classes/ViewHelpers/UserRoleViewHelper.php
@@ -54,7 +54,7 @@ final class UserRoleViewHelper extends AbstractViewHelper
             $roleKey = $profile->getIsCertifier()
                 ? 'role.certifier'
                 : (
-                    $profile->getIsInstructor()
+                    $profile->isInstructor()
                     ? 'role.instructor'
                     : 'role.participant'
                 );


### PR DESCRIPTION
## Summary
- drop `getIsInstructor` from UserProfile
- reference `isInstructor` in UserProfileService
- update UserRoleViewHelper to use `isInstructor`

## Testing
- `composer test` (fails: cannot declare interface in LMS tests)
- `composer test` in equed-core

------
https://chatgpt.com/codex/tasks/task_e_684a08652a3083249d188523d7720728