### PR TITLE
Make service center email configurable

### DIFF
--- a/equed-lms/Classes/Service/QmsEscalationService.php
+++ b/equed-lms/Classes/Service/QmsEscalationService.php
@@ -16,14 +16,17 @@ use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 final class QmsEscalationService
 {
     private readonly string $extensionKey;
+    private readonly string $serviceCenterEmail;
 
     public function __construct(
         private readonly LogService $logService,
         private readonly MailServiceInterface $mailService,
         private readonly GptTranslationServiceInterface $translationService,
+        string $serviceCenterEmail = 'servicecenter@equed.eu',
         string $extensionKey = 'equed_lms'
     ) {
         $this->extensionKey = $extensionKey;
+        $this->serviceCenterEmail = $serviceCenterEmail;
     }
 
     /**
@@ -47,7 +50,7 @@ final class QmsEscalationService
         );
 
         $this->mailService->sendMail(
-            'servicecenter@equed.eu',
+            $this->serviceCenterEmail,
             $subject,
             $body
         );


### PR DESCRIPTION
## Summary
- add a constructor parameter for the service center address
- use the parameter in `QmsEscalationService::escalate()`

## Testing
- `composer install --no-interaction` *(fails: ext-dom missing)*
- `composer test` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b567f56f08324a90a5f810a56a2d4