### PR TITLE
Add DI mappings and exam notification service

### DIFF
--- a/equed-lms/Classes/Service/ExamNotificationService.php
+++ b/equed-lms/Classes/Service/ExamNotificationService.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Service;
+
+use Equed\EquedLms\Domain\Repository\CourseInstanceRepositoryInterface;
+use Equed\EquedLms\Domain\Repository\FrontendUserRepositoryInterface;
+use Equed\EquedLms\Domain\Model\FrontendUser;
+use Equed\EquedLms\Domain\Service\ExamNotificationServiceInterface;
+
+/**
+ * Simple implementation that notifies assigned examiners about upcoming exams.
+ */
+final class ExamNotificationService implements ExamNotificationServiceInterface
+{
+    public function __construct(
+        private readonly CourseInstanceRepositoryInterface $courseInstanceRepository,
+        private readonly FrontendUserRepositoryInterface $frontendUserRepository,
+        private readonly MailServiceInterface $mailService,
+    ) {
+    }
+
+    public function notifyAll(): int
+    {
+        $instances = $this->courseInstanceRepository->findAllRequiringExternalExaminer();
+        $count = 0;
+
+        foreach ($instances as $instance) {
+            $examiner = $instance->getExternalExaminer();
+            if ($examiner instanceof FrontendUser && $examiner->getEmail() !== '') {
+                $subject = 'Upcoming exam reminder';
+                $body = sprintf('An exam for "%s" is scheduled soon.', $instance->getTitle());
+                $this->mailService->sendMail($examiner->getEmail(), $subject, $body);
+                ++$count;
+            }
+        }
+
+        return $count;
+    }
+}

--- a/equed-lms/Configuration/Services/Services.yaml
+++ b/equed-lms/Configuration/Services/Services.yaml
@@ -60,3 +60,45 @@ services:
 
   Equed\EquedLms\Domain\Service\ClockInterface:
     class: Equed\EquedLms\Service\SystemClock
+  Equed\EquedLms\Domain\Repository\CourseInstanceRepositoryInterface:
+    class: Equed\EquedLms\Domain\Repository\CourseInstanceRepository
+
+  Equed\EquedLms\Domain\Repository\LessonProgressRepositoryInterface:
+    class: Equed\EquedLms\Domain\Repository\LessonProgressRepository
+
+  Equed\EquedLms\Domain\Repository\NotificationRepositoryInterface:
+    class: Equed\EquedLms\Domain\Repository\NotificationRepository
+
+  Equed\EquedLms\Domain\Repository\UserCourseRecordRepositoryInterface:
+    class: Equed\EquedLms\Domain\Repository\UserCourseRecordRepository
+
+  Equed\EquedLms\Domain\Repository\UserSubmissionRepositoryInterface:
+    class: Equed\EquedLms\Domain\Repository\UserSubmissionRepository
+
+  Equed\EquedLms\Domain\Repository\CertificateDispatchRepositoryInterface:
+    class: Equed\EquedLms\Domain\Repository\CertificateDispatchRepository
+
+  Equed\EquedLms\Domain\Repository\SubmissionRepositoryInterface:
+    class: Equed\EquedLms\Domain\Repository\SubmissionRepository
+
+  Equed\EquedLms\Domain\Service\JwtServiceInterface:
+    class: Equed\EquedLms\Service\JwtService
+
+  Equed\EquedLms\Domain\Service\NotificationServiceInterface:
+    class: Equed\EquedLms\Service\NotificationService
+
+  Equed\EquedLms\Domain\Service\CourseGoalServiceInterface:
+    class: Equed\EquedLms\Service\CourseGoalService
+
+  Equed\EquedLms\Domain\Service\TrainingRecordGeneratorInterface:
+    class: Equed\EquedLms\Service\TrainingRecordGeneratorService
+
+  Equed\EquedLms\Domain\Service\ExamNotificationServiceInterface:
+    class: Equed\EquedLms\Service\ExamNotificationService
+
+  Equed\EquedLms\Service\ProgressServiceInterface:
+    class: Equed\EquedLms\Service\ProgressService
+
+  Equed\EquedLms\Service\MailServiceInterface:
+    class: Equed\EquedLms\Service\Email\MailService
+


### PR DESCRIPTION
## Summary
- implement `ExamNotificationService` to satisfy `ExamNotificationServiceInterface`
- register repository and service interfaces for dependency injection

## Testing
- `composer install --no-interaction` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b5d335d9c83248d4e2862c8f34d93