### PR TITLE
Implement countByStatus for user submissions

### DIFF
--- a/equed-lms/Classes/Domain/Repository/UserSubmissionRepository.php
+++ b/equed-lms/Classes/Domain/Repository/UserSubmissionRepository.php
@@ -159,6 +159,28 @@ final class UserSubmissionRepository extends Repository implements UserSubmissio
     }
 
     /**
+     * Count submissions by status.
+     */
+    public function countByStatus(SubmissionStatus|string $status): int
+    {
+        if (is_string($status)) {
+            $status = SubmissionStatus::from($status);
+        }
+
+        $qb = $this->createQuery()->getQueryBuilder();
+        $qb
+            ->select($qb->expr()->count('*'))
+            ->from('tx_equedlms_domain_model_usersubmission')
+            ->where(
+                $qb->expr()->eq('status', $qb->createNamedParameter($status->value))
+            );
+
+        $result = $qb->executeQuery()->fetchOne();
+
+        return $result === false ? 0 : (int) $result;
+    }
+
+    /**
      * Find submissions by status.
      *
      * @param SubmissionStatus|string $status

--- a/equed-lms/Classes/Domain/Repository/UserSubmissionRepositoryInterface.php
+++ b/equed-lms/Classes/Domain/Repository/UserSubmissionRepositoryInterface.php
@@ -61,6 +61,11 @@ interface UserSubmissionRepositoryInterface
     public function countByPracticeTest(PracticeTest $practiceTest): int;
 
     /**
+     * Count submissions by status.
+     */
+    public function countByStatus(SubmissionStatus|string $status): int;
+
+    /**
      * @param SubmissionStatus|string $status
      * @return UserSubmission[]
      */


### PR DESCRIPTION
## Summary
- add `countByStatus()` to `UserSubmissionRepositoryInterface`
- implement `countByStatus()` in `UserSubmissionRepository` using QueryBuilder

## Testing
- `composer test` *(fails: PHPUnit requires extensions dom, xml, xmlwriter)*

------
https://chatgpt.com/codex/tasks/task_e_684af57251f08324b4e894e4e392ff44