### PR TITLE
Remove deleted flag checks from repository queries

### DIFF
--- a/equed-lms/Classes/Domain/Repository/CourseMaterialRepository.php
+++ b/equed-lms/Classes/Domain/Repository/CourseMaterialRepository.php
@@ -36,12 +36,9 @@ final class CourseMaterialRepository extends Repository
      */
     public function findAllActive(): array
     {
-        $query = $this->createQuery();
-        $query->matching(
-            $query->equals('deleted', 0)
-        );
-
-        return $query->execute()->toArray();
+        return $this->createQuery()
+            ->execute()
+            ->toArray();
     }
 }
 // EOF

--- a/equed-lms/Classes/Domain/Repository/LessonQuestionRepository.php
+++ b/equed-lms/Classes/Domain/Repository/LessonQuestionRepository.php
@@ -48,12 +48,9 @@ final class LessonQuestionRepository extends Repository
      */
     public function findAllActive(): array
     {
-        $query = $this->createQuery();
-        $query->matching(
-            $query->equals('deleted', 0)
-        );
-
-        return $query->execute()->toArray();
+        return $this->createQuery()
+            ->execute()
+            ->toArray();
     }
 }
 // EOF

--- a/equed-lms/Classes/Domain/Repository/ObservationTemplateRepository.php
+++ b/equed-lms/Classes/Domain/Repository/ObservationTemplateRepository.php
@@ -19,12 +19,9 @@ final class ObservationTemplateRepository extends Repository
      */
     public function findAllActive(): array
     {
-        $query = $this->createQuery();
-        $query->matching(
-            $query->equals('deleted', 0)
-        );
-
-        return $query->execute()->toArray();
+        return $this->createQuery()
+            ->execute()
+            ->toArray();
     }
 
     /**

--- a/equed-lms/Classes/Domain/Repository/PracticeQuestionRepository.php
+++ b/equed-lms/Classes/Domain/Repository/PracticeQuestionRepository.php
@@ -20,12 +20,9 @@ final class PracticeQuestionRepository extends Repository
      */
     public function findAllActive(): array
     {
-        $query = $this->createQuery();
-        $query->matching(
-            $query->equals('deleted', 0)
-        );
-
-        return $query->execute()->toArray();
+        return $this->createQuery()
+            ->execute()
+            ->toArray();
     }
 
     /**

--- a/equed-lms/Classes/Domain/Repository/PracticeTestRepository.php
+++ b/equed-lms/Classes/Domain/Repository/PracticeTestRepository.php
@@ -19,12 +19,9 @@ final class PracticeTestRepository extends Repository
      */
     public function findAllActive(): array
     {
-        $query = $this->createQuery();
-        $query->matching(
-            $query->equals('deleted', 0)
-        );
-
-        return $query->execute()->toArray();
+        return $this->createQuery()
+            ->execute()
+            ->toArray();
     }
 
     /**

--- a/equed-lms/Classes/Domain/Repository/RecognitionAwardRepository.php
+++ b/equed-lms/Classes/Domain/Repository/RecognitionAwardRepository.php
@@ -30,12 +30,9 @@ final class RecognitionAwardRepository extends Repository
      */
     public function findAllActive(): array
     {
-        $query = $this->createQuery();
-        $query->matching(
-            $query->equals('deleted', 0)
-        );
-
-        return $query->execute()->toArray();
+        return $this->createQuery()
+            ->execute()
+            ->toArray();
     }
 
     /**


### PR DESCRIPTION
## Summary
- simplify queries across repository classes
- Extbase already filters out deleted records, so the explicit checks were redundant

## Testing
- `composer -n run-script lint` *(fails: composer not found)*
- `php -l equed-lms/Classes/Domain/Repository/CourseMaterialRepository.php` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ac02222788324be586c54ee217b99