### PR TITLE
Implement Module entity

### DIFF
--- a/equed-lms/Classes/Domain/Model/Lesson.php
+++ b/equed-lms/Classes/Domain/Model/Lesson.php
@@ -10,6 +10,7 @@ use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 use TYPO3\CMS\Extbase\Annotation as Extbase;
 use TYPO3\CMS\Extbase\Domain\Model\FileReference;
+use Equed\EquedLms\Domain\Model\Module;
 
 /**
  * Lesson
@@ -29,6 +30,9 @@ final class Lesson extends AbstractEntity
     protected int $expectedDuration = 0;
 
     protected string $category = '';
+
+    #[Extbase\ORM\ManyToOne]
+    protected ?Module $module = null;
 
     /**
      * @var ObjectStorage<ContentPage>
@@ -117,6 +121,16 @@ final class Lesson extends AbstractEntity
     public function setCategory(string $category): void
     {
         $this->category = $category;
+    }
+
+    public function getModule(): ?Module
+    {
+        return $this->module;
+    }
+
+    public function setModule(?Module $module): void
+    {
+        $this->module = $module;
     }
 
     /**

--- a/equed-lms/Classes/Domain/Model/Module.php
+++ b/equed-lms/Classes/Domain/Model/Module.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Domain\Model;
+
+use Ramsey\Uuid\Uuid;
+use TYPO3\CMS\Extbase\Annotation as Extbase;
+use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
+use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
+
+/**
+ * Module
+ */
+final class Module extends AbstractEntity
+{
+    protected string $uuid;
+
+    protected string $title = '';
+
+    protected ?string $description = null;
+
+    protected string $identifier = '';
+
+    #[Extbase\ORM\ManyToOne]
+    protected ?CourseProgram $courseProgram = null;
+
+    /** @var ObjectStorage<Lesson> */
+    #[Extbase\ORM\OneToMany(mappedBy: 'module', cascade: ['remove'])]
+    protected ObjectStorage $lessons;
+
+    public function __construct()
+    {
+        $this->uuid = Uuid::uuid4()->toString();
+        $this->lessons = new ObjectStorage();
+    }
+
+    public function getUuid(): string
+    {
+        return $this->uuid;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(?string $description): void
+    {
+        $this->description = $description;
+    }
+
+    public function getIdentifier(): string
+    {
+        return $this->identifier;
+    }
+
+    public function setIdentifier(string $identifier): void
+    {
+        $this->identifier = $identifier;
+    }
+
+    public function getCourseProgram(): ?CourseProgram
+    {
+        return $this->courseProgram;
+    }
+
+    public function setCourseProgram(?CourseProgram $courseProgram): void
+    {
+        $this->courseProgram = $courseProgram;
+    }
+
+    /**
+     * @return ObjectStorage<Lesson>
+     */
+    public function getLessons(): ObjectStorage
+    {
+        return $this->lessons;
+    }
+
+    public function addLesson(Lesson $lesson): void
+    {
+        if (!$this->lessons->contains($lesson)) {
+            $this->lessons->attach($lesson);
+        }
+    }
+
+    public function removeLesson(Lesson $lesson): void
+    {
+        if ($this->lessons->contains($lesson)) {
+            $this->lessons->detach($lesson);
+        }
+    }
+}

--- a/equed-lms/Configuration/Schema/Domain/Model/Module.yaml
+++ b/equed-lms/Configuration/Schema/Domain/Model/Module.yaml
@@ -1,0 +1,16 @@
+table: tx_equedlms_domain_model_module
+columns:
+  uid:
+    type: integer
+  pid:
+    type: integer
+  title:
+    type: string
+  description:
+    type: text
+  identifier:
+    type: string
+  course_program:
+    type: integer
+  lessons:
+    type: string

--- a/equed-lms/Configuration/TCA/tx_equedlms_domain_model_lesson.php
+++ b/equed-lms/Configuration/TCA/tx_equedlms_domain_model_lesson.php
@@ -42,6 +42,15 @@ return [
                 'eval' => 'int'
             ]
         ],
+        'module' => [
+            'exclude' => true,
+            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_lesson.module',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'foreign_table' => 'tx_equedlms_domain_model_module'
+            ]
+        ],
         'sort_order' => [
             'exclude' => true,
             'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_lesson.sort_order',
@@ -68,10 +77,10 @@ return [
     ],
     'types' => [
         1 => [
-            'showitem' => 'title, description, duration_minutes, course_program, sort_order, visible, materials'
+            'showitem' => 'title, description, duration_minutes, course_program, module, sort_order, visible, materials'
         ]
     ],
     'interface' => [
-        'showRecordFieldList' => 'title,description,duration_minutes,course_program,sort_order,visible,materials'
+        'showRecordFieldList' => 'title,description,duration_minutes,course_program,module,sort_order,visible,materials'
     ]
 ];

--- a/equed-lms/Configuration/TCA/tx_equedlms_domain_model_module.php
+++ b/equed-lms/Configuration/TCA/tx_equedlms_domain_model_module.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+defined('TYPO3') or die();
+
+return [
+    'ctrl' => [
+        'title' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_module',
+        'label' => 'title',
+        'hideTable' => true
+    ],
+    'columns' => [
+        'title' => [
+            'exclude' => true,
+            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_module.title',
+            'config' => [
+                'type' => 'input',
+                'eval' => 'trim'
+            ]
+        ],
+        'description' => [
+            'exclude' => true,
+            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_module.description',
+            'config' => [
+                'type' => 'text'
+            ]
+        ],
+        'identifier' => [
+            'exclude' => true,
+            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_module.identifier',
+            'config' => [
+                'type' => 'input',
+                'eval' => 'trim'
+            ]
+        ],
+        'course_program' => [
+            'exclude' => true,
+            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_module.course_program',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'foreign_table' => 'tx_equedlms_domain_model_courseprogram'
+            ]
+        ],
+        'lessons' => [
+            'exclude' => true,
+            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_module.lessons',
+            'config' => [
+                'type' => 'inline',
+                'foreign_table' => 'tx_equedlms_domain_model_lesson',
+                'foreign_field' => 'module',
+                'appearance' => [
+                    'collapseAll' => true,
+                    'useSortable' => true
+                ]
+            ]
+        ]
+    ],
+    'types' => [
+        1 => [
+            'showitem' => 'title, description, identifier, course_program, lessons'
+        ]
+    ],
+    'interface' => [
+        'showRecordFieldList' => 'title,description,identifier,course_program,lessons'
+    ]
+];

--- a/equed-lms/Resources/Private/Language/locallang_db.de.xlf
+++ b/equed-lms/Resources/Private/Language/locallang_db.de.xlf
@@ -36,6 +36,19 @@
         <source>Associated materials</source><target>Zugehörige Materialien</target></trans-unit>
       <trans-unit id="tx_equedlms_domain_model_lesson.course">
         <source>Parent course</source><target>Zugehöriger Kurs</target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_lesson.module">
+        <source>Parent module</source><target>Zugehöriges Modul</target></trans-unit>
+      <!-- Module -->
+      <trans-unit id="tx_equedlms_domain_model_module.title">
+        <source>Module title</source><target>Modultitel</target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_module.description">
+        <source>Module description</source><target>Modulbeschreibung</target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_module.identifier">
+        <source>Module identifier</source><target>Modulkennung</target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_module.course_program">
+        <source>Course program</source><target>Kursprogramm</target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_module.lessons">
+        <source>Lessons</source><target>Lektionen</target></trans-unit>
 
       
       <trans-unit id="tx_equedlms_domain_model_submission.title">

--- a/equed-lms/Resources/Private/Language/locallang_db.easy.xlf
+++ b/equed-lms/Resources/Private/Language/locallang_db.easy.xlf
@@ -36,6 +36,19 @@
         <source>Associated materials</source><target>Dazu passende Materialien</target></trans-unit>
       <trans-unit id="tx_equedlms_domain_model_lesson.course">
         <source>Parent course</source><target>Zu welchem Kurs gehört das?</target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_lesson.module">
+        <source>Parent module</source><target>Zu welchem Modul gehört das?</target></trans-unit>
+      <!-- Module -->
+      <trans-unit id="tx_equedlms_domain_model_module.title">
+        <source>Module title</source><target>Titel vom Modul</target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_module.description">
+        <source>Module description</source><target>Beschreibung vom Modul</target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_module.identifier">
+        <source>Module identifier</source><target>Modul-Kennung</target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_module.course_program">
+        <source>Course program</source><target>Kurs-Programm</target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_module.lessons">
+        <source>Lessons</source><target>Lektionen</target></trans-unit>
 
       
       <trans-unit id="tx_equedlms_domain_model_submission.title">

--- a/equed-lms/Resources/Private/Language/locallang_db.en.xlf
+++ b/equed-lms/Resources/Private/Language/locallang_db.en.xlf
@@ -51,6 +51,26 @@
       <trans-unit id="tx_equedlms_domain_model_lesson.course">
         <source>Parent course</source>
       </trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_lesson.module">
+        <source>Parent module</source>
+      </trans-unit>
+
+      <!-- Module -->
+      <trans-unit id="tx_equedlms_domain_model_module.title">
+        <source>Module title</source>
+      </trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_module.description">
+        <source>Module description</source>
+      </trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_module.identifier">
+        <source>Module identifier</source>
+      </trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_module.course_program">
+        <source>Course program</source>
+      </trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_module.lessons">
+        <source>Lessons</source>
+      </trans-unit>
 
       <!-- Submission -->
       <trans-unit id="tx_equedlms_domain_model_submission.title">

--- a/equed-lms/Resources/Private/Language/locallang_db.es.xlf
+++ b/equed-lms/Resources/Private/Language/locallang_db.es.xlf
@@ -36,6 +36,19 @@
         <source>Associated materials</source><target>Materiales relacionados</target></trans-unit>
       <trans-unit id="tx_equedlms_domain_model_lesson.course">
         <source>Parent course</source><target>Curso relacionado</target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_lesson.module">
+        <source>Parent module</source><target>Módulo principal</target></trans-unit>
+      <!-- Module -->
+      <trans-unit id="tx_equedlms_domain_model_module.title">
+        <source>Module title</source><target>Título del módulo</target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_module.description">
+        <source>Module description</source><target>Descripción del módulo</target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_module.identifier">
+        <source>Module identifier</source><target>Identificador del módulo</target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_module.course_program">
+        <source>Course program</source><target>Programa del curso</target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_module.lessons">
+        <source>Lessons</source><target>Lecciones</target></trans-unit>
 
       
       <trans-unit id="tx_equedlms_domain_model_submission.title">

--- a/equed-lms/Resources/Private/Language/locallang_db.fr.xlf
+++ b/equed-lms/Resources/Private/Language/locallang_db.fr.xlf
@@ -36,6 +36,19 @@
         <source>Associated materials</source><target>Matériaux associés</target></trans-unit>
       <trans-unit id="tx_equedlms_domain_model_lesson.course">
         <source>Parent course</source><target>Cours associé</target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_lesson.module">
+        <source>Parent module</source><target>Module parent</target></trans-unit>
+      <!-- Module -->
+      <trans-unit id="tx_equedlms_domain_model_module.title">
+        <source>Module title</source><target>Titre du module</target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_module.description">
+        <source>Module description</source><target>Description du module</target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_module.identifier">
+        <source>Module identifier</source><target>Identifiant du module</target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_module.course_program">
+        <source>Course program</source><target>Programme du cours</target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_module.lessons">
+        <source>Lessons</source><target>Leçons</target></trans-unit>
 
       
       <trans-unit id="tx_equedlms_domain_model_submission.title">

--- a/equed-lms/Resources/Private/Language/locallang_db.sw.xlf
+++ b/equed-lms/Resources/Private/Language/locallang_db.sw.xlf
@@ -36,6 +36,19 @@
         <source>Associated materials</source><target>Nyenzo zinazohusiana</target></trans-unit>
       <trans-unit id="tx_equedlms_domain_model_lesson.course">
         <source>Parent course</source><target>Kozi inayohusiana</target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_lesson.module">
+        <source>Parent module</source><target>Moduli kuu</target></trans-unit>
+      <!-- Module -->
+      <trans-unit id="tx_equedlms_domain_model_module.title">
+        <source>Module title</source><target>Kichwa cha moduli</target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_module.description">
+        <source>Module description</source><target>Maelezo ya moduli</target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_module.identifier">
+        <source>Module identifier</source><target>Kitambulisho cha moduli</target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_module.course_program">
+        <source>Course program</source><target>Programu ya kozi</target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_module.lessons">
+        <source>Lessons</source><target>Masomo</target></trans-unit>
 
       
       <trans-unit id="tx_equedlms_domain_model_submission.title">

--- a/equed-lms/Tests/Unit/Domain/Model/ModuleTest.php
+++ b/equed-lms/Tests/Unit/Domain/Model/ModuleTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Tests\Unit\Domain\Model;
+
+use PHPUnit\Framework\TestCase;
+use Equed\EquedLms\Domain\Model\Module;
+use Equed\EquedLms\Domain\Model\Lesson;
+use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
+
+class ModuleTest extends TestCase
+{
+    public function testModuleGettersAndRelations(): void
+    {
+        $module = new Module();
+        $module->setTitle('Intro');
+        $module->setDescription('Basics');
+        $module->setIdentifier('M1');
+
+        $lesson = new Lesson();
+        $module->addLesson($lesson);
+
+        $this->assertNotEmpty($module->getUuid());
+        $this->assertSame('Intro', $module->getTitle());
+        $this->assertSame('Basics', $module->getDescription());
+        $this->assertSame('M1', $module->getIdentifier());
+        $this->assertInstanceOf(ObjectStorage::class, $module->getLessons());
+        $this->assertTrue($module->getLessons()->contains($lesson));
+    }
+}


### PR DESCRIPTION
## Summary
- add `Module` domain model
- relate lessons to modules
- provide backend TCA and YAML schema for module
- localize new module fields in all languages
- cover Module model with unit test

## Testing
- `vendor/bin/phpunit --testsuite unit` *(fails: Cannot declare interface UuidGeneratorInterface)*

------
https://chatgpt.com/codex/tasks/task_e_684a6601181883249d9b5f34b4c83da3