### PR TITLE
Remove unused QueryBuilder import

### DIFF
--- a/equed-lms/Classes/Domain/Repository/LessonProgressRepository.php
+++ b/equed-lms/Classes/Domain/Repository/LessonProgressRepository.php
@@ -6,7 +6,6 @@ namespace Equed\EquedLms\Domain\Repository;
 
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
-use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Extbase\Persistence\Repository;
 use Equed\EquedLms\Domain\Model\Lesson;
 use Equed\EquedLms\Domain\Model\LessonProgress;


### PR DESCRIPTION
## Summary
- clean up an unused `use` statement in `LessonProgressRepository.php`

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684af3282230832483858659b6d81018