### PR TITLE
Add completed_at column for lesson progress

### DIFF
--- a/equed-lms/Configuration/Schema/Domain/Model/Lessonprogress.yaml
+++ b/equed-lms/Configuration/Schema/Domain/Model/Lessonprogress.yaml
@@ -30,5 +30,7 @@ columns:
     type: integer
   updated_at:
     type: integer
+  completed_at:
+    type: integer
   completed:
     type: boolean

--- a/equed-lms/Migrations/Version20250801009000.php
+++ b/equed-lms/Migrations/Version20250801009000.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250801009000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add completed_at column to lesson progress table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $table = $schema->getTable('tx_equedlms_domain_model_lessonprogress');
+        $table->addColumn('completed_at', 'integer');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $table = $schema->getTable('tx_equedlms_domain_model_lessonprogress');
+        if ($table->hasColumn('completed_at')) {
+            $table->dropColumn('completed_at');
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- include `completed_at` timestamp in Lessonprogress schema
- add migration to add `completed_at` column

## Testing
- `composer install` *(fails: command not found)*
- `composer phpstan` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bb269bea883248db3536c29c0e498