### PR TITLE
Fix QMS escalation mail parameters

### DIFF
--- a/equed-lms/Classes/Service/QmsEscalationService.php
+++ b/equed-lms/Classes/Service/QmsEscalationService.php
@@ -47,8 +47,6 @@ final class QmsEscalationService
         );
 
         $this->mailService->sendMail(
-            'qms@equed.eu',
-            'QMS System',
             'servicecenter@equed.eu',
             $subject,
             $body


### PR DESCRIPTION
## Summary
- update `QmsEscalationService` to use the `MailServiceInterface` signature

## Testing
- `composer lint` *(fails: `composer: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684b34f3b1688324bd0c707cf133518c