### PR TITLE
Update notification schema

### DIFF
--- a/equed-lms/Classes/Domain/Repository/NotificationRepository.php
+++ b/equed-lms/Classes/Domain/Repository/NotificationRepository.php
@@ -28,8 +28,8 @@ final class NotificationRepository extends Repository implements NotificationRep
         $query = $this->createQuery();
         $query->matching(
             $query->logicalAnd([
-                $query->equals('instructor', $user),
-                $query->equals('read', false),
+                $query->equals('recipient', $user),
+                $query->equals('isRead', false),
             ])
         );
 
@@ -47,9 +47,9 @@ final class NotificationRepository extends Repository implements NotificationRep
     {
         $query = $this->createQuery();
         $query->matching(
-            $query->equals('instructor', $user)
+            $query->equals('recipient', $user)
         );
-        $query->setOrderings(['crdate' => QueryInterface::ORDER_DESCENDING]);
+        $query->setOrderings(['createdAt' => QueryInterface::ORDER_DESCENDING]);
         $query->setLimit($limit);
 
         return $query->execute()->toArray();

--- a/equed-lms/Classes/EventListener/CertificateNotificationListener.php
+++ b/equed-lms/Classes/EventListener/CertificateNotificationListener.php
@@ -53,13 +53,16 @@ final class CertificateNotificationListener
             ?? 'Your certificate has been issued.';
 
         $notification = $this->notificationRepository->create([
-            'feUser' => $user,
-            'message' => $message,
-            'type' => 'certificate',
-            'lang' => $user->getUserProfile()?->getLanguage() ?? 'en',
-            'read' => false,
-            'crdate' => new \DateTimeImmutable(),
-            'tstamp' => new \DateTimeImmutable(),
+            'recipient'      => $user,
+            'titleKey'       => $messageKey,
+            'customMessage'  => $message,
+            'type'           => 'certificate',
+            'language'       => $user->getUserProfile()?->getLanguage() ?? 'en',
+            'status'         => 'active',
+            'isRead'         => false,
+            'isArchived'     => false,
+            'createdAt'      => new \DateTimeImmutable(),
+            'updatedAt'      => new \DateTimeImmutable(),
         ]);
 
         $this->notificationRepository->add($notification);

--- a/equed-lms/Classes/Service/DashboardService.php
+++ b/equed-lms/Classes/Service/DashboardService.php
@@ -162,9 +162,10 @@ final class DashboardService implements DashboardServiceInterface
         $result = [];
         foreach ($notifications as $note) {
             $result[] = [
-                'type'    => $note->getType(),
-                'message' => $note->getMessage(),
-                'date'    => $note->getCreatedAt()?->format('Y-m-d H:i') ?? '',
+                'type'          => $note->getType(),
+                'titleKey'      => $note->getTitleKey(),
+                'customMessage' => $note->getCustomMessage(),
+                'date'          => $note->getCreatedAt()?->format('Y-m-d H:i') ?? '',
             ];
         }
         return $result;

--- a/equed-lms/Configuration/Schema/Domain/Model/Notification.yaml
+++ b/equed-lms/Configuration/Schema/Domain/Model/Notification.yaml
@@ -6,35 +6,29 @@ columns:
     type: integer
   recipient:
     type: integer
-  type:
+  course_instance:
     type: integer
-  title:
+  submission:
+    type: integer
+  user_course_record:
+    type: integer
+  type:
     type: string
-  message:
-    type: text
-  payload:
-    type: text
-  related_model:
-    type: string
-  related_uid:
+  status:
     type: string
   is_read:
     type: boolean
+  is_archived:
+    type: boolean
   created_at:
     type: string
-  valid_until:
-    type: string
-  priority:
-    type: integer
   uuid:
     type: string
   language:
     type: string
-  send_email:
-    type: boolean
-  send_push:
-    type: boolean
-  channel:
-    type: integer
-  sender:
+  title_key:
+    type: string
+  custom_message:
+    type: text
+  updated_at:
     type: string

--- a/equed-lms/Configuration/TCA/Overrides/tx_equedlms_domain_model_notification.php
+++ b/equed-lms/Configuration/TCA/Overrides/tx_equedlms_domain_model_notification.php
@@ -15,6 +15,27 @@ use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
                 'maxitems' => 1,
             ],
         ],
+        'course_instance' => [
+            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:notification.course_instance',
+            'config' => [
+                'type' => 'input',
+                'eval' => 'int',
+            ],
+        ],
+        'submission' => [
+            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:notification.submission',
+            'config' => [
+                'type' => 'input',
+                'eval' => 'int',
+            ],
+        ],
+        'user_course_record' => [
+            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:notification.user_course_record',
+            'config' => [
+                'type' => 'input',
+                'eval' => 'int',
+            ],
+        ],
         'type' => [
             'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:notification.type',
             'config' => [
@@ -31,38 +52,11 @@ use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
                 'default' => 'info',
             ],
         ],
-        'title' => [
-            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.title',
-            'config' => [
-                'type' => 'input',
-                'eval' => 'trim,required',
-            ],
-        ],
-        'message' => [
-            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.message',
-            'config' => [
-                'type' => 'text',
-                'rows' => 4,
-                'cols' => 60,
-            ],
-        ],
-        'payload' => [
-            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:notification.payload',
-            'config' => [
-                'type' => 'text',
-            ],
-        ],
-        'related_model' => [
-            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:notification.related_model',
+        'status' => [
+            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:notification.status',
             'config' => [
                 'type' => 'input',
                 'eval' => 'trim',
-            ],
-        ],
-        'related_uid' => [
-            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.uid',
-            'config' => [
-                'type' => 'number',
             ],
         ],
         'is_read' => [
@@ -72,29 +66,17 @@ use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
                 'default' => 0,
             ],
         ],
+        'is_archived' => [
+            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_common.xlf:label.archived',
+            'config' => [
+                'type' => 'check',
+                'default' => 0,
+            ],
+        ],
         'created_at' => [
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.creationDate',
             'config' => [
                 'type' => 'datetime',
-            ],
-        ],
-        'valid_until' => [
-            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.endtime',
-            'config' => [
-                'type' => 'datetime',
-            ],
-        ],
-        'priority' => [
-            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:notification.priority',
-            'config' => [
-                'type' => 'select',
-                'items' => [
-                    ['Low', 'low'],
-                    ['Normal', 'normal'],
-                    ['High', 'high'],
-                    ['Urgent', 'urgent'],
-                ],
-                'default' => 'normal',
             ],
         ],
         'uuid' => [
@@ -112,39 +94,25 @@ use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
                 'default' => 'en',
             ],
         ],
-        'send_email' => [
-            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:notification.send_email',
-            'config' => [
-                'type' => 'check',
-                'default' => 0,
-            ],
-        ],
-        'send_push' => [
-            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:notification.send_push',
-            'config' => [
-                'type' => 'check',
-                'default' => 0,
-            ],
-        ],
-        'channel' => [
-            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:notification.channel',
-            'config' => [
-                'type' => 'select',
-                'items' => [
-                    ['In-App', 'in-app'],
-                    ['Email', 'email'],
-                    ['App Push', 'app'],
-                    ['SMS', 'sms'],
-                ],
-                'default' => 'in-app',
-            ],
-        ],
-        'sender' => [
-            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:notification.sender',
+        'title_key' => [
+            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:notification.title_key',
             'config' => [
                 'type' => 'input',
                 'eval' => 'trim',
-                'default' => 'system',
+            ],
+        ],
+        'custom_message' => [
+            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.message',
+            'config' => [
+                'type' => 'text',
+                'rows' => 4,
+                'cols' => 60,
+            ],
+        ],
+        'updated_at' => [
+            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.updated',
+            'config' => [
+                'type' => 'datetime',
             ],
         ],
     ]);
@@ -152,8 +120,8 @@ use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
     ExtensionManagementUtility::addToAllTCAtypes(
         'tx_equedlms_domain_model_notification',
         '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,
-        recipient, type, title, message, payload, related_model, related_uid,
-        is_read, created_at, valid_until, priority, uuid, language,
-        send_email, send_push, channel, sender'
+        recipient, course_instance, submission, user_course_record, type, status,
+        is_read, is_archived, created_at, updated_at, uuid, language,
+        title_key, custom_message'
     );
 })();

--- a/equed-lms/Configuration/TCA/tx_equedlms_domain_model_notification.php
+++ b/equed-lms/Configuration/TCA/tx_equedlms_domain_model_notification.php
@@ -19,47 +19,41 @@ return [
                 'eval' => 'int'
             ]
         ],
-        'type' => [
+        'course_instance' => [
             'exclude' => true,
-            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_notification.type',
+            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_notification.course_instance',
             'config' => [
                 'type' => 'input',
                 'eval' => 'int'
             ]
         ],
-        'title' => [
+        'submission' => [
             'exclude' => true,
-            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_notification.title',
+            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_notification.submission',
+            'config' => [
+                'type' => 'input',
+                'eval' => 'int'
+            ]
+        ],
+        'user_course_record' => [
+            'exclude' => true,
+            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_notification.user_course_record',
+            'config' => [
+                'type' => 'input',
+                'eval' => 'int'
+            ]
+        ],
+        'type' => [
+            'exclude' => true,
+            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_notification.type',
             'config' => [
                 'type' => 'input',
                 'eval' => 'trim'
             ]
         ],
-        'message' => [
+        'status' => [
             'exclude' => true,
-            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_notification.message',
-            'config' => [
-                'type' => 'text'
-            ]
-        ],
-        'payload' => [
-            'exclude' => true,
-            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_notification.payload',
-            'config' => [
-                'type' => 'text'
-            ]
-        ],
-        'related_model' => [
-            'exclude' => true,
-            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_notification.related_model',
-            'config' => [
-                'type' => 'input',
-                'eval' => 'trim'
-            ]
-        ],
-        'related_uid' => [
-            'exclude' => true,
-            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_notification.related_uid',
+            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_notification.status',
             'config' => [
                 'type' => 'input',
                 'eval' => 'trim'
@@ -72,28 +66,19 @@ return [
                 'type' => 'check'
             ]
         ],
+        'is_archived' => [
+            'exclude' => true,
+            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_notification.is_archived',
+            'config' => [
+                'type' => 'check'
+            ]
+        ],
         'created_at' => [
             'exclude' => true,
             'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_notification.created_at',
             'config' => [
                 'type' => 'input',
                 'eval' => 'trim'
-            ]
-        ],
-        'valid_until' => [
-            'exclude' => true,
-            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_notification.valid_until',
-            'config' => [
-                'type' => 'input',
-                'eval' => 'trim'
-            ]
-        ],
-        'priority' => [
-            'exclude' => true,
-            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_notification.priority',
-            'config' => [
-                'type' => 'input',
-                'eval' => 'int'
             ]
         ],
         'uuid' => [
@@ -112,31 +97,24 @@ return [
                 'eval' => 'trim'
             ]
         ],
-        'send_email' => [
+        'title_key' => [
             'exclude' => true,
-            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_notification.send_email',
-            'config' => [
-                'type' => 'check'
-            ]
-        ],
-        'send_push' => [
-            'exclude' => true,
-            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_notification.send_push',
-            'config' => [
-                'type' => 'check'
-            ]
-        ],
-        'channel' => [
-            'exclude' => true,
-            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_notification.channel',
+            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_notification.title_key',
             'config' => [
                 'type' => 'input',
-                'eval' => 'int'
+                'eval' => 'trim'
             ]
         ],
-        'sender' => [
+        'custom_message' => [
             'exclude' => true,
-            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_notification.sender',
+            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_notification.custom_message',
+            'config' => [
+                'type' => 'text'
+            ]
+        ],
+        'updated_at' => [
+            'exclude' => true,
+            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_notification.updated_at',
             'config' => [
                 'type' => 'input',
                 'eval' => 'trim'
@@ -145,10 +123,10 @@ return [
     ],
     'types' => [
         1 => [
-            'showitem' => 'recipient, type, title, message, payload, related_model, related_uid, is_read, created_at, valid_until, priority, uuid, language, send_email, send_push, channel, sender'
+            'showitem' => 'recipient, course_instance, submission, user_course_record, type, status, is_read, is_archived, language, title_key, custom_message, created_at, updated_at, uuid'
         ]
     ],
     'interface' => [
-        'showRecordFieldList' => 'recipient,type,title,message,payload,related_model,related_uid,is_read,created_at,valid_until,priority,uuid,language,send_email,send_push,channel,sender'
+        'showRecordFieldList' => 'recipient,course_instance,submission,user_course_record,type,status,is_read,is_archived,language,title_key,custom_message,created_at,updated_at,uuid'
     ]
 ];


### PR DESCRIPTION
## Summary
- update notification database schema
- update TYPO3 TCA configuration
- adjust repository queries
- adapt certificate notification listener
- show notification title and message on dashboard

## Testing
- `composer --working-dir=equed-lms test` *(fails: Cannot open vendor autoload)*

------
https://chatgpt.com/codex/tasks/task_e_684bbead46d08324978640ff3e4db135