### PR TITLE
Add typed $defaultOrderings properties

### DIFF
--- a/equed-lms/Classes/Domain/Repository/LearningPathRepository.php
+++ b/equed-lms/Classes/Domain/Repository/LearningPathRepository.php
@@ -17,7 +17,7 @@ final class LearningPathRepository extends Repository
      *
      * @var array<string,int>
      */
-    protected $defaultOrderings = [
+    protected array $defaultOrderings = [
         'level' => QueryInterface::ORDER_ASCENDING,
         'title' => QueryInterface::ORDER_ASCENDING,
     ];

--- a/equed-lms/Classes/Domain/Repository/QmsCaseRepository.php
+++ b/equed-lms/Classes/Domain/Repository/QmsCaseRepository.php
@@ -14,7 +14,7 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
  */
 final class QmsCaseRepository extends Repository
 {
-    protected $defaultOrderings = [
+    protected array $defaultOrderings = [
         'createdAt' => QueryInterface::ORDER_DESCENDING,
     ];
 

--- a/equed-lms/Classes/Domain/Repository/RecognitionAwardRepository.php
+++ b/equed-lms/Classes/Domain/Repository/RecognitionAwardRepository.php
@@ -19,7 +19,7 @@ final class RecognitionAwardRepository extends Repository
      *
      * @var array<string,int>
      */
-    protected $defaultOrderings = [
+    protected array $defaultOrderings = [
         'createdAt' => QueryInterface::ORDER_DESCENDING,
     ];
 

--- a/equed-lms/Classes/Domain/Repository/SubmissionRepository.php
+++ b/equed-lms/Classes/Domain/Repository/SubmissionRepository.php
@@ -20,7 +20,7 @@ final class SubmissionRepository extends Repository implements SubmissionReposit
      *
      * @var array<string,int>
      */
-    protected $defaultOrderings = [
+    protected array $defaultOrderings = [
         'createdAt' => QueryInterface::ORDER_DESCENDING,
     ];
 

--- a/equed-lms/Classes/Domain/Repository/TrainingCenterFeedbackRepository.php
+++ b/equed-lms/Classes/Domain/Repository/TrainingCenterFeedbackRepository.php
@@ -20,7 +20,7 @@ final class TrainingCenterFeedbackRepository extends Repository
      *
      * @var array<string,int>
      */
-    protected $defaultOrderings = [
+    protected array $defaultOrderings = [
         'createdAt' => QueryInterface::ORDER_DESCENDING,
     ];
 

--- a/equed-lms/Classes/Domain/Repository/TrainingRecordRepository.php
+++ b/equed-lms/Classes/Domain/Repository/TrainingRecordRepository.php
@@ -25,7 +25,7 @@ final class TrainingRecordRepository extends Repository
      *
      * @var array<string,int>
      */
-    protected $defaultOrderings = [
+    protected array $defaultOrderings = [
         'createdAt' => QueryInterface::ORDER_DESCENDING,
     ];
 

--- a/equed-lms/Classes/Domain/Repository/UserBadgeRepository.php
+++ b/equed-lms/Classes/Domain/Repository/UserBadgeRepository.php
@@ -22,7 +22,7 @@ final class UserBadgeRepository extends Repository implements UserBadgeRepositor
      *
      * @var array<string,int>
      */
-    protected $defaultOrderings = [
+    protected array $defaultOrderings = [
         'earnedAt' => QueryInterface::ORDER_DESCENDING,
     ];
 

--- a/equed-lms/Classes/Domain/Repository/UserCourseRecordRepository.php
+++ b/equed-lms/Classes/Domain/Repository/UserCourseRecordRepository.php
@@ -24,7 +24,7 @@ final class UserCourseRecordRepository extends Repository implements UserCourseR
      *
      * @var array<string,int>
      */
-    protected $defaultOrderings = [
+    protected array $defaultOrderings = [
         'crdate' => QueryInterface::ORDER_DESCENDING,
     ];
 

--- a/equed-lms/Classes/Domain/Repository/UserProfileRepository.php
+++ b/equed-lms/Classes/Domain/Repository/UserProfileRepository.php
@@ -23,7 +23,7 @@ final class UserProfileRepository extends Repository implements UserProfileRepos
      *
      * @var array<string,int>
      */
-    protected $defaultOrderings = [
+    protected array $defaultOrderings = [
         'updatedAt' => QueryInterface::ORDER_DESCENDING,
     ];
 

--- a/equed-lms/Classes/Domain/Repository/UserProgressRecordRepository.php
+++ b/equed-lms/Classes/Domain/Repository/UserProgressRecordRepository.php
@@ -20,7 +20,7 @@ final class UserProgressRecordRepository extends Repository
      *
      * @var array<string,int>
      */
-    protected $defaultOrderings = [
+    protected array $defaultOrderings = [
         'createdAt' => QueryInterface::ORDER_ASCENDING,
     ];
 

--- a/equed-lms/Classes/Domain/Repository/UserSubmissionRepository.php
+++ b/equed-lms/Classes/Domain/Repository/UserSubmissionRepository.php
@@ -21,7 +21,7 @@ final class UserSubmissionRepository extends Repository implements UserSubmissio
      *
      * @var array<string,int>
      */
-    protected $defaultOrderings = [
+    protected array $defaultOrderings = [
         'createdAt' => QueryInterface::ORDER_DESCENDING,
     ];
 


### PR DESCRIPTION
## Summary
- add `array` type hint for `$defaultOrderings` in repository classes

## Testing
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684abd8fe7dc8324aa2786058b838860