### PR TITLE
Refactor services to use injected clock

### DIFF
--- a/equed-lms/Classes/Service/LessonProgressSyncService.php
+++ b/equed-lms/Classes/Service/LessonProgressSyncService.php
@@ -9,13 +9,15 @@ use Equed\EquedLms\Domain\Repository\LessonRepositoryInterface;
 use Equed\EquedLms\Domain\Model\LessonProgress;
 use Equed\EquedLms\Domain\Model\Lesson;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
+use Equed\EquedLms\Domain\Service\ClockInterface;
 
 final class LessonProgressSyncService
 {
     public function __construct(
         private readonly LessonProgressRepositoryInterface $progressRepository,
         private readonly LessonRepositoryInterface $lessonRepository,
-        private readonly PersistenceManagerInterface $persistenceManager
+        private readonly PersistenceManagerInterface $persistenceManager,
+        private readonly ClockInterface $clock
     ) {
     }
 
@@ -55,7 +57,7 @@ final class LessonProgressSyncService
                 $entry->setProgress((int) $item['progress']);
                 $entry->setStatus($item['status'] ?? 'incomplete');
                 $entry->setCompleted((bool) $item['completed']);
-                $entry->setUpdatedAt(new \DateTimeImmutable());
+                $entry->setUpdatedAt($this->clock->now());
             }
 
             $this->progressRepository->updateOrAdd($entry);

--- a/equed-lms/Classes/Service/ProgressService.php
+++ b/equed-lms/Classes/Service/ProgressService.php
@@ -13,7 +13,7 @@ use Equed\EquedLms\Domain\Model\FrontendUser;
 use Equed\EquedLms\Enum\UserCourseStatus;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
-use DateTimeImmutable;
+use Equed\EquedLms\Domain\Service\ClockInterface;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
 /**
@@ -25,6 +25,7 @@ final class ProgressService implements ProgressServiceInterface
         private readonly UserCourseRecordRepositoryInterface $userCourseRecordRepository,
         private readonly GptTranslationServiceInterface $translationService,
         private readonly ConnectionPool $connectionPool,
+        private readonly ClockInterface $clock,
         private readonly string $extensionKey = 'equed_lms'
     ) {
     }
@@ -114,7 +115,7 @@ final class ProgressService implements ProgressServiceInterface
 
     public function cleanupAbandonedCourseProgress(int $days): void
     {
-        $cutoff = (new DateTimeImmutable())
+        $cutoff = $this->clock->now()
             ->modify(sprintf('-%d days', $days))
             ->format('Y-m-d H:i:s');
 

--- a/equed-lms/Classes/Service/RecognitionAwardService.php
+++ b/equed-lms/Classes/Service/RecognitionAwardService.php
@@ -9,6 +9,7 @@ use Equed\EquedLms\Domain\Repository\UserBadgeRepositoryInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
+use Equed\EquedLms\Domain\Service\ClockInterface;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
 /**
@@ -22,7 +23,8 @@ final class RecognitionAwardService
         private readonly UserBadgeRepositoryInterface $userBadgeRepository,
         private readonly PersistenceManagerInterface $persistenceManager,
         private readonly CacheItemPoolInterface $cachePool,
-        private readonly GptTranslationServiceInterface $translationService
+        private readonly GptTranslationServiceInterface $translationService,
+        private readonly ClockInterface $clock
     ) {
     }
 
@@ -54,7 +56,7 @@ final class RecognitionAwardService
         $badge->setFeUserId($userId);
         $badge->setType($type);
         $badge->setTitle($this->translate("badge.{$type}.title"));
-        $badge->setAwardedAt(new \DateTimeImmutable());
+        $badge->setAwardedAt($this->clock->now());
 
         $this->userBadgeRepository->add($badge);
         $this->persistenceManager->persistAll();

--- a/equed-lms/Classes/Service/SubmissionEvaluationService.php
+++ b/equed-lms/Classes/Service/SubmissionEvaluationService.php
@@ -8,6 +8,7 @@ use Equed\EquedLms\Domain\Model\UserSubmission;
 use Equed\EquedLms\Domain\Repository\UserSubmissionRepositoryInterface;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
+use Equed\EquedLms\Domain\Service\ClockInterface;
 
 /**
  * Service to evaluate user submissions manually or assisted by GPT.
@@ -17,7 +18,8 @@ final class SubmissionEvaluationService
     public function __construct(
         private readonly UserSubmissionRepositoryInterface $submissionRepository,
         private readonly GptTranslationServiceInterface $translationService,
-        private readonly PersistenceManagerInterface $persistenceManager
+        private readonly PersistenceManagerInterface $persistenceManager,
+        private readonly ClockInterface $clock
     ) {
     }
 
@@ -34,7 +36,7 @@ final class SubmissionEvaluationService
         $submission->setScore($score);
         $submission->setFeedback($feedback);
         $submission->setScored(true);
-        $submission->setEvaluatedAt(new \DateTimeImmutable());
+        $submission->setEvaluatedAt($this->clock->now());
 
         $this->submissionRepository->update($submission);
         $this->persistenceManager->persistAll();

--- a/equed-lms/Classes/Service/SubmissionSyncService.php
+++ b/equed-lms/Classes/Service/SubmissionSyncService.php
@@ -8,12 +8,14 @@ use Equed\EquedLms\Domain\Model\UserSubmission;
 use Equed\EquedLms\Domain\Repository\UserSubmissionRepository;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 use Ramsey\Uuid\Uuid;
+use Equed\EquedLms\Domain\Service\ClockInterface;
 
 final class SubmissionSyncService
 {
     public function __construct(
         private readonly UserSubmissionRepository $submissionRepository,
-        private readonly PersistenceManagerInterface $persistenceManager
+        private readonly PersistenceManagerInterface $persistenceManager,
+        private readonly ClockInterface $clock
     ) {
     }
 
@@ -57,7 +59,7 @@ final class SubmissionSyncService
             $submission->setStatus($data['status']);
             $submission->setScore((float) ($data['score'] ?? 0));
             $submission->setGptFeedback((string) ($data['gptFeedback'] ?? ''));
-            $submission->setUpdatedAt(new \DateTimeImmutable());
+            $submission->setUpdatedAt($this->clock->now());
         }
 
         if ($submission->getUid() === null) {

--- a/equed-lms/Classes/Service/SyncService.php
+++ b/equed-lms/Classes/Service/SyncService.php
@@ -8,12 +8,14 @@ use Equed\EquedLms\Domain\Model\UserProfile;
 use Equed\EquedLms\Domain\Repository\UserProfileRepositoryInterface;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 use Ramsey\Uuid\Uuid;
+use Equed\EquedLms\Domain\Service\ClockInterface;
 
 final class SyncService
 {
     public function __construct(
         private readonly UserProfileRepositoryInterface $profileRepository,
-        private readonly PersistenceManagerInterface $persistenceManager
+        private readonly PersistenceManagerInterface $persistenceManager,
+        private readonly ClockInterface $clock
     ) {
     }
 
@@ -56,7 +58,7 @@ final class SyncService
             if (isset($data['country'])) {
                 $profile->setCountry((string) $data['country']);
             }
-            $profile->setUpdatedAt(new \DateTimeImmutable());
+            $profile->setUpdatedAt($this->clock->now());
         }
 
         if ($profile->getUid() === null) {

--- a/equed-lms/Tests/Unit/Service/RecognitionAwardServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/RecognitionAwardServiceTest.php
@@ -13,6 +13,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Cache\CacheItemInterface;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
+use Equed\EquedLms\Domain\Service\ClockInterface;
 
 class RecognitionAwardServiceTest extends TestCase
 {
@@ -23,6 +24,7 @@ class RecognitionAwardServiceTest extends TestCase
     private $persistence;
     private $cache;
     private $translation;
+    private $clock;
 
     protected function setUp(): void
     {
@@ -30,12 +32,14 @@ class RecognitionAwardServiceTest extends TestCase
         $this->persistence = $this->prophesize(PersistenceManagerInterface::class);
         $this->cache = $this->prophesize(CacheItemPoolInterface::class);
         $this->translation = $this->prophesize(GptTranslationServiceInterface::class);
+        $this->clock = $this->prophesize(ClockInterface::class);
 
         $this->subject = new RecognitionAwardService(
             $this->repo->reveal(),
             $this->persistence->reveal(),
             $this->cache->reveal(),
-            $this->translation->reveal()
+            $this->translation->reveal(),
+            $this->clock->reveal()
         );
     }
 

--- a/equed-lms/Tests/Unit/Service/SubmissionSyncServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/SubmissionSyncServiceTest.php
@@ -8,6 +8,7 @@ use Equed\EquedLms\Domain\Model\UserSubmission;
 use Equed\EquedLms\Domain\Repository\UserSubmissionRepository;
 use Equed\EquedLms\Enum\SubmissionStatus;
 use Equed\EquedLms\Service\SubmissionSyncService;
+use Equed\EquedLms\Domain\Service\ClockInterface;
 use Equed\EquedLms\Tests\Traits\ProphecyTrait;
 use PHPUnit\Framework\TestCase;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
@@ -19,14 +20,17 @@ class SubmissionSyncServiceTest extends TestCase
     private SubmissionSyncService $subject;
     private $repo;
     private $persistence;
+    private $clock;
 
     protected function setUp(): void
     {
         $this->repo = $this->prophesize(UserSubmissionRepository::class);
         $this->persistence = $this->prophesize(PersistenceManagerInterface::class);
+        $this->clock = $this->prophesize(ClockInterface::class);
         $this->subject = new SubmissionSyncService(
             $this->repo->reveal(),
-            $this->persistence->reveal()
+            $this->persistence->reveal(),
+            $this->clock->reveal()
         );
     }
 

--- a/equed-lms/Tests/Unit/Service/SyncServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/SyncServiceTest.php
@@ -9,6 +9,7 @@ namespace Equed\EquedLms\Tests\Unit\Service;
 use Equed\EquedLms\Domain\Model\UserProfile;
 use Equed\EquedLms\Domain\Repository\UserProfileRepositoryInterface;
 use Equed\EquedLms\Service\SyncService;
+use Equed\EquedLms\Domain\Service\ClockInterface;
 use PHPUnit\Framework\TestCase;
 use Equed\EquedLms\Tests\Traits\ProphecyTrait;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
@@ -30,7 +31,8 @@ class SyncServiceTest extends TestCase
 
         $repo = $this->prophesize(UserProfileRepositoryInterface::class);
         $pm = $this->prophesize(PersistenceManagerInterface::class);
-        $service = new SyncService($repo->reveal(), $pm->reveal());
+        $clock = $this->prophesize(ClockInterface::class);
+        $service = new SyncService($repo->reveal(), $pm->reveal(), $clock->reveal());
 
         $data = $service->pushToApp($profile);
         $this->assertSame($profile->getFeUser(), $data['userId']);
@@ -45,8 +47,9 @@ class SyncServiceTest extends TestCase
 
         $pm = $this->prophesize(PersistenceManagerInterface::class);
         $pm->persistAll()->shouldBeCalled();
+        $clock = $this->prophesize(ClockInterface::class);
 
-        $service = new SyncService($repo->reveal(), $pm->reveal());
+        $service = new SyncService($repo->reveal(), $pm->reveal(), $clock->reveal());
         $result = $service->pullFromApp([
             'userId' => 5,
             'updatedAt' => '2024-01-01T00:00:00+00:00'


### PR DESCRIPTION
## Summary
- inject `ClockInterface` into service constructors
- use `$this->clock->now()` instead of direct `new DateTimeImmutable()` calls
- update unit tests to mock the clock

## Testing
- `vendor/bin/phpunit --version` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ba8ed99a483249b454bf640da7e80