### PR TITLE
Add active record query

### DIFF
--- a/equed-lms/Classes/Domain/Repository/UserCourseRecordRepository.php
+++ b/equed-lms/Classes/Domain/Repository/UserCourseRecordRepository.php
@@ -45,6 +45,27 @@ final class UserCourseRecordRepository extends Repository implements UserCourseR
     }
 
     /**
+     * Find active course records for a user.
+     *
+     * Active records have the status "in_progress".
+     *
+     * @param FrontendUser $user
+     * @return UserCourseRecord[]
+     */
+    public function findActiveByUser(FrontendUser $user): array
+    {
+        $query = $this->createQuery();
+        $query->matching(
+            $query->logicalAnd([
+                $query->equals('user', $user),
+                $query->equals('status', UserCourseStatus::InProgress->value),
+            ])
+        );
+
+        return $query->execute()->toArray();
+    }
+
+    /**
      * Find all course records for a given course instance.
      *
      * @param CourseInstance $instance

--- a/equed-lms/Tests/Unit/Domain/Repository/UserCourseRecordRepositoryTest.php
+++ b/equed-lms/Tests/Unit/Domain/Repository/UserCourseRecordRepositoryTest.php
@@ -44,4 +44,16 @@ class UserCourseRecordRepositoryTest extends TestCase
         $result = $this->subject->findByUser(new FrontendUser());
         $this->assertSame($expected->reveal(), $result);
     }
+
+    public function testFindActiveByUserReturnsRecords(): void
+    {
+        $expected = $this->prophesize(QueryResultInterface::class);
+
+        $this->query->matching(\Prophecy\Argument::any())->willReturn($this->query);
+        $this->query->execute()->willReturn($expected);
+        $expected->toArray()->willReturn(['rec']);
+
+        $result = $this->subject->findActiveByUser(new FrontendUser());
+        $this->assertSame(['rec'], $result);
+    }
 }


### PR DESCRIPTION
## Summary
- add `findActiveByUser` to the user course record repository
- cover the new method with a unit test

## Testing
- `composer test` *(fails: command not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ab52a95088324ad07e78b0309a2ee