### PR TITLE
Rename findByCourseInstance method

### DIFF
--- a/equed-lms/Classes/Domain/Repository/CourseBookingRequestRepository.php
+++ b/equed-lms/Classes/Domain/Repository/CourseBookingRequestRepository.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Equed\EquedLms\Domain\Repository;
 
 use Equed\EquedLms\Domain\Model\CourseBookingRequest;
-use Equed\EquedLms\Domain\Model\CourseInstance;
+use Equed\EquedLms\Domain\Model\CourseProgram;
 use Equed\EquedLms\Domain\Model\FrontendUser;
 use TYPO3\CMS\Extbase\Persistence\Repository;
 
@@ -31,16 +31,16 @@ class CourseBookingRequestRepository extends Repository
     }
 
     /**
-     * Finds all booking requests for the given course instance.
+     * Finds all booking requests for the given course program.
      *
-     * @param CourseInstance $courseInstance
+     * @param CourseProgram $courseProgram
      * @return CourseBookingRequest[]
      */
-    public function findByCourseInstance(CourseInstance $courseInstance): array
+    public function findByCourseProgram(CourseProgram $courseProgram): array
     {
         $query = $this->createQuery();
         $query->matching(
-            $query->equals('courseInstance', $courseInstance)
+            $query->equals('courseProgram', $courseProgram)
         );
 
         return $query->execute()->toArray();


### PR DESCRIPTION
## Summary
- rename `findByCourseInstance` to `findByCourseProgram`
- update query parameter to `courseProgram`
- adjust PHPDoc and remove unused import

## Testing
- ❌ `composer install --no-interaction` *(fails: composer not found)*


------
https://chatgpt.com/codex/tasks/task_e_684a817fc3b483248ee7837de4fa331b