### PR TITLE
Add add() method to NotificationRepository

### DIFF
--- a/equed-lms/Classes/Domain/Repository/NotificationRepository.php
+++ b/equed-lms/Classes/Domain/Repository/NotificationRepository.php
@@ -65,4 +65,14 @@ final class NotificationRepository extends Repository implements NotificationRep
     {
         return $this->findByIdentifier($uid);
     }
+
+    /**
+     * Adds a notification to the repository.
+     *
+     * @param Notification $notification Notification entity to add
+     */
+    public function add(Notification $notification): void
+    {
+        parent::add($notification);
+    }
 }


### PR DESCRIPTION
## Summary
- implement missing `add()` method in `NotificationRepository`

## Testing
- `composer lint` *(fails: command not found)*
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684afe207cf08324a3c0bbb4fe29ba0a