### PR TITLE
Implement add() in UserBadgeRepository

### DIFF
--- a/equed-lms/Classes/Domain/Repository/UserBadgeRepository.php
+++ b/equed-lms/Classes/Domain/Repository/UserBadgeRepository.php
@@ -171,4 +171,14 @@ final class UserBadgeRepository extends Repository implements UserBadgeRepositor
 
         return $result === false ? 0 : (int)$result;
     }
+
+    /**
+     * Add a badge to the repository.
+     *
+     * @param UserBadge $badge Badge instance to add
+     */
+    public function add(UserBadge $badge): void
+    {
+        parent::add($badge);
+    }
 }


### PR DESCRIPTION
## Summary
- extend `UserBadgeRepository` with `add()` method

## Testing
- `composer install` *(fails: command not found)*
- `php -l Classes/Domain/Repository/UserBadgeRepository.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684afef4107883248cdf5cf53a42786f