### PR TITLE
Update UserBadgeRepository to use feUser

### DIFF
--- a/equed-lms/Classes/Domain/Repository/UserBadgeRepository.php
+++ b/equed-lms/Classes/Domain/Repository/UserBadgeRepository.php
@@ -27,7 +27,7 @@ final class UserBadgeRepository extends Repository implements UserBadgeRepositor
     ];
 
     /**
-     * Find all badges earned by a specific instructor.
+     * Find all badges earned by a specific user.
      *
      * @param FrontendUser $user
      * @return UserBadge[]
@@ -36,7 +36,7 @@ final class UserBadgeRepository extends Repository implements UserBadgeRepositor
     {
         $query = $this->createQuery();
         $query->matching(
-            $query->equals('instructor', $user)
+            $query->equals('feUser', $user)
         );
 
         return $query->execute()->toArray();
@@ -78,7 +78,7 @@ final class UserBadgeRepository extends Repository implements UserBadgeRepositor
     {
         $query = $this->createQuery();
         $query->matching(
-            $query->equals('instructor', $userId)
+            $query->equals('feUser', $userId)
         );
 
         return $query->execute()->toArray();
@@ -88,7 +88,7 @@ final class UserBadgeRepository extends Repository implements UserBadgeRepositor
     {
         $query = $this->createQuery();
         $query->matching(
-            $query->equals('instructor', $userId)
+            $query->equals('feUser', $userId)
         );
 
         return $query->execute()->count();
@@ -99,7 +99,7 @@ final class UserBadgeRepository extends Repository implements UserBadgeRepositor
         $query = $this->createQuery();
         $query->matching(
             $query->logicalAnd([
-                $query->equals('instructor', $userId),
+                $query->equals('feUser', $userId),
                 $query->equals('badgeType', $type),
             ])
         );
@@ -113,7 +113,7 @@ final class UserBadgeRepository extends Repository implements UserBadgeRepositor
         $query = $this->createQuery();
         $query->matching(
             $query->logicalAnd([
-                $query->equals('instructor', $userId),
+                $query->equals('feUser', $userId),
                 $query->equals('badgeType', $identifier),
             ])
         );


### PR DESCRIPTION
## Summary
- query UserBadgeRepository by `feUser` instead of `instructor`
- update related comment

## Testing
- `composer install` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_684abb83b5508324959844c0d960411d