### PR TITLE
Update user course record table

### DIFF
--- a/equed-lms/Configuration/Schema/Domain/Model/Usercourserecord.yaml
+++ b/equed-lms/Configuration/Schema/Domain/Model/Usercourserecord.yaml
@@ -4,16 +4,18 @@ columns:
     type: integer
   pid:
     type: integer
+  uuid:
+    type: string
   fe_user:
     type: integer
   course_instance:
     type: integer
   enrolled_at:
-    type: string
+    type: integer
   completed_at:
-    type: string
+    type: integer
   revoked_at:
-    type: string
+    type: integer
   certificate_number:
     type: string
   certificate_hash:
@@ -25,13 +27,13 @@ columns:
   progress_percent:
     type: string
   last_activity:
-    type: string
+    type: integer
   certifier:
     type: integer
   instructor:
     type: integer
   certified_at:
-    type: string
+    type: integer
   certificate_file:
     type: string
   certificate_code:
@@ -45,7 +47,7 @@ columns:
   validated_by:
     type: integer
   validated_at:
-    type: string
+    type: integer
   qms_flagged:
     type: boolean
   qms_case:
@@ -56,3 +58,13 @@ columns:
     type: string
   recognition_awarded:
     type: boolean
+  archived_attempts:
+    type: text
+  passed_modules:
+    type: text
+  external_certificate_flag:
+    type: boolean
+  created_at:
+    type: integer
+  updated_at:
+    type: integer

--- a/equed-lms/Configuration/TCA/Overrides/tx_equedlms_domain_model_usercourserecord.php
+++ b/equed-lms/Configuration/TCA/Overrides/tx_equedlms_domain_model_usercourserecord.php
@@ -229,7 +229,7 @@ return [
                 instructor, certifier, certified_at, certificate_file, certificate_code, certificate_number, certificate_hash, badge_level,
                 requires_external_examiner, external_examiner, validation_required,
                 validated_by, validated_at, qms_flagged, qms_case, note_internal,
-                attempts_total, recognition_awarded
+                attempts_total, recognition_awarded, uuid, archived_attempts, passed_modules, external_certificate_flag, created_at, updated_at
             ',
         ],
     ],

--- a/equed-lms/Configuration/TCA/tx_equedlms_domain_model_usercourserecord.php
+++ b/equed-lms/Configuration/TCA/tx_equedlms_domain_model_usercourserecord.php
@@ -15,16 +15,22 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_usercourserecord.fe_user',
             'config' => [
-                'type' => 'input',
-                'eval' => 'int'
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'foreign_table' => 'fe_users',
+                'minitems' => 1,
+                'maxitems' => 1,
             ]
         ],
         'course_instance' => [
             'exclude' => true,
             'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_usercourserecord.course_instance',
             'config' => [
-                'type' => 'input',
-                'eval' => 'int'
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'foreign_table' => 'tx_equedlms_domain_model_courseinstance',
+                'minitems' => 1,
+                'maxitems' => 1,
             ]
         ],
         'enrolled_at' => [
@@ -32,7 +38,7 @@ return [
             'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_usercourserecord.enrolled_at',
             'config' => [
                 'type' => 'input',
-                'eval' => 'trim'
+                'eval' => 'int'
             ]
         ],
         'completed_at' => [
@@ -40,7 +46,7 @@ return [
             'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_usercourserecord.completed_at',
             'config' => [
                 'type' => 'input',
-                'eval' => 'trim'
+                'eval' => 'int'
             ]
         ],
         'revoked_at' => [
@@ -48,7 +54,7 @@ return [
             'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_usercourserecord.revoked_at',
             'config' => [
                 'type' => 'input',
-                'eval' => 'trim'
+                'eval' => 'int'
             ]
         ],
         'certificate_number' => [
@@ -62,6 +68,14 @@ return [
         'certificate_hash' => [
             'exclude' => true,
             'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_usercourserecord.certificate_hash',
+            'config' => [
+                'type' => 'input',
+                'eval' => 'trim'
+            ]
+        ],
+        'uuid' => [
+            'exclude' => true,
+            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_usercourserecord.uuid',
             'config' => [
                 'type' => 'input',
                 'eval' => 'trim'
@@ -96,7 +110,7 @@ return [
             'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_usercourserecord.last_activity',
             'config' => [
                 'type' => 'input',
-                'eval' => 'trim'
+                'eval' => 'int'
             ]
         ],
         'certifier' => [
@@ -120,7 +134,7 @@ return [
             'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_usercourserecord.certified_at',
             'config' => [
                 'type' => 'input',
-                'eval' => 'trim'
+                'eval' => 'int'
             ]
         ],
         'certificate_file' => [
@@ -174,7 +188,7 @@ return [
             'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_usercourserecord.validated_at',
             'config' => [
                 'type' => 'input',
-                'eval' => 'trim'
+                'eval' => 'int'
             ]
         ],
         'qms_flagged' => [
@@ -213,14 +227,51 @@ return [
             'config' => [
                 'type' => 'check'
             ]
+        ],
+        'archived_attempts' => [
+            'exclude' => true,
+            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_usercourserecord.archived_attempts',
+            'config' => [
+                'type' => 'text'
+            ]
+        ],
+        'passed_modules' => [
+            'exclude' => true,
+            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_usercourserecord.passed_modules',
+            'config' => [
+                'type' => 'text'
+            ]
+        ],
+        'external_certificate_flag' => [
+            'exclude' => true,
+            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_usercourserecord.external_certificate_flag',
+            'config' => [
+                'type' => 'check'
+            ]
+        ],
+        'created_at' => [
+            'exclude' => true,
+            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_usercourserecord.created_at',
+            'config' => [
+                'type' => 'input',
+                'eval' => 'int'
+            ]
+        ],
+        'updated_at' => [
+            'exclude' => true,
+            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_usercourserecord.updated_at',
+            'config' => [
+                'type' => 'input',
+                'eval' => 'int'
+            ]
         ]
     ],
     'types' => [
         1 => [
-            'showitem' => 'fe_user, course_instance, enrolled_at, completed_at, revoked_at, certificate_number, certificate_hash, badge_level, status, progress_percent, last_activity, certifier, instructor, certified_at, certificate_file, certificate_code, requires_external_examiner, external_examiner, validation_required, validated_by, validated_at, qms_flagged, qms_case, note_internal, attempts_total, recognition_awarded'
+            'showitem' => 'fe_user, course_instance, enrolled_at, completed_at, revoked_at, certificate_number, certificate_hash, uuid, badge_level, status, progress_percent, last_activity, certifier, instructor, certified_at, certificate_file, certificate_code, requires_external_examiner, external_examiner, validation_required, validated_by, validated_at, qms_flagged, qms_case, note_internal, attempts_total, recognition_awarded, archived_attempts, passed_modules, external_certificate_flag, created_at, updated_at'
         ]
     ],
     'interface' => [
-        'showRecordFieldList' => 'fe_user,course_instance,enrolled_at,completed_at,revoked_at,certificate_number,certificate_hash,badge_level,status,progress_percent,last_activity,certifier,instructor,certified_at,certificate_file,certificate_code,requires_external_examiner,external_examiner,validation_required,validated_by,validated_at,qms_flagged,qms_case,note_internal,attempts_total,recognition_awarded'
+        'showRecordFieldList' => 'fe_user,course_instance,enrolled_at,completed_at,revoked_at,certificate_number,certificate_hash,uuid,badge_level,status,progress_percent,last_activity,certifier,instructor,certified_at,certificate_file,certificate_code,requires_external_examiner,external_examiner,validation_required,validated_by,validated_at,qms_flagged,qms_case,note_internal,attempts_total,recognition_awarded,archived_attempts,passed_modules,external_certificate_flag,created_at,updated_at'
     ]
 ];

--- a/equed-lms/Migrations/Version20250801010000.php
+++ b/equed-lms/Migrations/Version20250801010000.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250801010000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Update user course record table with additional columns and timestamp types';
+    }
+
+    public function up(Schema $schema): void
+    {
+        if ($schema->hasTable('tx_equedlms_domain_model_usercourserecord')) {
+            $table = $schema->getTable('tx_equedlms_domain_model_usercourserecord');
+            if (!$table->hasColumn('uuid')) {
+                $table->addColumn('uuid', 'string');
+            }
+            if (!$table->hasColumn('archived_attempts')) {
+                $table->addColumn('archived_attempts', 'text', ['notnull' => false]);
+            }
+            if (!$table->hasColumn('passed_modules')) {
+                $table->addColumn('passed_modules', 'text', ['notnull' => false]);
+            }
+            if (!$table->hasColumn('external_certificate_flag')) {
+                $table->addColumn('external_certificate_flag', 'boolean');
+            }
+            if (!$table->hasColumn('created_at')) {
+                $table->addColumn('created_at', 'integer');
+            }
+            if (!$table->hasColumn('updated_at')) {
+                $table->addColumn('updated_at', 'integer');
+            }
+            $table->changeColumn('enrolled_at', ['type' => 'integer']);
+            $table->changeColumn('completed_at', ['type' => 'integer']);
+            $table->changeColumn('revoked_at', ['type' => 'integer']);
+            $table->changeColumn('last_activity', ['type' => 'integer']);
+            $table->changeColumn('certified_at', ['type' => 'integer']);
+            $table->changeColumn('validated_at', ['type' => 'integer']);
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        if ($schema->hasTable('tx_equedlms_domain_model_usercourserecord')) {
+            $table = $schema->getTable('tx_equedlms_domain_model_usercourserecord');
+            if ($table->hasColumn('uuid')) {
+                $table->dropColumn('uuid');
+            }
+            if ($table->hasColumn('archived_attempts')) {
+                $table->dropColumn('archived_attempts');
+            }
+            if ($table->hasColumn('passed_modules')) {
+                $table->dropColumn('passed_modules');
+            }
+            if ($table->hasColumn('external_certificate_flag')) {
+                $table->dropColumn('external_certificate_flag');
+            }
+            if ($table->hasColumn('created_at')) {
+                $table->dropColumn('created_at');
+            }
+            if ($table->hasColumn('updated_at')) {
+                $table->dropColumn('updated_at');
+            }
+            $table->changeColumn('enrolled_at', ['type' => 'string']);
+            $table->changeColumn('completed_at', ['type' => 'string']);
+            $table->changeColumn('revoked_at', ['type' => 'string']);
+            $table->changeColumn('last_activity', ['type' => 'string']);
+            $table->changeColumn('certified_at', ['type' => 'string']);
+            $table->changeColumn('validated_at', ['type' => 'string']);
+        }
+    }
+}

--- a/equed-lms/Resources/Private/Language/locallang_db.de.xlf
+++ b/equed-lms/Resources/Private/Language/locallang_db.de.xlf
@@ -463,6 +463,18 @@
         <source>Attempts total</source><target></target></trans-unit>
       <trans-unit id="tx_equedlms_domain_model_usercourserecord.recognition_awarded">
         <source>Recognition awarded</source><target></target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_usercourserecord.uuid">
+        <source>UUID</source><target></target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_usercourserecord.archived_attempts">
+        <source>Archived attempts</source><target></target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_usercourserecord.passed_modules">
+        <source>Passed modules</source><target></target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_usercourserecord.external_certificate_flag">
+        <source>External certificate flag</source><target></target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_usercourserecord.created_at">
+        <source>Created at</source><target></target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_usercourserecord.updated_at">
+        <source>Updated at</source><target></target></trans-unit>
 
       <!-- CourseExamSlot -->
       <trans-unit id="tx_equedlms_domain_model_courseexamslot.uuid">

--- a/equed-lms/Resources/Private/Language/locallang_db.easy.xlf
+++ b/equed-lms/Resources/Private/Language/locallang_db.easy.xlf
@@ -437,6 +437,18 @@
         <source>Attempts total</source><target></target></trans-unit>
       <trans-unit id="tx_equedlms_domain_model_usercourserecord.recognition_awarded">
         <source>Recognition awarded</source><target></target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_usercourserecord.uuid">
+        <source>UUID</source><target></target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_usercourserecord.archived_attempts">
+        <source>Archived attempts</source><target></target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_usercourserecord.passed_modules">
+        <source>Passed modules</source><target></target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_usercourserecord.external_certificate_flag">
+        <source>External certificate flag</source><target></target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_usercourserecord.created_at">
+        <source>Created at</source><target></target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_usercourserecord.updated_at">
+        <source>Updated at</source><target></target></trans-unit>
 
       <!-- CourseExamSlot -->
       <trans-unit id="tx_equedlms_domain_model_courseexamslot.uuid">

--- a/equed-lms/Resources/Private/Language/locallang_db.en.xlf
+++ b/equed-lms/Resources/Private/Language/locallang_db.en.xlf
@@ -226,6 +226,24 @@
       <trans-unit id="tx_equedlms_domain_model_usercourserecord.recognition_awarded">
         <source>Recognition awarded</source>
       </trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_usercourserecord.uuid">
+        <source>UUID</source>
+      </trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_usercourserecord.archived_attempts">
+        <source>Archived attempts</source>
+      </trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_usercourserecord.passed_modules">
+        <source>Passed modules</source>
+      </trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_usercourserecord.external_certificate_flag">
+        <source>External certificate flag</source>
+      </trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_usercourserecord.created_at">
+        <source>Created at</source>
+      </trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_usercourserecord.updated_at">
+        <source>Updated at</source>
+      </trans-unit>
 
       <!-- GlossaryEntry (bereits definiert) -->
       <trans-unit id="tx_equedlms_domain_model_glossaryentry.term">

--- a/equed-lms/Resources/Private/Language/locallang_db.es.xlf
+++ b/equed-lms/Resources/Private/Language/locallang_db.es.xlf
@@ -459,6 +459,18 @@
         <source>Attempts total</source><target></target></trans-unit>
       <trans-unit id="tx_equedlms_domain_model_usercourserecord.recognition_awarded">
         <source>Recognition awarded</source><target></target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_usercourserecord.uuid">
+        <source>UUID</source><target></target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_usercourserecord.archived_attempts">
+        <source>Archived attempts</source><target></target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_usercourserecord.passed_modules">
+        <source>Passed modules</source><target></target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_usercourserecord.external_certificate_flag">
+        <source>External certificate flag</source><target></target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_usercourserecord.created_at">
+        <source>Created at</source><target></target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_usercourserecord.updated_at">
+        <source>Updated at</source><target></target></trans-unit>
 
       <!-- CourseExamSlot -->
       <trans-unit id="tx_equedlms_domain_model_courseexamslot.uuid">

--- a/equed-lms/Resources/Private/Language/locallang_db.fr.xlf
+++ b/equed-lms/Resources/Private/Language/locallang_db.fr.xlf
@@ -459,6 +459,18 @@
         <source>Attempts total</source><target></target></trans-unit>
       <trans-unit id="tx_equedlms_domain_model_usercourserecord.recognition_awarded">
         <source>Recognition awarded</source><target></target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_usercourserecord.uuid">
+        <source>UUID</source><target></target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_usercourserecord.archived_attempts">
+        <source>Archived attempts</source><target></target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_usercourserecord.passed_modules">
+        <source>Passed modules</source><target></target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_usercourserecord.external_certificate_flag">
+        <source>External certificate flag</source><target></target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_usercourserecord.created_at">
+        <source>Created at</source><target></target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_usercourserecord.updated_at">
+        <source>Updated at</source><target></target></trans-unit>
 
       <!-- CourseExamSlot -->
       <trans-unit id="tx_equedlms_domain_model_courseexamslot.uuid">

--- a/equed-lms/Resources/Private/Language/locallang_db.sw.xlf
+++ b/equed-lms/Resources/Private/Language/locallang_db.sw.xlf
@@ -459,6 +459,18 @@
         <source>Attempts total</source><target></target></trans-unit>
       <trans-unit id="tx_equedlms_domain_model_usercourserecord.recognition_awarded">
         <source>Recognition awarded</source><target></target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_usercourserecord.uuid">
+        <source>UUID</source><target></target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_usercourserecord.archived_attempts">
+        <source>Archived attempts</source><target></target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_usercourserecord.passed_modules">
+        <source>Passed modules</source><target></target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_usercourserecord.external_certificate_flag">
+        <source>External certificate flag</source><target></target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_usercourserecord.created_at">
+        <source>Created at</source><target></target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_usercourserecord.updated_at">
+        <source>Updated at</source><target></target></trans-unit>
 
       <!-- CourseExamSlot -->
       <trans-unit id="tx_equedlms_domain_model_courseexamslot.uuid">


### PR DESCRIPTION
## Summary
- expand `usercourserecord` schema with uuid and timestamp fields
- use integer timestamps for date columns
- link `fe_user` and `course_instance` via proper foreign keys
- provide migration for the new schema
- translate the new fields in all language files

## Testing
- `php` command not available so no tests were run

------
https://chatgpt.com/codex/tasks/task_e_684bb4a36248832481c8702534b8ac1a