### PR TITLE
Implement module and UUID search for LessonRepository

### DIFF
--- a/equed-lms/Classes/Domain/Repository/LessonRepository.php
+++ b/equed-lms/Classes/Domain/Repository/LessonRepository.php
@@ -6,6 +6,7 @@ namespace Equed\EquedLms\Domain\Repository;
 
 use Equed\EquedLms\Domain\Model\CourseProgram;
 use Equed\EquedLms\Domain\Model\Lesson;
+use Equed\EquedLms\Domain\Model\Module;
 use TYPO3\CMS\Extbase\Persistence\QueryInterface;
 use TYPO3\CMS\Extbase\Persistence\Repository;
 
@@ -58,6 +59,39 @@ final class LessonRepository extends Repository
         );
 
         return $query->execute()->toArray();
+    }
+
+    /**
+     * Find all lessons for a specific module.
+     *
+     * @param Module $module
+     * @return Lesson[]
+     */
+    public function findByModule(Module $module): array
+    {
+        $query = $this->createQuery();
+        $query->matching(
+            $query->equals('module', $module)
+        );
+
+        return $query->execute()->toArray();
+    }
+
+    /**
+     * Find a lesson by its UUID.
+     *
+     * @param string $uuid
+     * @return Lesson|null
+     */
+    public function findByUuid(string $uuid): ?Lesson
+    {
+        $query = $this->createQuery();
+        $query->matching(
+            $query->equals('uuid', $uuid)
+        );
+        $query->setLimit(1);
+
+        return $query->execute()->getFirst();
     }
 }
 // EOF


### PR DESCRIPTION
## Summary
- expand LessonRepository with query helpers
- add `findByModule()` and `findByUuid()` methods
- import Module model

## Testing
- `composer lint`
- `composer phpstan` *(fails: invalid phpstan configuration)*
- `composer test` *(fails: PHP fatal error due to duplicate interface)*

------
https://chatgpt.com/codex/tasks/task_e_684aaf4b4aa08324aea31b32d63bd8d4