### PR TITLE
Implement NotificationService interface

### DIFF
--- a/equed-lms/Tests/Unit/Service/CertificateServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/CertificateServiceTest.php
@@ -10,7 +10,7 @@ use Equed\EquedLms\Domain\Repository\CertificateDispatchRepository;
 use Equed\EquedLms\Factory\CertificateDispatchFactoryInterface;
 use Equed\EquedLms\Service\CertificateService;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
-use Equed\EquedLms\Service\NotificationServiceInterface;
+use Equed\EquedLms\Domain\Service\NotificationServiceInterface;
 use Equed\EquedLms\Tests\Traits\ProphecyTrait;
 use PHPUnit\Framework\TestCase;
 


### PR DESCRIPTION
## Summary
- implement NotificationServiceInterface in NotificationService
- adjust constructor dependencies and add retrieval methods
- update unit test to use new interface path

## Testing
- `php -l equed-lms/Classes/Service/NotificationService.php`
- `php -l equed-lms/Classes/Domain/Service/NotificationServiceInterface.php`
- `php -l equed-lms/Tests/Unit/Service/CertificateServiceTest.php`
- `composer install --no-interaction`
- `vendor/bin/phpunit --configuration phpunit.xml.dist Tests/Unit/Service/CertificateServiceTest.php` *(fails: CertificateDispatchRepository::add must be compatible)*

------
https://chatgpt.com/codex/tasks/task_e_684b50c787948324b87c1ecde7411ae2