### PR TITLE
Fix badge count queries to use fe_user column

### DIFF
--- a/equed-lms/Classes/Domain/Repository/UserBadgeRepository.php
+++ b/equed-lms/Classes/Domain/Repository/UserBadgeRepository.php
@@ -103,7 +103,7 @@ final class UserBadgeRepository extends Repository implements UserBadgeRepositor
             ->select($qb->expr()->count('*'))
             ->from('tx_equedlms_domain_model_userbadge')
             ->where(
-                $qb->expr()->eq('user', $qb->createNamedParameter($userId, \PDO::PARAM_INT))
+                $qb->expr()->eq('fe_user', $qb->createNamedParameter($userId, \PDO::PARAM_INT))
             );
 
         $result = $qb->executeQuery()->fetchOne();
@@ -146,7 +146,7 @@ final class UserBadgeRepository extends Repository implements UserBadgeRepositor
             ->select($qb->expr()->count('*'))
             ->from('tx_equedlms_domain_model_userbadge')
             ->where(
-                $qb->expr()->eq('user', $qb->createNamedParameter($userId, \PDO::PARAM_INT)),
+                $qb->expr()->eq('fe_user', $qb->createNamedParameter($userId, \PDO::PARAM_INT)),
                 $qb->expr()->eq('badge_type', $qb->createNamedParameter($identifier))
             );
 


### PR DESCRIPTION
## Summary
- ensure `countValidBadges()` and `countByUserAndIdentifier()` query the `fe_user` column

## Testing
- `composer install --prefer-dist` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ae42147188324a8e8abb21c99f5b3