### PR TITLE
Fix FeedbackRepository to use CourseFeedback

### DIFF
--- a/equed-lms/Classes/Domain/Repository/FeedbackRepository.php
+++ b/equed-lms/Classes/Domain/Repository/FeedbackRepository.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Equed\EquedLms\Domain\Repository;
 
-use Equed\EquedLms\Domain\Model\Feedback;
+use Equed\EquedLms\Domain\Model\CourseFeedback;
 use Equed\EquedLms\Domain\Model\CourseInstance;
 use Equed\EquedLms\Domain\Model\FrontendUser;
 use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
- * Repository for Feedback entities.
+ * Repository for CourseFeedback entities.
  */
 class FeedbackRepository extends Repository
 {
@@ -19,13 +19,13 @@ class FeedbackRepository extends Repository
      * Finds all feedback entries for a specific frontend user.
      *
      * @param FrontendUser $user
-     * @return Feedback[]
+     * @return CourseFeedback[]
      */
     public function findByFeUser(FrontendUser $user): array
     {
         $query = $this->createQuery();
         $query->matching(
-            $query->equals('feUser', $user)
+            $query->equals('submittedByUser', $user)
         );
 
         return $query->execute()->toArray();
@@ -34,13 +34,13 @@ class FeedbackRepository extends Repository
     /**
      * Finds all feedback entries not yet seen by instructors.
      *
-     * @return Feedback[]
-     */
+     * @return CourseFeedback[]
+    */
     public function findUnseenFeedback(): array
     {
         $query = $this->createQuery();
         $query->matching(
-            $query->equals('seenByInstructor', false)
+            $query->equals('isVisibleToInstructor', false)
         );
 
         return $query->execute()->toArray();
@@ -49,17 +49,13 @@ class FeedbackRepository extends Repository
     /**
      * Finds all feedback entries that have not been analyzed by GPT.
      *
-     * @return QueryResultInterface<Feedback>
+     * @return QueryResultInterface<CourseFeedback>
      */
     public function findUnanalyzed(): QueryResultInterface
     {
         $query = $this->createQuery();
         $query->matching(
-            $query->logicalOr([
-                $query->equals('analysisSummary', null),
-                $query->equals('analysisSummary', ''),
-                $query->equals('suggestedRating', 0),
-            ])
+            $query->equals('status', 'submitted')
         );
 
         return $query->execute();
@@ -70,15 +66,15 @@ class FeedbackRepository extends Repository
      *
      * @param FrontendUser   $user
      * @param CourseInstance $courseInstance
-     * @return Feedback|null
+     * @return CourseFeedback|null
      */
-    public function findByUserAndCourse(FrontendUser $user, CourseInstance $courseInstance): ?Feedback
+    public function findByUserAndCourse(FrontendUser $user, CourseInstance $courseInstance): ?CourseFeedback
     {
         $query = $this->createQuery();
         $query->matching(
             $query->logicalAnd([
-                $query->equals('feUser', $user),
-                $query->equals('course', $courseInstance),
+                $query->equals('submittedByUser', $user),
+                $query->equals('userCourseRecord.courseInstance', $courseInstance),
             ])
         );
         $query->setLimit(1);

--- a/equed-lms/Classes/Service/FeedbackAnalysisService.php
+++ b/equed-lms/Classes/Service/FeedbackAnalysisService.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Equed\EquedLms\Service;
 
-use Equed\EquedLms\Domain\Model\Feedback;
+use Equed\EquedLms\Domain\Model\CourseFeedback;
 use JsonException;
 use Psr\Http\Client\ClientExceptionInterface;
 use Equed\EquedLms\Service\LogServiceInterface;
@@ -31,10 +31,10 @@ final class FeedbackAnalysisService
     /**
      * Analyze feedback; returns analysis array with 'summary', 'clusters', 'suggestedRating' or null.
      *
-     * @param Feedback $feedback Feedback entity
+     * @param CourseFeedback $feedback Feedback entity
      * @return array<string, mixed>|null
      */
-    public function analyzeFeedback(Feedback $feedback): ?array
+    public function analyzeFeedback(CourseFeedback $feedback): ?array
     {
         if (!$this->feedbackAnalysisEnabled) {
             return null;

--- a/equed-lms/Tests/Unit/Domain/Repository/FeedbackRepositoryTest.php
+++ b/equed-lms/Tests/Unit/Domain/Repository/FeedbackRepositoryTest.php
@@ -25,7 +25,7 @@ class FeedbackRepositoryTest extends TestCase
         $this->persistenceManager = $this->prophesize(PersistenceManager::class);
 
         $this->persistenceManager
-            ->createQueryForType(\Equed\EquedLms\Domain\Model\Feedback::class)
+            ->createQueryForType(\Equed\EquedLms\Domain\Model\CourseFeedback::class)
             ->willReturn($this->query);
 
         $this->subject = new FeedbackRepository();

--- a/equed-lms/Tests/Unit/Service/FeedbackAnalysisServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/FeedbackAnalysisServiceTest.php
@@ -6,7 +6,7 @@ namespace Equed\EquedLms\Tests\Unit\Service;
 
 use PHPUnit\Framework\TestCase;
 use Equed\EquedLms\Service\FeedbackAnalysisService;
-use Equed\EquedLms\Domain\Model\Feedback;
+use Equed\EquedLms\Domain\Model\CourseFeedback;
 use TYPO3\CMS\Core\Http\RequestFactory;
 use Psr\Log\NullLogger;
 use Equed\EquedLms\Service\LogService;
@@ -16,7 +16,7 @@ class FeedbackAnalysisServiceTest extends TestCase
 {
     public function testAnalyzeFeedbackReturnsMockedResponse(): void
     {
-        $feedback = new Feedback();
+        $feedback = new CourseFeedback();
         $feedback->setOriginalComment('Sehr strukturiertes, klares Feedback.');
 
         $mockRequestFactory = $this->createMock(RequestFactory::class);

--- a/equed-lms/Tests/Unit/Service/FeedbackServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/FeedbackServiceTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Equed\EquedLms\Tests\Unit\Service;
 
-use Equed\EquedLms\Domain\Model\Feedback;
+use Equed\EquedLms\Domain\Model\CourseFeedback;
 use Equed\EquedLms\Service\FeedbackAnalysisService;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 use Equed\EquedLms\Service\LogServiceInterface;
@@ -30,7 +30,7 @@ class FeedbackServiceTest extends TestCase
             false
         );
 
-        $result = $service->analyzeFeedback(new Feedback());
+        $result = $service->analyzeFeedback(new CourseFeedback());
         $this->assertNull($result);
     }
 }


### PR DESCRIPTION
## Summary
- update FeedbackRepository to work with CourseFeedback model
- adjust FeedbackAnalysisService and related tests for new model name
- update repository tests to use CourseFeedback

## Testing
- `composer install` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a8d7958e08324b67b201f60ab5dc6