### PR TITLE
Replace status strings with enums

### DIFF
--- a/equed-lms/Classes/Domain/Repository/UserCourseRecordRepository.php
+++ b/equed-lms/Classes/Domain/Repository/UserCourseRecordRepository.php
@@ -84,7 +84,7 @@ final class UserCourseRecordRepository extends Repository implements UserCourseR
     /**
      * Find course records by status.
      *
-     * @param string $status Enum: in_progress, failed, passed, validated
+     * @param UserCourseStatus|string $status Value from UserCourseStatus enum
      * @return UserCourseRecord[]
      */
     public function findByStatus(UserCourseStatus|string $status): array

--- a/equed-lms/Classes/Service/DashboardService.php
+++ b/equed-lms/Classes/Service/DashboardService.php
@@ -13,6 +13,7 @@ use Equed\EquedLms\Domain\Repository\CertificateDispatchRepositoryInterface;
 use Equed\EquedLms\Domain\Repository\NotificationRepositoryInterface;
 use Equed\EquedLms\Service\ProgressServiceInterface;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
+use Equed\EquedLms\Enum\UserCourseStatus;
 
 /**
  * Aggregates and prepares all data for the user dashboard,
@@ -115,10 +116,10 @@ final class DashboardService
 
         foreach ($records as $record) {
             $ci     = $record->getCourseInstance();
-            $status = $record->getStatus()->value;
+            $status = $record->getStatus();
             $tabKey = match ($status) {
-                'validated', 'passed' => 'completed',
-                default               => 'running',
+                UserCourseStatus::Validated, UserCourseStatus::Passed => 'completed',
+                default                                            => 'running',
             };
             $ciId   = $ci->getUid();
             $certUrl = $latestCertificates[$ciId]?->getQrCodeUrl() ?? null;

--- a/equed-lms/Classes/Service/UserSubmissionService.php
+++ b/equed-lms/Classes/Service/UserSubmissionService.php
@@ -47,7 +47,7 @@ final class UserSubmissionService
      * Determines if a submission is validatable (pending validation).
      *
      * @param int $submissionId UID of the submission
-     * @return bool True if submission exists and status is 'pending'
+     * @return bool True if submission exists and status is SubmissionStatus::Pending
      */
     public function isValidatable(int $submissionId): bool
     {

--- a/equed-lms/Tests/Unit/Domain/Model/UserCourseRecordTest.php
+++ b/equed-lms/Tests/Unit/Domain/Model/UserCourseRecordTest.php
@@ -35,7 +35,7 @@ namespace Equed\EquedLms\Tests\Unit\Domain\Model {
 
         public function testSetAndGetStatus(): void
         {
-            $this->subject->setStatus('validated');
+            $this->subject->setStatus(\Equed\EquedLms\Enum\UserCourseStatus::Validated);
             $this->assertSame('validated', $this->subject->getStatus()->value);
         }
 

--- a/equed-lms/Tests/Unit/Service/UserSubmissionServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/UserSubmissionServiceTest.php
@@ -33,7 +33,7 @@ class UserSubmissionServiceTest extends TestCase
     public function testGetInstructorFeedbackStatusReturnsValue(): void
     {
         $submission = $this->prophesize(\stdClass::class);
-        $submission->getStatus()->willReturn((object)['value' => 'pending']);
+        $submission->getStatus()->willReturn(\Equed\EquedLms\Enum\SubmissionStatus::Pending);
         $this->repository->findByUid(7)->willReturn($submission->reveal());
 
         $this->assertSame('pending', $this->subject->getInstructorFeedbackStatus(7));


### PR DESCRIPTION
## Summary
- update docblocks and logic to use enum constants
- use enum constants in dashboard service
- adjust unit tests for enum usage

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684acacd56e08324836b8800b0a15351