### PR TITLE
Add configurable filesystem for training record output

### DIFF
--- a/equed-lms/Configuration/Services/Services.yaml
+++ b/equed-lms/Configuration/Services/Services.yaml
@@ -1,3 +1,6 @@
+parameters:
+  equed_lms.training_record_output_path: '%kernel.project_dir%/var/training_records'
+
 services:
   _defaults:
     autowire: true
@@ -92,6 +95,10 @@ services:
 
   Equed\EquedLms\Domain\Service\TrainingRecordGeneratorInterface:
     class: Equed\EquedLms\Service\TrainingRecordGeneratorService
+
+  Equed\EquedLms\Service\TrainingRecordGeneratorService:
+    arguments:
+      $outputDirectory: '%equed_lms.training_record_output_path%'
 
   Equed\EquedLms\Domain\Service\ExamNotificationServiceInterface:
     class: Equed\EquedLms\Service\ExamNotificationService


### PR DESCRIPTION
## Summary
- inject `Symfony\Component\Filesystem\Filesystem` in `TrainingRecordGeneratorService`
- use filesystem to create directories and write PDF files
- introduce a `training_record_output_path` parameter and wire it to the service

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b65e8f90c8324b8f0bc71eac8b594