### PR TITLE
Add service interfaces and DI mappings

### DIFF
--- a/equed-lms/Classes/Domain/Service/CourseCompletionServiceInterface.php
+++ b/equed-lms/Classes/Domain/Service/CourseCompletionServiceInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Domain\Service;
+
+interface CourseCompletionServiceInterface
+{
+    /**
+     * Marks a user's course record as completed if not already done.
+     *
+     * @param int $feUserId  Frontend user UID
+     * @param int $courseUid Course UID
+     * @return bool True if the record was newly marked completed, false otherwise
+     */
+    public function markCompletedIfNotYet(int $feUserId, int $courseUid): bool;
+}

--- a/equed-lms/Classes/Domain/Service/DashboardServiceInterface.php
+++ b/equed-lms/Classes/Domain/Service/DashboardServiceInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Domain\Service;
+
+use Equed\EquedLms\Domain\Model\FrontendUser;
+
+interface DashboardServiceInterface
+{
+    /**
+     * Retrieve all dashboard data for a frontend user.
+     *
+     * @param FrontendUser $user
+     * @return array<string,mixed>
+     */
+    public function getDashboardDataForUser(FrontendUser $user): array;
+}

--- a/equed-lms/Classes/Domain/Service/DocumentServiceInterface.php
+++ b/equed-lms/Classes/Domain/Service/DocumentServiceInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Domain\Service;
+
+use Equed\EquedLms\Exception\InvalidFileTypeException;
+
+interface DocumentServiceInterface
+{
+    /**
+     * Generate a download URI for a given file.
+     *
+     * @param string $fileName
+     * @return string
+     * @throws InvalidFileTypeException
+     */
+    public function generateDownloadLink(string $fileName): string;
+
+    /**
+     * Get the template PDF URI for a given template name.
+     */
+    public function getTemplatePath(string $templateName): string;
+}

--- a/equed-lms/Classes/Domain/Service/MediaUploadServiceInterface.php
+++ b/equed-lms/Classes/Domain/Service/MediaUploadServiceInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Domain\Service;
+
+use Equed\EquedLms\Domain\Model\FrontendUser;
+use TYPO3\CMS\Extbase\Domain\Model\FileReference;
+
+interface MediaUploadServiceInterface
+{
+    /**
+     * Handles an upload request and stores the file in the default storage.
+     *
+     * @param array $uploadedFile Superglobal-like $_FILES['file'] array
+     * @param FrontendUser $user  Authenticated user
+     * @return FileReference|null Stored file reference or null on error
+     */
+    public function handleUpload(array $uploadedFile, FrontendUser $user): ?FileReference;
+}

--- a/equed-lms/Classes/Service/CourseCompletionService.php
+++ b/equed-lms/Classes/Service/CourseCompletionService.php
@@ -9,13 +9,14 @@ use Equed\EquedLms\Domain\Model\UserCourseRecord;
 use Equed\EquedLms\Domain\Repository\UserCourseRecordRepository;
 use Equed\EquedLms\Factory\UserCourseRecordFactoryInterface;
 use Equed\EquedLms\Event\Course\CourseCompletedEvent;
+use Equed\EquedLms\Domain\Service\CourseCompletionServiceInterface;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 
 /**
  * Service responsible for marking user course records as completed.
  */
-final class CourseCompletionService
+final class CourseCompletionService implements CourseCompletionServiceInterface
 {
     public function __construct(
         private readonly UserCourseRecordRepository        $recordRepository,

--- a/equed-lms/Classes/Service/DashboardService.php
+++ b/equed-lms/Classes/Service/DashboardService.php
@@ -13,6 +13,7 @@ use Equed\EquedLms\Domain\Repository\CertificateDispatchRepositoryInterface;
 use Equed\EquedLms\Domain\Repository\NotificationRepositoryInterface;
 use Equed\EquedLms\Service\ProgressServiceInterface;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
+use Equed\EquedLms\Domain\Service\DashboardServiceInterface;
 use Equed\EquedLms\Enum\UserCourseStatus;
 
 /**
@@ -20,7 +21,7 @@ use Equed\EquedLms\Enum\UserCourseStatus;
  * implementing tabbed navigation, card metrics, filters, DataTables metadata,
  * translation fallback, feature toggles, and offline caching metadata.
  */
-final class DashboardService
+final class DashboardService implements DashboardServiceInterface
 {
     private const CACHE_TTL_SECONDS = 600;
 

--- a/equed-lms/Classes/Service/DocumentService.php
+++ b/equed-lms/Classes/Service/DocumentService.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace Equed\EquedLms\Service;
 
 use Equed\EquedLms\Exception\InvalidFileTypeException;
+use Equed\EquedLms\Domain\Service\DocumentServiceInterface;
 
 /**
  * Service to generate secure download and template URIs for documents.
  */
-final class DocumentService
+final class DocumentService implements DocumentServiceInterface
 {
     /**
      * @var string[]

--- a/equed-lms/Classes/Service/MediaUploadService.php
+++ b/equed-lms/Classes/Service/MediaUploadService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Equed\EquedLms\Service;
 
 use Equed\EquedLms\Service\LogServiceInterface;
+use Equed\EquedLms\Domain\Service\MediaUploadServiceInterface;
 use TYPO3\CMS\Core\Resource\ResourceStorage;
 use TYPO3\CMS\Core\Resource\StorageRepository;
 use TYPO3\CMS\Extbase\Domain\Model\FileReference;
@@ -15,7 +16,7 @@ use Equed\EquedLms\Domain\Model\FrontendUser;
 /**
  * Service to securely handle media file uploads.
  */
-final class MediaUploadService
+final class MediaUploadService implements MediaUploadServiceInterface
 {
     private const ALLOWED_MIME_TYPES = [
         'image/jpeg',

--- a/equed-lms/Configuration/Services/Services.yaml
+++ b/equed-lms/Configuration/Services/Services.yaml
@@ -45,3 +45,15 @@ services:
 
   Equed\EquedLms\Domain\Repository\UserBadgeRepositoryInterface:
     class: Equed\EquedLms\Domain\Repository\UserBadgeRepository
+
+  Equed\EquedLms\Domain\Service\DashboardServiceInterface:
+    class: Equed\EquedLms\Service\DashboardService
+
+  Equed\EquedLms\Domain\Service\CourseCompletionServiceInterface:
+    class: Equed\EquedLms\Service\CourseCompletionService
+
+  Equed\EquedLms\Domain\Service\MediaUploadServiceInterface:
+    class: Equed\EquedLms\Service\MediaUploadService
+
+  Equed\EquedLms\Domain\Service\DocumentServiceInterface:
+    class: Equed\EquedLms\Service\DocumentService


### PR DESCRIPTION
## Summary
- add interfaces for CourseCompletion, Dashboard, MediaUpload and Document services
- implement interfaces in concrete services
- wire the implementations via `Services.yaml` for DI

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684b3cacada48324b071fad2eca79815