### PR TITLE
Add visibility flag to Lesson model

### DIFF
--- a/equed-lms/Classes/Domain/Model/Lesson.php
+++ b/equed-lms/Classes/Domain/Model/Lesson.php
@@ -31,6 +31,8 @@ final class Lesson extends AbstractEntity
 
     protected string $category = '';
 
+    protected bool $visible = true;
+
     #[Extbase\ORM\ManyToOne]
     protected ?Module $module = null;
 
@@ -121,6 +123,16 @@ final class Lesson extends AbstractEntity
     public function setCategory(string $category): void
     {
         $this->category = $category;
+    }
+
+    public function isVisible(): bool
+    {
+        return $this->visible;
+    }
+
+    public function setVisible(bool $visible): void
+    {
+        $this->visible = $visible;
     }
 
     public function getModule(): ?Module


### PR DESCRIPTION
## Summary
- add `visible` property to Lesson model with accessor methods
- keep repository lookup for visible lessons

## Testing
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ba2daadc083248b064d86018f34a6