### PR TITLE
Add GPT analysis fields to submission

### DIFF
--- a/equed-lms/Configuration/Schema/Domain/Model/Submission.yaml
+++ b/equed-lms/Configuration/Schema/Domain/Model/Submission.yaml
@@ -16,3 +16,19 @@ columns:
     type: integer
   created_at:
     type: integer
+  uuid:
+    type: string
+  gpt_analysis_status:
+    type: string
+  gpt_score:
+    type: float
+  gpt_summary:
+    type: text
+  gpt_suggestion:
+    type: text
+  gpt_analysis_data:
+    type: text
+  analyzed_at:
+    type: integer
+  text_content:
+    type: text

--- a/equed-lms/Configuration/TCA/Overrides/tx_equedlms_domain_model_submission.php
+++ b/equed-lms/Configuration/TCA/Overrides/tx_equedlms_domain_model_submission.php
@@ -65,12 +65,65 @@ return [
                 'eval' => 'datetime',
             ],
         ],
+        'uuid' => [
+            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:submission.uuid',
+            'config' => [
+                'type' => 'input',
+                'eval' => 'trim',
+            ],
+        ],
+        'gpt_analysis_status' => [
+            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:submission.gpt_analysis_status',
+            'config' => [
+                'type' => 'input',
+                'eval' => 'trim',
+            ],
+        ],
+        'gpt_score' => [
+            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:submission.gpt_score',
+            'config' => [
+                'type' => 'input',
+                'eval' => 'double2',
+            ],
+        ],
+        'gpt_summary' => [
+            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:submission.gpt_summary',
+            'config' => [
+                'type' => 'text',
+            ],
+        ],
+        'gpt_suggestion' => [
+            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:submission.gpt_suggestion',
+            'config' => [
+                'type' => 'text',
+            ],
+        ],
+        'gpt_analysis_data' => [
+            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:submission.gpt_analysis_data',
+            'config' => [
+                'type' => 'text',
+            ],
+        ],
+        'analyzed_at' => [
+            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:submission.analyzed_at',
+            'config' => [
+                'type' => 'input',
+                'renderType' => 'inputDateTime',
+                'eval' => 'datetime',
+            ],
+        ],
+        'text_content' => [
+            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:submission.text_content',
+            'config' => [
+                'type' => 'text',
+            ],
+        ],
     ],
     'types' => [
         '0' => [
             'showitem' => '
                 --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,
-                title, description, file, user, lesson, created_at
+                title, description, file, user, lesson, created_at, uuid, gpt_analysis_status, gpt_score, gpt_summary, gpt_suggestion, gpt_analysis_data, analyzed_at, text_content
             ',
         ],
     ],

--- a/equed-lms/Configuration/TCA/tx_equedlms_domain_model_submission.php
+++ b/equed-lms/Configuration/TCA/tx_equedlms_domain_model_submission.php
@@ -38,16 +38,20 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_submission.user',
             'config' => [
-                'type' => 'input',
-                'eval' => 'int'
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'foreign_table' => 'fe_users',
+                'maxitems' => 1,
             ]
         ],
         'lesson' => [
             'exclude' => true,
             'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_submission.lesson',
             'config' => [
-                'type' => 'input',
-                'eval' => 'int'
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'foreign_table' => 'tx_equedlms_domain_model_lesson',
+                'default' => 0,
             ]
         ],
         'created_at' => [
@@ -57,14 +61,74 @@ return [
                 'type' => 'input',
                 'eval' => 'int'
             ]
-        ]
+        ],
+        'uuid' => [
+            'exclude' => true,
+            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_submission.uuid',
+            'config' => [
+                'type' => 'input',
+                'eval' => 'trim'
+            ]
+        ],
+        'gpt_analysis_status' => [
+            'exclude' => true,
+            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_submission.gpt_analysis_status',
+            'config' => [
+                'type' => 'input',
+                'eval' => 'trim'
+            ]
+        ],
+        'gpt_score' => [
+            'exclude' => true,
+            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_submission.gpt_score',
+            'config' => [
+                'type' => 'input',
+                'eval' => 'double2'
+            ]
+        ],
+        'gpt_summary' => [
+            'exclude' => true,
+            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_submission.gpt_summary',
+            'config' => [
+                'type' => 'text'
+            ]
+        ],
+        'gpt_suggestion' => [
+            'exclude' => true,
+            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_submission.gpt_suggestion',
+            'config' => [
+                'type' => 'text'
+            ]
+        ],
+        'gpt_analysis_data' => [
+            'exclude' => true,
+            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_submission.gpt_analysis_data',
+            'config' => [
+                'type' => 'text'
+            ]
+        ],
+        'analyzed_at' => [
+            'exclude' => true,
+            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_submission.analyzed_at',
+            'config' => [
+                'type' => 'input',
+                'eval' => 'int',
+            ]
+        ],
+        'text_content' => [
+            'exclude' => true,
+            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_submission.text_content',
+            'config' => [
+                'type' => 'text'
+            ]
+        ],
     ],
     'types' => [
         1 => [
-            'showitem' => 'title, description, file, user, lesson, created_at'
+            'showitem' => 'title, description, file, user, lesson, created_at, uuid, gpt_analysis_status, gpt_score, gpt_summary, gpt_suggestion, gpt_analysis_data, analyzed_at, text_content'
         ]
     ],
     'interface' => [
-        'showRecordFieldList' => 'title,description,file,user,lesson,created_at'
+        'showRecordFieldList' => 'title,description,file,user,lesson,created_at,uuid,gpt_analysis_status,gpt_score,gpt_summary,gpt_suggestion,gpt_analysis_data,analyzed_at,text_content'
     ]
 ];

--- a/equed-lms/Migrations/Version20250801011000.php
+++ b/equed-lms/Migrations/Version20250801011000.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250801011000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Extend submission table with GPT analysis columns and foreign keys';
+    }
+
+    public function up(Schema $schema): void
+    {
+        if ($schema->hasTable('tx_equedlms_domain_model_submission')) {
+            $table = $schema->getTable('tx_equedlms_domain_model_submission');
+            if (!$table->hasColumn('uuid')) {
+                $table->addColumn('uuid', 'string');
+            }
+            if (!$table->hasColumn('gpt_analysis_status')) {
+                $table->addColumn('gpt_analysis_status', 'string', ['notnull' => false]);
+            }
+            if (!$table->hasColumn('gpt_score')) {
+                $table->addColumn('gpt_score', 'float', ['notnull' => false]);
+            }
+            if (!$table->hasColumn('gpt_summary')) {
+                $table->addColumn('gpt_summary', 'text', ['notnull' => false]);
+            }
+            if (!$table->hasColumn('gpt_suggestion')) {
+                $table->addColumn('gpt_suggestion', 'text', ['notnull' => false]);
+            }
+            if (!$table->hasColumn('gpt_analysis_data')) {
+                $table->addColumn('gpt_analysis_data', 'text', ['notnull' => false]);
+            }
+            if (!$table->hasColumn('analyzed_at')) {
+                $table->addColumn('analyzed_at', 'integer', ['notnull' => false]);
+            }
+            if (!$table->hasColumn('text_content')) {
+                $table->addColumn('text_content', 'text', ['notnull' => false]);
+            }
+            $table->changeColumn('created_at', ['type' => 'integer']);
+            $table->addForeignKeyConstraint('fe_users', ['user'], ['uid'], ['onDelete' => 'SET NULL']);
+            $table->addForeignKeyConstraint('tx_equedlms_domain_model_lesson', ['lesson'], ['uid'], ['onDelete' => 'SET NULL']);
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        if ($schema->hasTable('tx_equedlms_domain_model_submission')) {
+            $table = $schema->getTable('tx_equedlms_domain_model_submission');
+            foreach ($table->getForeignKeys() as $fk) {
+                $table->removeForeignKey($fk->getName());
+            }
+            foreach ([
+                'uuid',
+                'gpt_analysis_status',
+                'gpt_score',
+                'gpt_summary',
+                'gpt_suggestion',
+                'gpt_analysis_data',
+                'analyzed_at',
+                'text_content'
+            ] as $column) {
+                if ($table->hasColumn($column)) {
+                    $table->dropColumn($column);
+                }
+            }
+            $table->changeColumn('created_at', ['type' => 'integer']);
+        }
+    }
+}

--- a/equed-lms/Resources/Private/Language/locallang_db.de.xlf
+++ b/equed-lms/Resources/Private/Language/locallang_db.de.xlf
@@ -64,6 +64,23 @@
       <trans-unit id="tx_equedlms_domain_model_submission.created_at">
         <source>Submission date</source><target>Abgabedatum</target></trans-unit>
 
+      <trans-unit id="tx_equedlms_domain_model_submission.uuid">
+        <source>UUID</source><target>UUID</target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_submission.gpt_analysis_status">
+        <source>GPT analysis status</source><target>GPT-Analyse-Status</target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_submission.gpt_score">
+        <source>GPT score</source><target>GPT-Score</target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_submission.gpt_summary">
+        <source>GPT summary</source><target>GPT-Zusammenfassung</target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_submission.gpt_suggestion">
+        <source>GPT suggestion</source><target>GPT-Vorschlag</target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_submission.gpt_analysis_data">
+        <source>GPT analysis data</source><target>GPT-Analysedaten</target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_submission.analyzed_at">
+        <source>Analyzed at</source><target>Analysiert am</target></trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_submission.text_content">
+        <source>Text content</source><target>Textinhalt</target></trans-unit>
+
       
       <trans-unit id="tx_equedlms_domain_model_material.title">
         <source>Material title</source><target>Materialtitel</target></trans-unit>

--- a/equed-lms/Resources/Private/Language/locallang_db.en.xlf
+++ b/equed-lms/Resources/Private/Language/locallang_db.en.xlf
@@ -91,6 +91,30 @@
       <trans-unit id="tx_equedlms_domain_model_submission.created_at">
         <source>Submission date</source>
       </trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_submission.uuid">
+        <source>UUID</source>
+      </trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_submission.gpt_analysis_status">
+        <source>GPT analysis status</source>
+      </trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_submission.gpt_score">
+        <source>GPT score</source>
+      </trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_submission.gpt_summary">
+        <source>GPT summary</source>
+      </trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_submission.gpt_suggestion">
+        <source>GPT suggestion</source>
+      </trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_submission.gpt_analysis_data">
+        <source>GPT analysis data</source>
+      </trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_submission.analyzed_at">
+        <source>Analyzed at</source>
+      </trans-unit>
+      <trans-unit id="tx_equedlms_domain_model_submission.text_content">
+        <source>Text content</source>
+      </trans-unit>
 
       <!-- Material -->
       <trans-unit id="tx_equedlms_domain_model_material.title">


### PR DESCRIPTION
## Summary
- extend submission schema with GPT analysis columns
- reference users and lessons via foreign keys
- document new fields in TCA and translations
- migration adds columns and foreign keys

## Testing
- `composer install --no-interaction`
- `composer test` *(fails: Cannot declare interface)*

------
https://chatgpt.com/codex/tasks/task_e_684bb8ddb01483248d6dc6c36c3460d5