### PR TITLE
Add PHPDoc for findBySlug

### DIFF
--- a/equed-lms/Classes/Domain/Repository/CourseBundleRepository.php
+++ b/equed-lms/Classes/Domain/Repository/CourseBundleRepository.php
@@ -16,7 +16,10 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
 final class CourseBundleRepository extends Repository
 {
     /**
-     * Finds a CourseBundle by its slug (URL key).
+     * Finds a CourseBundle by its slug.
+     *
+     * @param string $slug
+     * @return CourseBundle|null
      */
     public function findBySlug(string $slug): ?CourseBundle
     {


### PR DESCRIPTION
## Summary
- document `findBySlug()` in `CourseBundleRepository`

## Testing
- `composer phpstan` *(fails: invalid escaping in phpstan-baseline)*
- `composer test` *(fails: cannot declare interface UuidGeneratorInterface)*

------
https://chatgpt.com/codex/tasks/task_e_684ba4e0876c8324af2f83f415dbe2b9