### PR TITLE
Add findByUuid methods to user repositories

### DIFF
--- a/equed-lms/Classes/Domain/Repository/UserBadgeRepository.php
+++ b/equed-lms/Classes/Domain/Repository/UserBadgeRepository.php
@@ -75,6 +75,23 @@ final class UserBadgeRepository extends Repository implements UserBadgeRepositor
     }
 
     /**
+     * Find a badge by its UUID.
+     *
+     * @param string $uuid
+     * @return UserBadge|null
+     */
+    public function findByUuid(string $uuid): ?UserBadge
+    {
+        $query = $this->createQuery();
+        $query->matching(
+            $query->equals('uuid', $uuid)
+        );
+        $query->setLimit(1);
+
+        return $query->execute()->getFirst();
+    }
+
+    /**
      * Find all valid badges for a user.
      *
      * @param int $userId Frontend user UID

--- a/equed-lms/Classes/Domain/Repository/UserBadgeRepositoryInterface.php
+++ b/equed-lms/Classes/Domain/Repository/UserBadgeRepositoryInterface.php
@@ -18,6 +18,8 @@ interface UserBadgeRepositoryInterface
 
     public function findByUserAndType(int $userId, string $type): ?UserBadge;
 
+    public function findByUuid(string $uuid): ?UserBadge;
+
     public function countByUserAndIdentifier(int $userId, string $identifier): int;
 
     public function add(UserBadge $badge): void;

--- a/equed-lms/Classes/Domain/Repository/UserCourseRecordRepository.php
+++ b/equed-lms/Classes/Domain/Repository/UserCourseRecordRepository.php
@@ -82,6 +82,23 @@ final class UserCourseRecordRepository extends Repository implements UserCourseR
     }
 
     /**
+     * Find a course record by its UUID.
+     *
+     * @param string $uuid
+     * @return UserCourseRecord|null
+     */
+    public function findByUuid(string $uuid): ?UserCourseRecord
+    {
+        $query = $this->createQuery();
+        $query->matching(
+            $query->equals('uuid', $uuid)
+        );
+        $query->setLimit(1);
+
+        return $query->execute()->getFirst();
+    }
+
+    /**
      * Find course records by status.
      *
      * @param UserCourseStatus|string $status Value from UserCourseStatus enum

--- a/equed-lms/Classes/Domain/Repository/UserCourseRecordRepositoryInterface.php
+++ b/equed-lms/Classes/Domain/Repository/UserCourseRecordRepositoryInterface.php
@@ -27,4 +27,5 @@ use Equed\EquedLms\Domain\Model\UserCourseRecord;
  */
 interface UserCourseRecordRepositoryInterface
 {
+    public function findByUuid(string $uuid): ?UserCourseRecord;
 }

--- a/equed-lms/Classes/Domain/Repository/UserSubmissionRepository.php
+++ b/equed-lms/Classes/Domain/Repository/UserSubmissionRepository.php
@@ -106,6 +106,23 @@ final class UserSubmissionRepository extends Repository implements UserSubmissio
     }
 
     /**
+     * Find a submission by its UUID.
+     *
+     * @param string $uuid
+     * @return UserSubmission|null
+     */
+    public function findByUuid(string $uuid): ?UserSubmission
+    {
+        $query = $this->createQuery();
+        $query->matching(
+            $query->equals('uuid', $uuid)
+        );
+        $query->setLimit(1);
+
+        return $query->execute()->getFirst();
+    }
+
+    /**
      * Count submissions for a specific lesson.
      */
     public function countByLesson(Lesson $lesson): int

--- a/equed-lms/Classes/Domain/Repository/UserSubmissionRepositoryInterface.php
+++ b/equed-lms/Classes/Domain/Repository/UserSubmissionRepositoryInterface.php
@@ -31,6 +31,8 @@ interface UserSubmissionRepositoryInterface
 
     public function findByUid(int $uid): ?UserSubmission;
 
+    public function findByUuid(string $uuid): ?UserSubmission;
+
     /**
      * @return UserSubmission[]
      */


### PR DESCRIPTION
## Summary
- add `findByUuid()` to `UserBadgeRepository`
- expose the new method via `UserBadgeRepositoryInterface`
- implement `findByUuid()` in `UserCourseRecordRepository`
- add interface definition for user course record repository
- implement `findByUuid()` in `UserSubmissionRepository`
- add interface method for user submissions

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684af3c0077c8324a8ecfa3f8810223b