### PR TITLE
Fix PSR-4 namespace alignment

### DIFF
--- a/equed-lms/Classes/Event/Course/CourseCompletionValidatedEvent.php
+++ b/equed-lms/Classes/Event/Course/CourseCompletionValidatedEvent.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Equed\EquedLms\Event;
+namespace Equed\EquedLms\Event\Course;
 
 use DateTimeImmutable;
 use Equed\EquedLms\Domain\Model\UserCourseRecord;

--- a/equed-lms/Classes/Event/Qms/QmsCaseEscalatedEvent.php
+++ b/equed-lms/Classes/Event/Qms/QmsCaseEscalatedEvent.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Equed\EquedLms\Event;
+namespace Equed\EquedLms\Event\Qms;
 
 use DateTimeImmutable;
 use Equed\EquedLms\Domain\Model\QmsCase;

--- a/equed-lms/Classes/Event/Submission/SubmissionUploadedEvent.php
+++ b/equed-lms/Classes/Event/Submission/SubmissionUploadedEvent.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Equed\EquedLms\Event;
+namespace Equed\EquedLms\Event\Submission;
 
 use DateTimeImmutable;
 use Equed\EquedLms\Domain\Model\UserSubmission;

--- a/equed-lms/Classes/Event/User/OnboardingCompletedEvent.php
+++ b/equed-lms/Classes/Event/User/OnboardingCompletedEvent.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Equed\EquedLms\Event;
+namespace Equed\EquedLms\Event\User;
 
 use DateTimeImmutable;
 use Psr\EventDispatcher\StoppableEventInterface;

--- a/equed-lms/Classes/EventListener/AutoCertificationListener.php
+++ b/equed-lms/Classes/EventListener/AutoCertificationListener.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Equed\EquedLms\Listener;
+namespace Equed\EquedLms\EventListener;
 
 use Equed\EquedLms\Domain\Repository\CertificateDispatchRepository;
 use Equed\EquedLms\Domain\Repository\UserCourseRecordRepository;
 use Equed\EquedLms\Service\CertificateGeneratorInterface;
 use Equed\EquedLms\Enum\UserCourseStatus;
-use Equed\EquedLms\Event\CourseCompletionValidatedEvent;
+use Equed\EquedLms\Event\Course\CourseCompletionValidatedEvent;
 use Psr\EventDispatcher\ListenerProviderInterface;
 use TYPO3\CMS\Core\Annotations\EventListener;
 use TYPO3\CMS\Core\Messaging\FlashMessageService;
@@ -20,7 +20,7 @@ use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
  * @EventListener(
  *     identifier="auto_certification_listener",
  *     after={"typo3.eventlistener"},
- *     eventName=Equed\EquedLms\Event\CourseCompletionValidatedEvent::class
+ *     eventName=Equed\EquedLms\Event\Course\CourseCompletionValidatedEvent::class
  * )
  */
 final class AutoCertificationListener

--- a/equed-lms/Classes/EventListener/CertificateNotificationListener.php
+++ b/equed-lms/Classes/EventListener/CertificateNotificationListener.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Equed\EquedLms\Listener;
+namespace Equed\EquedLms\EventListener;
 
 use Equed\EquedLms\Domain\Repository\NotificationRepository;
 use Equed\EquedLms\Event\CertificateIssuedEvent;

--- a/equed-lms/Classes/EventListener/CourseCompletionListener.php
+++ b/equed-lms/Classes/EventListener/CourseCompletionListener.php
@@ -2,10 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Equed\EquedLms\Listener;
+namespace Equed\EquedLms\EventListener;
 
 use Equed\EquedLms\Event\CourseCompletedEvent;
 use Equed\EquedLms\Event\CertificateIssuedEvent;
+use Equed\EquedLms\Event\Course\CourseCompletionValidatedEvent;
 use Equed\EquedLms\Service\AutoCertificationServiceInterface;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 use Equed\EquedLms\Domain\Repository\UserCourseRecordRepository;

--- a/equed-lms/Classes/ViewHelpers/AttemptResultViewHelper.php
+++ b/equed-lms/Classes/ViewHelpers/AttemptResultViewHelper.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Equed\EquedLms\ViewHelper;
+namespace Equed\EquedLms\ViewHelpers;
 
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;

--- a/equed-lms/Classes/ViewHelpers/BadgeLabelViewHelper.php
+++ b/equed-lms/Classes/ViewHelpers/BadgeLabelViewHelper.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Equed\EquedLms\ViewHelper;
+namespace Equed\EquedLms\ViewHelpers;
 
 use Equed\EquedLms\Service\LanguageServiceInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;

--- a/equed-lms/Classes/ViewHelpers/BadgeViewHelper.php
+++ b/equed-lms/Classes/ViewHelpers/BadgeViewHelper.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Equed\EquedLms\ViewHelper;
+namespace Equed\EquedLms\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use Equed\EquedLms\Service\LanguageServiceInterface;

--- a/equed-lms/Classes/ViewHelpers/CertificateListViewHelper.php
+++ b/equed-lms/Classes/ViewHelpers/CertificateListViewHelper.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Equed\EquedLms\ViewHelper;
+namespace Equed\EquedLms\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;

--- a/equed-lms/Classes/ViewHelpers/CertificateNumberViewHelper.php
+++ b/equed-lms/Classes/ViewHelpers/CertificateNumberViewHelper.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Equed\EquedLms\ViewHelper;
+namespace Equed\EquedLms\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 

--- a/equed-lms/Classes/ViewHelpers/CourseTitleViewHelper.php
+++ b/equed-lms/Classes/ViewHelpers/CourseTitleViewHelper.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Equed\EquedLms\ViewHelper;
+namespace Equed\EquedLms\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;

--- a/equed-lms/Classes/ViewHelpers/IconViewHelper.php
+++ b/equed-lms/Classes/ViewHelpers/IconViewHelper.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Equed\EquedLms\ViewHelper;
+namespace Equed\EquedLms\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;

--- a/equed-lms/Classes/ViewHelpers/ProgressBarViewHelper.php
+++ b/equed-lms/Classes/ViewHelpers/ProgressBarViewHelper.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Equed\EquedLms\ViewHelper;
+namespace Equed\EquedLms\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;

--- a/equed-lms/Classes/ViewHelpers/ProgressViewHelper.php
+++ b/equed-lms/Classes/ViewHelpers/ProgressViewHelper.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Equed\EquedLms\ViewHelper;
+namespace Equed\EquedLms\ViewHelpers;
 
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;

--- a/equed-lms/Classes/ViewHelpers/RatingStarsViewHelper.php
+++ b/equed-lms/Classes/ViewHelpers/RatingStarsViewHelper.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Equed\EquedLms\ViewHelper;
+namespace Equed\EquedLms\ViewHelpers;
 
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;

--- a/equed-lms/Classes/ViewHelpers/StatusIconViewHelper.php
+++ b/equed-lms/Classes/ViewHelpers/StatusIconViewHelper.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Equed\EquedLms\ViewHelper;
+namespace Equed\EquedLms\ViewHelpers;
 
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;

--- a/equed-lms/Classes/ViewHelpers/UserRoleViewHelper.php
+++ b/equed-lms/Classes/ViewHelpers/UserRoleViewHelper.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Equed\EquedLms\ViewHelper;
+namespace Equed\EquedLms\ViewHelpers;
 
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 use Equed\EquedLms\Domain\Repository\UserProfileRepositoryInterface;


### PR DESCRIPTION
## Summary
- correct PSR-4 namespaces in event classes
- adjust listener imports for renamed events
- align view helper namespaces

## Testing
- `vendor/bin/phpunit` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b5f226f2c8324a3fec2137319620b