### PR TITLE
Improve repository docs and count queries

### DIFF
--- a/equed-lms/Classes/Domain/Repository/CertificateDispatchRepository.php
+++ b/equed-lms/Classes/Domain/Repository/CertificateDispatchRepository.php
@@ -12,6 +12,9 @@ use Equed\EquedLms\Domain\Repository\CertificateDispatchRepositoryInterface;
 
 /**
  * Repository for CertificateDispatch entities.
+
+ *
+ * @extends Repository<CertificateDispatch>
  */
 final class CertificateDispatchRepository extends Repository implements CertificateDispatchRepositoryInterface
 {

--- a/equed-lms/Classes/Domain/Repository/CertificateTemplateRepository.php
+++ b/equed-lms/Classes/Domain/Repository/CertificateTemplateRepository.php
@@ -9,6 +9,9 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
  * Repository for CertificateTemplate entities.
+
+ *
+ * @extends Repository<CertificateTemplate>
  */
 final class CertificateTemplateRepository extends Repository
 {

--- a/equed-lms/Classes/Domain/Repository/CourseAccessMapRepository.php
+++ b/equed-lms/Classes/Domain/Repository/CourseAccessMapRepository.php
@@ -11,6 +11,9 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
  * Repository for CourseAccessMap entities.
+
+ *
+ * @extends Repository<CourseAccessMap>
  */
 final class CourseAccessMapRepository extends Repository
 {

--- a/equed-lms/Classes/Domain/Repository/CourseBookingRequestRepository.php
+++ b/equed-lms/Classes/Domain/Repository/CourseBookingRequestRepository.php
@@ -11,6 +11,9 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
  * Repository for CourseBookingRequest entities.
+
+ *
+ * @extends Repository<CourseBookingRequest>
  */
 final class CourseBookingRequestRepository extends Repository
 {

--- a/equed-lms/Classes/Domain/Repository/CourseBundleRepository.php
+++ b/equed-lms/Classes/Domain/Repository/CourseBundleRepository.php
@@ -9,6 +9,9 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
  * Repository for CourseBundle entities.
+
+ *
+ * @extends Repository<CourseBundle>
  */
 final class CourseBundleRepository extends Repository
 {

--- a/equed-lms/Classes/Domain/Repository/CourseInstanceRepository.php
+++ b/equed-lms/Classes/Domain/Repository/CourseInstanceRepository.php
@@ -42,7 +42,6 @@ final class CourseInstanceRepository extends Repository implements CourseInstanc
     public function findDistinctField(string $field): array
     {
         $queryBuilder = $this->createQuery()->getQueryBuilder();
-        $queryBuilder->resetQueryParts();
         $rows = $queryBuilder
             ->selectDistinct($field)
             ->from('tx_equedlms_domain_model_courseinstance')

--- a/equed-lms/Classes/Domain/Repository/CourseMaterialRepository.php
+++ b/equed-lms/Classes/Domain/Repository/CourseMaterialRepository.php
@@ -9,6 +9,9 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
  * Repository for CourseMaterial entities.
+
+ *
+ * @extends Repository<CourseMaterial>
  */
 final class CourseMaterialRepository extends Repository
 {

--- a/equed-lms/Classes/Domain/Repository/ExamAttemptRepository.php
+++ b/equed-lms/Classes/Domain/Repository/ExamAttemptRepository.php
@@ -11,6 +11,9 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
  * Repository for ExamAttempt entities.
+
+ *
+ * @extends Repository<ExamAttempt>
  */
 final class ExamAttemptRepository extends Repository
 {

--- a/equed-lms/Classes/Domain/Repository/FeedbackEntryRepository.php
+++ b/equed-lms/Classes/Domain/Repository/FeedbackEntryRepository.php
@@ -10,6 +10,9 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
  * Repository for FeedbackEntry entities.
+
+ *
+ * @extends Repository<FeedbackEntry>
  */
 final class FeedbackEntryRepository extends Repository
 {

--- a/equed-lms/Classes/Domain/Repository/FeedbackRepository.php
+++ b/equed-lms/Classes/Domain/Repository/FeedbackRepository.php
@@ -12,6 +12,9 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
  * Repository for CourseFeedback entities.
+
+ *
+ * @extends Repository<Feedback>
  */
 final class FeedbackRepository extends Repository
 {

--- a/equed-lms/Classes/Domain/Repository/GlossaryEntryRepository.php
+++ b/equed-lms/Classes/Domain/Repository/GlossaryEntryRepository.php
@@ -9,6 +9,9 @@ use TYPO3\CMS\Extbase\Persistence\QueryInterface;
 
 /**
  * Repository for GlossaryEntry entities.
+
+ *
+ * @extends Repository<GlossaryEntry>
  */
 final class GlossaryEntryRepository extends Repository
 {

--- a/equed-lms/Classes/Domain/Repository/IncidentReportRepository.php
+++ b/equed-lms/Classes/Domain/Repository/IncidentReportRepository.php
@@ -11,6 +11,9 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
  * Repository for IncidentReport entities.
+
+ *
+ * @extends Repository<IncidentReport>
  */
 final class IncidentReportRepository extends Repository
 {

--- a/equed-lms/Classes/Domain/Repository/InstructorAvailabilityRegionRepository.php
+++ b/equed-lms/Classes/Domain/Repository/InstructorAvailabilityRegionRepository.php
@@ -11,6 +11,9 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
  * Repository for InstructorAvailabilityRegion entities.
+
+ *
+ * @extends Repository<InstructorAvailabilityRegion>
  */
 final class InstructorAvailabilityRegionRepository extends Repository
 {

--- a/equed-lms/Classes/Domain/Repository/InstructorEligibilityRepository.php
+++ b/equed-lms/Classes/Domain/Repository/InstructorEligibilityRepository.php
@@ -11,6 +11,9 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
  * Repository for InstructorEligibility entities.
+
+ *
+ * @extends Repository<InstructorEligibility>
  */
 final class InstructorEligibilityRepository extends Repository
 {

--- a/equed-lms/Classes/Domain/Repository/InstructorFeedbackRepository.php
+++ b/equed-lms/Classes/Domain/Repository/InstructorFeedbackRepository.php
@@ -11,6 +11,9 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
  * Repository for InstructorFeedback entities.
+
+ *
+ * @extends Repository<InstructorFeedback>
  */
 final class InstructorFeedbackRepository extends Repository
 {

--- a/equed-lms/Classes/Domain/Repository/LearningPathRepository.php
+++ b/equed-lms/Classes/Domain/Repository/LearningPathRepository.php
@@ -9,6 +9,9 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
  * Repository for LearningPath entities.
+
+ *
+ * @extends Repository<LearningPath>
  */
 final class LearningPathRepository extends Repository
 {

--- a/equed-lms/Classes/Domain/Repository/LessonAnswerOptionRepository.php
+++ b/equed-lms/Classes/Domain/Repository/LessonAnswerOptionRepository.php
@@ -10,6 +10,9 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
  * Repository for LessonAnswerOption entities.
+
+ *
+ * @extends Repository<LessonAnswerOption>
  */
 final class LessonAnswerOptionRepository extends Repository
 {

--- a/equed-lms/Classes/Domain/Repository/LessonAttemptAnswerRepository.php
+++ b/equed-lms/Classes/Domain/Repository/LessonAttemptAnswerRepository.php
@@ -11,6 +11,9 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
  * Repository for LessonAttemptAnswer entities.
+
+ *
+ * @extends Repository<LessonAttemptAnswer>
  */
 final class LessonAttemptAnswerRepository extends Repository
 {

--- a/equed-lms/Classes/Domain/Repository/LessonAttemptRepository.php
+++ b/equed-lms/Classes/Domain/Repository/LessonAttemptRepository.php
@@ -12,6 +12,9 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
  * Repository for LessonAttempt entities.
+
+ *
+ * @extends Repository<LessonAttempt>
  */
 final class LessonAttemptRepository extends Repository
 {

--- a/equed-lms/Classes/Domain/Repository/LessonProgressRepository.php
+++ b/equed-lms/Classes/Domain/Repository/LessonProgressRepository.php
@@ -14,6 +14,9 @@ use Equed\EquedLms\Domain\Repository\LessonProgressRepositoryInterface;
 
 /**
  * Repository for LessonProgress entries.
+
+ *
+ * @extends Repository<LessonProgress>
  *
  * Uses QueryBuilder for efficient scalar queries,
  * returns only needed fields,

--- a/equed-lms/Classes/Domain/Repository/LessonQuestionRepository.php
+++ b/equed-lms/Classes/Domain/Repository/LessonQuestionRepository.php
@@ -11,6 +11,9 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
  * Repository for LessonQuestion entities.
+
+ *
+ * @extends Repository<LessonQuestion>
  */
 final class LessonQuestionRepository extends Repository
 {

--- a/equed-lms/Classes/Domain/Repository/LessonQuizRepository.php
+++ b/equed-lms/Classes/Domain/Repository/LessonQuizRepository.php
@@ -11,6 +11,9 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
  * Repository for LessonQuiz entities.
+
+ *
+ * @extends Repository<LessonQuiz>
  */
 final class LessonQuizRepository extends Repository
 {

--- a/equed-lms/Classes/Domain/Repository/LessonRepository.php
+++ b/equed-lms/Classes/Domain/Repository/LessonRepository.php
@@ -12,6 +12,9 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
  * Repository for Lesson entities.
+
+ *
+ * @extends Repository<Lesson>
  */
 final class LessonRepository extends Repository
 {

--- a/equed-lms/Classes/Domain/Repository/ModuleRepository.php
+++ b/equed-lms/Classes/Domain/Repository/ModuleRepository.php
@@ -10,6 +10,8 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
  * Repository for Module entities.
+ *
+ * @extends Repository<Module>
  */
 final class ModuleRepository extends Repository
 {

--- a/equed-lms/Classes/Domain/Repository/ObservationTemplateRepository.php
+++ b/equed-lms/Classes/Domain/Repository/ObservationTemplateRepository.php
@@ -9,6 +9,9 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
  * Repository for ObservationTemplate entities.
+
+ *
+ * @extends Repository<ObservationTemplate>
  */
 final class ObservationTemplateRepository extends Repository
 {

--- a/equed-lms/Classes/Domain/Repository/PracticeQuestionRepository.php
+++ b/equed-lms/Classes/Domain/Repository/PracticeQuestionRepository.php
@@ -10,6 +10,9 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
  * Repository for PracticeQuestion entities.
+
+ *
+ * @extends Repository<PracticeQuestion>
  */
 final class PracticeQuestionRepository extends Repository
 {

--- a/equed-lms/Classes/Domain/Repository/PracticeTestRepository.php
+++ b/equed-lms/Classes/Domain/Repository/PracticeTestRepository.php
@@ -9,6 +9,9 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
  * Repository for PracticeTest entities.
+
+ *
+ * @extends Repository<PracticeTest>
  */
 final class PracticeTestRepository extends Repository
 {

--- a/equed-lms/Classes/Domain/Repository/QmsCaseRepository.php
+++ b/equed-lms/Classes/Domain/Repository/QmsCaseRepository.php
@@ -11,6 +11,8 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
  * Repository for QMS cases.
+ *
+ * @extends Repository<QmsCase>
  */
 final class QmsCaseRepository extends Repository
 {

--- a/equed-lms/Classes/Domain/Repository/RecognitionAwardRepository.php
+++ b/equed-lms/Classes/Domain/Repository/RecognitionAwardRepository.php
@@ -11,6 +11,9 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
  * Repository for RecognitionAward entities.
+
+ *
+ * @extends Repository<RecognitionAward>
  */
 final class RecognitionAwardRepository extends Repository
 {

--- a/equed-lms/Classes/Domain/Repository/TrainingCenterFeedbackRepository.php
+++ b/equed-lms/Classes/Domain/Repository/TrainingCenterFeedbackRepository.php
@@ -12,6 +12,9 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
  * Repository for TrainingCenterFeedback entities.
+
+ *
+ * @extends Repository<TrainingCenterFeedback>
  */
 final class TrainingCenterFeedbackRepository extends Repository
 {

--- a/equed-lms/Classes/Domain/Repository/UserBadgeRepository.php
+++ b/equed-lms/Classes/Domain/Repository/UserBadgeRepository.php
@@ -98,12 +98,17 @@ final class UserBadgeRepository extends Repository implements UserBadgeRepositor
      */
     public function countValidBadges(int $userId): int
     {
-        $query = $this->createQuery();
-        $query->matching(
-            $query->equals('feUser', $userId)
-        );
+        $qb = $this->createQuery()->getQueryBuilder();
+        $qb
+            ->select($qb->expr()->count('*'))
+            ->from('tx_equedlms_domain_model_userbadge')
+            ->where(
+                $qb->expr()->eq('user', $qb->createNamedParameter($userId, \PDO::PARAM_INT))
+            );
 
-        return $query->count();
+        $result = $qb->executeQuery()->fetchOne();
+
+        return $result === false ? 0 : (int)$result;
     }
 
     /**
@@ -136,15 +141,18 @@ final class UserBadgeRepository extends Repository implements UserBadgeRepositor
      */
     public function countByUserAndIdentifier(int $userId, string $identifier): int
     {
-        $query = $this->createQuery();
-        $query->matching(
-            $query->logicalAnd([
-                $query->equals('feUser', $userId),
-                $query->equals('badgeType', $identifier),
-            ])
-        );
+        $qb = $this->createQuery()->getQueryBuilder();
+        $qb
+            ->select($qb->expr()->count('*'))
+            ->from('tx_equedlms_domain_model_userbadge')
+            ->where(
+                $qb->expr()->eq('user', $qb->createNamedParameter($userId, \PDO::PARAM_INT)),
+                $qb->expr()->eq('badge_type', $qb->createNamedParameter($identifier))
+            );
 
-        return $query->count();
+        $result = $qb->executeQuery()->fetchOne();
+
+        return $result === false ? 0 : (int)$result;
     }
 }
 // EOF

--- a/equed-lms/Classes/Domain/Repository/UserCourseRecordRepository.php
+++ b/equed-lms/Classes/Domain/Repository/UserCourseRecordRepository.php
@@ -179,7 +179,6 @@ final class UserCourseRecordRepository extends Repository implements UserCourseR
         }
 
         $qb = $this->createQuery()->getQueryBuilder();
-        $qb->resetQueryParts();
         $qb
             ->select($qb->expr()->count('*'))
             ->from('tx_equedlms_domain_model_usercourserecord')
@@ -198,7 +197,6 @@ final class UserCourseRecordRepository extends Repository implements UserCourseR
     public function countByUserId(int $userId): int
     {
         $qb = $this->createQuery()->getQueryBuilder();
-        $qb->resetQueryParts();
         $qb
             ->select($qb->expr()->count('*'))
             ->from('tx_equedlms_domain_model_usercourserecord')
@@ -223,7 +221,6 @@ final class UserCourseRecordRepository extends Repository implements UserCourseR
         }
 
         $qb = $this->createQuery()->getQueryBuilder();
-        $qb->resetQueryParts();
         $qb
             ->select($qb->expr()->count('*'))
             ->from('tx_equedlms_domain_model_usercourserecord')
@@ -249,7 +246,6 @@ final class UserCourseRecordRepository extends Repository implements UserCourseR
         }
 
         $qb = $this->createQuery()->getQueryBuilder();
-        $qb->resetQueryParts();
         $qb
             ->select($qb->expr()->count('*'))
             ->from('tx_equedlms_domain_model_usercourserecord')
@@ -270,7 +266,6 @@ final class UserCourseRecordRepository extends Repository implements UserCourseR
     public function countByUserIdAndCourseProgram(int $userId, int $courseProgramId): int
     {
         $qb = $this->createQuery()->getQueryBuilder();
-        $qb->resetQueryParts();
         $qb
             ->select($qb->expr()->count('*'))
             ->from('tx_equedlms_domain_model_usercourserecord', 'ucr')
@@ -299,7 +294,6 @@ final class UserCourseRecordRepository extends Repository implements UserCourseR
     public function findDistinctField(string $field): array
     {
         $queryBuilder = $this->createQuery()->getQueryBuilder();
-        $queryBuilder->resetQueryParts();
         $rows = $queryBuilder
             ->selectDistinct($field)
             ->from('tx_equedlms_domain_model_usercourserecord')

--- a/equed-lms/Classes/Domain/Repository/UserSubmissionRepository.php
+++ b/equed-lms/Classes/Domain/Repository/UserSubmissionRepository.php
@@ -49,7 +49,6 @@ final class UserSubmissionRepository extends Repository implements UserSubmissio
     public function findScoresByUserCourseRecord(int $userCourseRecordUid): array
     {
         $queryBuilder = $this->createQuery()->getQueryBuilder();
-        $queryBuilder->resetQueryParts();
         $queryBuilder
             ->select('us.points_awarded AS points', 'us.max_points AS maxPoints')
             ->from('tx_equedlms_domain_model_usersubmission', 'us')
@@ -111,12 +110,17 @@ final class UserSubmissionRepository extends Repository implements UserSubmissio
      */
     public function countByLesson(Lesson $lesson): int
     {
-        $query = $this->createQuery();
-        $query->matching(
-            $query->equals('lesson', $lesson)
-        );
+        $qb = $this->createQuery()->getQueryBuilder();
+        $qb
+            ->select($qb->expr()->count('*'))
+            ->from('tx_equedlms_domain_model_usersubmission')
+            ->where(
+                $qb->expr()->eq('lesson', $qb->createNamedParameter($lesson->getUid(), \PDO::PARAM_INT))
+            );
 
-        return $query->count();
+        $result = $qb->executeQuery()->fetchOne();
+
+        return $result === false ? 0 : (int)$result;
     }
 
     /**
@@ -124,12 +128,17 @@ final class UserSubmissionRepository extends Repository implements UserSubmissio
      */
     public function countByPracticeTest(PracticeTest $practiceTest): int
     {
-        $query = $this->createQuery();
-        $query->matching(
-            $query->equals('practiceTest', $practiceTest)
-        );
+        $qb = $this->createQuery()->getQueryBuilder();
+        $qb
+            ->select($qb->expr()->count('*'))
+            ->from('tx_equedlms_domain_model_usersubmission')
+            ->where(
+                $qb->expr()->eq('practice_test', $qb->createNamedParameter($practiceTest->getUid(), \PDO::PARAM_INT))
+            );
 
-        return $query->count();
+        $result = $qb->executeQuery()->fetchOne();
+
+        return $result === false ? 0 : (int)$result;
     }
 
     /**
@@ -204,12 +213,17 @@ final class UserSubmissionRepository extends Repository implements UserSubmissio
      */
     public function countByCourseInstance(int $courseInstanceId): int
     {
-        $query = $this->createQuery();
-        $query->matching(
-            $query->equals('userCourseRecord.courseInstance', $courseInstanceId)
-        );
+        $qb = $this->createQuery()->getQueryBuilder();
+        $qb
+            ->select($qb->expr()->count('*'))
+            ->from('tx_equedlms_domain_model_usersubmission')
+            ->where(
+                $qb->expr()->eq('course_instance', $qb->createNamedParameter($courseInstanceId, \PDO::PARAM_INT))
+            );
 
-        return $query->count();
+        $result = $qb->executeQuery()->fetchOne();
+
+        return $result === false ? 0 : (int)$result;
     }
 
     /**


### PR DESCRIPTION
## Summary
- document repository generics via `@extends` annotations
- rewrite count methods to use QueryBuilder `COUNT(*)`
- drop obsolete `resetQueryParts()` calls

## Testing
- `composer -V` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684adeda73488324a597f1e1cb9c871a