### PR TITLE
Add training record generator interface

### DIFF
--- a/equed-lms/Classes/Domain/Service/TrainingRecordGeneratorInterface.php
+++ b/equed-lms/Classes/Domain/Service/TrainingRecordGeneratorInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Domain\Service;
+
+interface TrainingRecordGeneratorInterface
+{
+    /**
+     * Generates a PDF certificate document.
+     *
+     * @param array{course:string,cert_number:string,issued_on:string} $certificateData
+     * @return string Absolute path to the generated PDF file
+     */
+    public function generatePdf(array $certificateData): string;
+
+    /**
+     * Generates a ZIP archive containing the PDF certificate.
+     *
+     * @param array{course:string,cert_number:string,issued_on:string} $certificateData
+     * @return string Absolute path to the generated ZIP file
+     */
+    public function generateZip(array $certificateData): string;
+}

--- a/equed-lms/Classes/Service/TrainingRecordGeneratorService.php
+++ b/equed-lms/Classes/Service/TrainingRecordGeneratorService.php
@@ -8,11 +8,12 @@ use Closure;
 use TCPDF;
 use ZipArchive;
 use RuntimeException;
+use Equed\EquedLms\Domain\Service\TrainingRecordGeneratorInterface;
 
 /**
  * Service for generating training record documents (PDF and ZIP).
  */
-final class TrainingRecordGeneratorService
+final class TrainingRecordGeneratorService implements TrainingRecordGeneratorInterface
 {
     private readonly string $outputDirectory;
     /** @var callable(): TCPDF */


### PR DESCRIPTION
## Summary
- add `TrainingRecordGeneratorInterface` with methods for PDF and ZIP generation
- rename `TrainingRecordGenerator.php` file to `TrainingRecordGeneratorService.php`
- implement the interface in the service class

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b53c8fc048324aa840f390cd152b3