### PR TITLE
Implement UserSubmissionRepositoryInterface

### DIFF
--- a/equed-lms/Classes/Domain/Repository/UserSubmissionRepository.php
+++ b/equed-lms/Classes/Domain/Repository/UserSubmissionRepository.php
@@ -14,7 +14,7 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
  *
  * @extends Repository<UserSubmission>
  */
-class UserSubmissionRepository extends Repository
+class UserSubmissionRepository extends Repository implements UserSubmissionRepositoryInterface
 {
     /**
      * Default ordering: newest submissions first.
@@ -119,6 +119,79 @@ class UserSubmissionRepository extends Repository
         $query->setLimit(1);
 
         return $query->execute()->getFirst();
+    }
+
+    /**
+     * Find submissions pending instructor feedback for a given instructor.
+     *
+     * @param int $feUserId Instructor FE user UID
+     * @return UserSubmission[]
+     */
+    public function findPendingSubmissionsForInstructor(int $feUserId): array
+    {
+        $query = $this->createQuery();
+        $query->matching(
+            $query->logicalAnd([
+                $query->equals('userCourseRecord.courseInstance.instructor', $feUserId),
+                $query->equals('status', SubmissionStatus::Pending->value),
+            ])
+        );
+
+        return $query->execute()->toArray();
+    }
+
+    /**
+     * Count submissions for a specific course instance.
+     */
+    public function countByCourseInstance(int $courseInstanceId): int
+    {
+        $query = $this->createQuery();
+        $query->matching(
+            $query->equals('userCourseRecord.courseInstance', $courseInstanceId)
+        );
+
+        return $query->execute()->count();
+    }
+
+    /**
+     * Find submissions by frontend user.
+     *
+     * @return UserSubmission[]
+     */
+    public function findByFeUser(int $feUserId): array
+    {
+        $query = $this->createQuery();
+        $query->matching(
+            $query->equals('userCourseRecord.user', $feUserId)
+        );
+
+        return $query->execute()->toArray();
+    }
+
+    /**
+     * Find submissions by course instance UID.
+     *
+     * @return UserSubmission[]
+     */
+    public function findByCourseInstance(int $courseInstanceId): array
+    {
+        $query = $this->createQuery();
+        $query->matching(
+            $query->equals('userCourseRecord.courseInstance', $courseInstanceId)
+        );
+
+        return $query->execute()->toArray();
+    }
+
+    /**
+     * Find a submission by UID.
+     */
+    public function findByUid(int $uid): ?UserSubmission
+    {
+        /** @var UserSubmission|null $result */
+        $result = parent::findByUid($uid);
+
+        return $result;
     }
 }
 // EOF

--- a/equed-lms/Classes/Domain/Repository/UserSubmissionRepositoryInterface.php
+++ b/equed-lms/Classes/Domain/Repository/UserSubmissionRepositoryInterface.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Domain\Repository;
+
+use Equed\EquedLms\Domain\Model\UserSubmission;
+use Equed\EquedLms\Enum\SubmissionStatus;
+use TYPO3\CMS\Extbase\Persistence\QueryInterface;
+
+interface UserSubmissionRepositoryInterface
+{
+    /**
+     * @return UserSubmission[]
+     */
+    public function findPendingSubmissionsForInstructor(int $feUserId): array;
+
+    public function countByCourseInstance(int $courseInstanceId): int;
+
+    /**
+     * @return UserSubmission[]
+     */
+    public function findByFeUser(int $feUserId): array;
+
+    /**
+     * @return UserSubmission[]
+     */
+    public function findByCourseInstance(int $courseInstanceId): array;
+
+    public function findByUid(int $uid): ?UserSubmission;
+
+    /**
+     * @return UserSubmission[]
+     */
+    public function findByUserCourseRecord(int $userCourseRecordUid): array;
+
+    /**
+     * @return UserSubmission[]
+     */
+    public function findByLesson(int $lessonUid): array;
+
+    /**
+     * @return UserSubmission[]
+     */
+    public function findByPracticeTest(int $practiceTestUid): array;
+
+    /**
+     * @param SubmissionStatus|string $status
+     * @return UserSubmission[]
+     */
+    public function findByStatus(SubmissionStatus|string $status): array;
+
+    /**
+     * @return UserSubmission[]
+     */
+    public function findPending(): array;
+
+    public function findLatestByUserCourseRecord(int $userCourseRecordUid): ?UserSubmission;
+
+    /**
+     * @return QueryInterface<UserSubmission>
+     */
+    public function createQuery();
+}


### PR DESCRIPTION
## Summary
- add `UserSubmissionRepositoryInterface`
- implement the interface on `UserSubmissionRepository`
- provide methods for pending submissions, course instances, and users

## Testing
- `composer test` *(fails: composer not installed)*
- `vendor/bin/phpunit --version` *(fails: no such file)*

------
https://chatgpt.com/codex/tasks/task_e_684a6b85fca4832485f19791f96a9a69