### PR TITLE
Add notification methods and update phpstan baseline

### DIFF
--- a/equed-lms/Classes/Domain/Service/NotificationServiceInterface.php
+++ b/equed-lms/Classes/Domain/Service/NotificationServiceInterface.php
@@ -12,4 +12,8 @@ interface NotificationServiceInterface
     public function getNotificationsForUser(int $userId): array;
 
     public function markAsRead(int $userId, int $notificationId): void;
+
+    public function sendCourseCompletedNotice(\Equed\EquedLms\Domain\Model\FrontendUser $user, int $courseInstanceId): void;
+
+    public function sendCertificateIssuedInfo(\Equed\EquedLms\Domain\Model\FrontendUser $user, string $qrCodeUrl): void;
 }

--- a/equed-lms/Classes/Service/NotificationService.php
+++ b/equed-lms/Classes/Service/NotificationService.php
@@ -50,6 +50,32 @@ final class NotificationService implements NotificationServiceInterface
         $this->mailService->sendMail($email, $subject, $body);
     }
 
+    public function sendCourseCompletedNotice(FrontendUser $user, int $courseInstanceId): void
+    {
+        $email = $user->getEmail();
+        if ($email === '') {
+            return;
+        }
+
+        $subject = $this->translate('notification.course_completed.subject', ['course' => $courseInstanceId]);
+        $body    = $this->translate('notification.course_completed.body', ['course' => $courseInstanceId]);
+
+        $this->mailService->sendMail($email, $subject, $body);
+    }
+
+    public function sendCertificateIssuedInfo(FrontendUser $user, string $qrCodeUrl): void
+    {
+        $email = $user->getEmail();
+        if ($email === '') {
+            return;
+        }
+
+        $subject = $this->translate('notification.certificate_issued.subject');
+        $body    = $this->translate('notification.certificate_issued.body', ['url' => $qrCodeUrl]);
+
+        $this->mailService->sendMail($email, $subject, $body);
+    }
+
     public function getNotificationsForUser(int $userId): array
     {
         $query = $this->frontendUserRepository->createQuery();

--- a/equed-lms/phpstan-baseline.neon
+++ b/equed-lms/phpstan-baseline.neon
@@ -5289,35 +5289,6 @@ parameters:
 			count: 1
 			path: Classes/Service/CourseGoalService.php
 
-		-
-			message: "#^Access to undefined constant Equed\\\\EquedLms\\\\Enum\\\\CourseStatus\\:\\:Validated\\.$#"
-			count: 1
-			path: Classes/Service/CourseStatusUpdaterService.php
-
-		-
-			message: "#^Call to an undefined method Equed\\\\EquedLms\\\\Domain\\\\Model\\\\UserCourseRecord\\:\\:getFeUser\\(\\)\\.$#"
-			count: 1
-			path: Classes/Service/CourseStatusUpdaterService.php
-
-		-
-			message: "#^Call to an undefined method Equed\\\\EquedLms\\\\Domain\\\\Model\\\\UserCourseRecord\\:\\:setCompletionDate\\(\\)\\.$#"
-			count: 1
-			path: Classes/Service/CourseStatusUpdaterService.php
-
-		-
-			message: "#^Call to method sendCertificateIssuedInfo\\(\\) on an unknown class Equed\\\\EquedLms\\\\Service\\\\NotificationServiceInterface\\.$#"
-			count: 1
-			path: Classes/Service/CourseStatusUpdaterService.php
-
-		-
-			message: "#^Call to method sendCourseCompletedNotice\\(\\) on an unknown class Equed\\\\EquedLms\\\\Service\\\\NotificationServiceInterface\\.$#"
-			count: 1
-			path: Classes/Service/CourseStatusUpdaterService.php
-
-		-
-			message: "#^Parameter \\$notificationService of method Equed\\\\EquedLms\\\\Service\\\\CourseStatusUpdaterService\\:\\:__construct\\(\\) has invalid type Equed\\\\EquedLms\\\\Service\\\\NotificationServiceInterface\\.$#"
-			count: 1
-			path: Classes/Service/CourseStatusUpdaterService.php
 
 		-
 			message: "#^Call to an undefined method Equed\\\\EquedLms\\\\Domain\\\\Model\\\\FrontendUser\\:\\:getName\\(\\)\\.$#"


### PR DESCRIPTION
## Summary
- add missing notification methods
- expose them in the domain service interface
- clean up phpstan baseline for CourseStatusUpdaterService

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ba66f646c83248463c6d97069bd70