### PR TITLE
Add clock abstraction to services

### DIFF
--- a/equed-lms/Classes/Domain/Service/ClockInterface.php
+++ b/equed-lms/Classes/Domain/Service/ClockInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Domain\Service;
+
+use DateTimeImmutable;
+
+/**
+ * Provides the current time, allowing for easier testing.
+ */
+interface ClockInterface
+{
+    /**
+     * Get the current time as an immutable DateTime instance.
+     */
+    public function now(): DateTimeImmutable;
+}

--- a/equed-lms/Classes/Service/CertificateService.php
+++ b/equed-lms/Classes/Service/CertificateService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Equed\EquedLms\Service;
 
 use DateTimeImmutable;
+use Equed\EquedLms\Domain\Service\ClockInterface;
 use Equed\EquedLms\Domain\Model\CertificateDispatch;
 use Equed\EquedLms\Domain\Model\UserCourseRecord;
 use Equed\EquedLms\Domain\Repository\CertificateDispatchRepository;
@@ -21,6 +22,7 @@ final class CertificateService
         private readonly CertificateDispatchFactoryInterface $dispatchFactory,
         private readonly GptTranslationServiceInterface $translationService,
         private readonly NotificationService $notificationService,
+        private readonly ClockInterface $clock,
         string $qrCodeBaseUrl
     ) {
         $this->qrCodeBaseUrl = rtrim($qrCodeBaseUrl, '/') . '/';
@@ -50,7 +52,7 @@ final class CertificateService
     private function generateQrCodeUrl(UserCourseRecord|CertificateDispatch $source): string
     {
         $userId = $source->getFeUser()?->getUid() ?? 0;
-        $timestamp = (new DateTimeImmutable())->format('YmdHis');
+        $timestamp = $this->clock->now()->format('YmdHis');
 
         return sprintf('%s%s/%s', $this->qrCodeBaseUrl, $userId, $timestamp);
     }

--- a/equed-lms/Classes/Service/CourseCompletionService.php
+++ b/equed-lms/Classes/Service/CourseCompletionService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Equed\EquedLms\Service;
 
 use DateTimeImmutable;
+use Equed\EquedLms\Domain\Service\ClockInterface;
 use Equed\EquedLms\Domain\Model\UserCourseRecord;
 use Equed\EquedLms\Domain\Repository\UserCourseRecordRepository;
 use Equed\EquedLms\Factory\UserCourseRecordFactoryInterface;
@@ -22,7 +23,8 @@ final class CourseCompletionService implements CourseCompletionServiceInterface
         private readonly UserCourseRecordRepository        $recordRepository,
         private readonly UserCourseRecordFactoryInterface  $recordFactory,
         private readonly PersistenceManagerInterface       $persistenceManager,
-        private readonly EventDispatcherInterface          $eventDispatcher
+        private readonly EventDispatcherInterface          $eventDispatcher,
+        private readonly ClockInterface                    $clock
     ) {
     }
 
@@ -47,7 +49,7 @@ final class CourseCompletionService implements CourseCompletionServiceInterface
         }
 
         $record->setCompleted(true);
-        $record->setCompletedAt(new DateTimeImmutable());
+        $record->setCompletedAt($this->clock->now());
 
         $this->persistenceManager->persistAll();
         $this->eventDispatcher->dispatch(new CourseCompletedEvent($record));

--- a/equed-lms/Classes/Service/CourseStatusUpdaterService.php
+++ b/equed-lms/Classes/Service/CourseStatusUpdaterService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Equed\EquedLms\Service;
 
 use DateTimeImmutable;
+use Equed\EquedLms\Domain\Service\ClockInterface;
 use Equed\EquedLms\Domain\Model\UserCourseRecord;
 use Equed\EquedLms\Domain\Repository\UserCourseRecordRepository;
 use Equed\EquedLms\Enum\CourseStatus;
@@ -20,7 +21,8 @@ final class CourseStatusUpdaterService
     public function __construct(
         private readonly CertificateService    $certificateService,
         private readonly NotificationService   $notificationService,
-        private readonly UserCourseRecordRepository     $userCourseRecordRepository
+        private readonly UserCourseRecordRepository     $userCourseRecordRepository,
+        private readonly ClockInterface        $clock
     ) {
     }
 
@@ -32,7 +34,7 @@ final class CourseStatusUpdaterService
     public function finalize(UserCourseRecord $record): void
     {
         $record->setStatus(CourseStatus::Validated->value);
-        $record->setCompletionDate(new DateTimeImmutable());
+        $record->setCompletionDate($this->clock->now());
 
         $this->userCourseRecordRepository->update($record);
 

--- a/equed-lms/Classes/Service/DashboardService.php
+++ b/equed-lms/Classes/Service/DashboardService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Equed\EquedLms\Service;
 
 use DateTimeImmutable;
+use Equed\EquedLms\Domain\Service\ClockInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use Equed\EquedLms\Domain\Model\FrontendUser;
 use Equed\EquedLms\Domain\Repository\UserCourseRecordRepository;
@@ -33,7 +34,8 @@ final class DashboardService implements DashboardServiceInterface
         private readonly ProgressServiceInterface               $progressService,
         private readonly GptTranslationServiceInterface                  $translationService,
         private readonly CacheItemPoolInterface                 $cachePool,
-        private readonly bool                                   $gptAnalysisEnabled
+        private readonly bool                                   $gptAnalysisEnabled,
+        private readonly ClockInterface                         $clock
     ) {
     }
 
@@ -78,7 +80,7 @@ final class DashboardService implements DashboardServiceInterface
             'notifications' => $this->buildNotificationsData($notificationList),
             'cacheMeta'     => [
                 'ttl'       => self::CACHE_TTL_SECONDS,
-                'fetchedAt' => (new DateTimeImmutable())->format(DateTimeImmutable::ATOM),
+                'fetchedAt' => $this->clock->now()->format(DateTimeImmutable::ATOM),
             ],
             'features'      => [
                 'gptAnalysis' => $this->gptAnalysisEnabled,

--- a/equed-lms/Classes/Service/ExamService.php
+++ b/equed-lms/Classes/Service/ExamService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Equed\EquedLms\Service;
 
 use DateTimeImmutable;
+use Equed\EquedLms\Domain\Service\ClockInterface;
 use Equed\EquedLms\Domain\Model\ExamAttempt;
 use Equed\EquedLms\Domain\Repository\ExamAttemptRepositoryInterface;
 use Equed\EquedLms\Factory\ExamAttemptFactoryInterface;
@@ -16,7 +17,8 @@ final class ExamService
 {
     public function __construct(
         private readonly ExamAttemptRepositoryInterface  $examAttemptRepository,
-        private readonly ExamAttemptFactoryInterface     $examAttemptFactory
+        private readonly ExamAttemptFactoryInterface     $examAttemptFactory,
+        private readonly ClockInterface                  $clock
     ) {
     }
 
@@ -46,7 +48,7 @@ final class ExamService
         if (!$attempt->getScored()) {
             $attempt->setScored(true);
             $attempt->setScore($score);
-            $attempt->setEndTime(new DateTimeImmutable());
+            $attempt->setEndTime($this->clock->now());
 
             $this->examAttemptRepository->update($attempt);
         }

--- a/equed-lms/Classes/Service/GptEvaluationService.php
+++ b/equed-lms/Classes/Service/GptEvaluationService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Equed\EquedLms\Service;
 
 use DateTimeImmutable;
+use Equed\EquedLms\Domain\Service\ClockInterface;
 use JsonException;
 use Psr\Http\Client\ClientExceptionInterface;
 use Equed\EquedLms\Service\LogService;
@@ -27,7 +28,8 @@ final class GptEvaluationService
         private readonly GptTranslationServiceInterface $translationService,
         private readonly string                        $openAiApiKey,
         private readonly bool                          $evaluationEnabled,
-        private readonly string                        $openAiApiUrl
+        private readonly string                        $openAiApiUrl,
+        private readonly ClockInterface                $clock
     ) {
     }
 
@@ -113,7 +115,7 @@ final class GptEvaluationService
                 ->setGptSummary($analysis['summary'] ?? '')
                 ->setGptSuggestion($analysis['suggestion'] ?? '')
                 ->setGptAnalysisData(json_encode($analysis, JSON_THROW_ON_ERROR))
-                ->setAnalyzedAt(new DateTimeImmutable());
+                ->setAnalyzedAt($this->clock->now());
 
             $this->submissionRepository->update($submission);
 

--- a/equed-lms/Classes/Service/LessonProgressService.php
+++ b/equed-lms/Classes/Service/LessonProgressService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Equed\EquedLms\Service;
 
 use DateTimeImmutable;
+use Equed\EquedLms\Domain\Service\ClockInterface;
 use Equed\EquedLms\Domain\Model\Lesson;
 use Equed\EquedLms\Domain\Model\LessonProgress;
 use Equed\EquedLms\Domain\Repository\LessonProgressRepositoryInterface;
@@ -16,7 +17,8 @@ use Equed\EquedLms\Domain\Model\FrontendUser;
 final class LessonProgressService
 {
     public function __construct(
-        private readonly LessonProgressRepositoryInterface $progressRepository
+        private readonly LessonProgressRepositoryInterface $progressRepository,
+        private readonly ClockInterface $clock
     ) {
     }
 
@@ -54,7 +56,7 @@ final class LessonProgressService
 
         $progress->setStatus('completed');
         $progress->setCompleted(true);
-        $progress->setCompletedAt(new DateTimeImmutable());
+        $progress->setCompletedAt($this->clock->now());
 
         $this->progressRepository->updateOrAdd($progress);
 

--- a/equed-lms/Classes/Service/SystemClock.php
+++ b/equed-lms/Classes/Service/SystemClock.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Service;
+
+use DateTimeImmutable;
+use Equed\EquedLms\Domain\Service\ClockInterface;
+
+/**
+ * Default clock using the system time.
+ */
+final class SystemClock implements ClockInterface
+{
+    public function now(): DateTimeImmutable
+    {
+        return new DateTimeImmutable();
+    }
+}

--- a/equed-lms/Configuration/Services/Services.yaml
+++ b/equed-lms/Configuration/Services/Services.yaml
@@ -57,3 +57,6 @@ services:
 
   Equed\EquedLms\Domain\Service\DocumentServiceInterface:
     class: Equed\EquedLms\Service\DocumentService
+
+  Equed\EquedLms\Domain\Service\ClockInterface:
+    class: Equed\EquedLms\Service\SystemClock


### PR DESCRIPTION
## Summary
- add `ClockInterface` and `SystemClock` implementation
- wire the clock service in DI configuration
- inject the clock into dashboard, certificate, exam and other services
- use `$this->clock->now()` instead of `new DateTimeImmutable()`

## Testing
- `composer install` *(fails: command not found)*
- `./vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684b5950ca008324ba035a2ddf11370e