### PR TITLE
Align repository interfaces with implementations

### DIFF
--- a/equed-lms/Classes/Domain/Repository/CourseInstanceRepository.php
+++ b/equed-lms/Classes/Domain/Repository/CourseInstanceRepository.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Domain\Repository;
+
+use Equed\EquedLms\Domain\Model\CourseInstance;
+use TYPO3\CMS\Extbase\Persistence\QueryInterface;
+use TYPO3\CMS\Extbase\Persistence\Repository;
+
+/**
+ * Repository for CourseInstance entities.
+ *
+ * @extends Repository<CourseInstance>
+ */
+final class CourseInstanceRepository extends Repository implements CourseInstanceRepositoryInterface
+{
+    /**
+     * Find instances that require an external examiner but don't have one yet.
+     *
+     * @return CourseInstance[]
+     */
+    public function findAllRequiringExternalExaminer(): array
+    {
+        $query = $this->createQuery();
+        $query->matching(
+            $query->logicalAnd([
+                $query->equals('requiresExternalExaminer', true),
+                $query->equals('externalExaminer', null),
+            ])
+        );
+
+        return $query->execute()->toArray();
+    }
+
+    /**
+     * Return distinct values for a database field.
+     *
+     * @param string $field Database field name
+     * @return array<int, mixed>
+     */
+    public function findDistinctField(string $field): array
+    {
+        $queryBuilder = $this->createQuery()->getQueryBuilder();
+        $queryBuilder->resetQueryParts();
+        $rows = $queryBuilder
+            ->selectDistinct($field)
+            ->from('tx_equedlms_domain_model_courseinstance')
+            ->executeQuery()
+            ->fetchFirstColumn();
+
+        return array_values(array_filter($rows, static fn ($v) => $v !== null && $v !== ''));
+    }
+}

--- a/equed-lms/Classes/Domain/Repository/CourseInstanceRepositoryInterface.php
+++ b/equed-lms/Classes/Domain/Repository/CourseInstanceRepositoryInterface.php
@@ -12,9 +12,17 @@ use Equed\EquedLms\Domain\Model\CourseInstance;
  * @method CourseInstance|null findByUid(int $uid)
  * @method CourseInstance[] findByInstructor(int $instructorId)
  * @method CourseInstance[] findByCourseProgram(int $courseProgramId)
- * @method CourseInstance[] findAllRequiringExternalExaminer()
- * @method array<int, mixed> findDistinctField(string $field)
  */
 interface CourseInstanceRepositoryInterface
 {
+    /**
+     * @return CourseInstance[]
+     */
+    public function findAllRequiringExternalExaminer(): array;
+
+    /**
+     * @param string $field
+     * @return array<int, mixed>
+     */
+    public function findDistinctField(string $field): array;
 }

--- a/equed-lms/Classes/Domain/Repository/NotificationRepository.php
+++ b/equed-lms/Classes/Domain/Repository/NotificationRepository.php
@@ -8,11 +8,14 @@ use Equed\EquedLms\Domain\Model\Notification;
 use Equed\EquedLms\Domain\Model\FrontendUser;
 use TYPO3\CMS\Extbase\Persistence\QueryInterface;
 use TYPO3\CMS\Extbase\Persistence\Repository;
+use Equed\EquedLms\Domain\Repository\NotificationRepositoryInterface;
 
 /**
  * Repository for Notification entities.
+ *
+ * @extends Repository<Notification>
  */
-final class NotificationRepository extends Repository
+final class NotificationRepository extends Repository implements NotificationRepositoryInterface
 {
     /**
      * Finds unread notifications for a specific instructor.

--- a/equed-lms/Classes/Domain/Repository/UserSubmissionRepositoryInterface.php
+++ b/equed-lms/Classes/Domain/Repository/UserSubmissionRepositoryInterface.php
@@ -72,5 +72,5 @@ interface UserSubmissionRepositoryInterface
     /**
      * @return QueryInterface<UserSubmission>
      */
-    public function createQuery();
+    public function createQuery(): QueryInterface;
 }


### PR DESCRIPTION
## Summary
- implement missing `CourseInstanceRepository`
- make `NotificationRepository` implement its interface and add generics
- clarify return type in `UserSubmissionRepositoryInterface`
- expose custom methods in `CourseInstanceRepositoryInterface`

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ac14626a08324aa16439d99b6d0f1