### PR TITLE
Use integer timestamps

### DIFF
--- a/equed-lms/Configuration/Schema/Domain/Model/Coursebookingrequest.yaml
+++ b/equed-lms/Configuration/Schema/Domain/Model/Coursebookingrequest.yaml
@@ -13,7 +13,7 @@ columns:
   preferred_instructor:
     type: integer
   preferred_date:
-    type: string
+    type: integer
   comments:
     type: text
   status:
@@ -21,8 +21,8 @@ columns:
   assigned_instance:
     type: integer
   created_at:
-    type: string
+    type: integer
   updated_at:
-    type: string
+    type: integer
   uuid:
     type: string

--- a/equed-lms/Configuration/Schema/Domain/Model/Coursebundle.yaml
+++ b/equed-lms/Configuration/Schema/Domain/Model/Coursebundle.yaml
@@ -33,6 +33,6 @@ columns:
   uuid:
     type: string
   created_at:
-    type: string
+    type: integer
   updated_at:
-    type: string
+    type: integer

--- a/equed-lms/Configuration/Schema/Domain/Model/Coursegoal.yaml
+++ b/equed-lms/Configuration/Schema/Domain/Model/Coursegoal.yaml
@@ -39,9 +39,9 @@ columns:
   uuid:
     type: string
   created_at:
-    type: string
+    type: integer
   updated_at:
-    type: string
+    type: integer
   title_key:
     type: string
   description_key:

--- a/equed-lms/Configuration/Schema/Domain/Model/Eventbooking.yaml
+++ b/equed-lms/Configuration/Schema/Domain/Model/Eventbooking.yaml
@@ -15,7 +15,7 @@ columns:
   confirmed_by_instructor:
     type: boolean
   confirmation_datetime:
-    type: string
+    type: integer
   cancelled_reason:
     type: text
   language:
@@ -23,6 +23,6 @@ columns:
   uuid:
     type: string
   created_at:
-    type: string
+    type: integer
   updated_at:
-    type: string
+    type: integer

--- a/equed-lms/Configuration/Schema/Domain/Model/Eventschedule.yaml
+++ b/equed-lms/Configuration/Schema/Domain/Model/Eventschedule.yaml
@@ -11,9 +11,9 @@ columns:
   course_instance:
     type: integer
   start_datetime:
-    type: string
+    type: integer
   end_datetime:
-    type: string
+    type: integer
   event_type:
     type: integer
   location:
@@ -29,9 +29,9 @@ columns:
   uuid:
     type: string
   created_at:
-    type: string
+    type: integer
   updated_at:
-    type: string
+    type: integer
   title_key:
     type: string
   description_key:

--- a/equed-lms/Configuration/Schema/Domain/Model/Examattempt.yaml
+++ b/equed-lms/Configuration/Schema/Domain/Model/Examattempt.yaml
@@ -11,7 +11,7 @@ columns:
   exam_type:
     type: integer
   exam_date:
-    type: string
+    type: integer
   status:
     type: integer
   is_passed:
@@ -33,7 +33,7 @@ columns:
   linked_quiz:
     type: integer
   reviewed_at:
-    type: string
+    type: integer
   allow_retake:
     type: boolean
   retake_reason:

--- a/equed-lms/Configuration/Schema/Domain/Model/Externalsystemsync.yaml
+++ b/equed-lms/Configuration/Schema/Domain/Model/Externalsystemsync.yaml
@@ -15,7 +15,7 @@ columns:
   sync_scope:
     type: text
   last_synced_at:
-    type: string
+    type: integer
   sync_status:
     type: integer
   is_active:
@@ -25,6 +25,6 @@ columns:
   uuid:
     type: string
   created_at:
-    type: string
+    type: integer
   updated_at:
-    type: string
+    type: integer

--- a/equed-lms/Configuration/Schema/Domain/Model/Feedbackentry.yaml
+++ b/equed-lms/Configuration/Schema/Domain/Model/Feedbackentry.yaml
@@ -25,7 +25,7 @@ columns:
   eligible_future_courses:
     type: text
   created_at:
-    type: string
+    type: integer
   uuid:
     type: string
   updated_at:

--- a/equed-lms/Configuration/Schema/Domain/Model/Instructoravailabilityregion.yaml
+++ b/equed-lms/Configuration/Schema/Domain/Model/Instructoravailabilityregion.yaml
@@ -21,6 +21,6 @@ columns:
   uuid:
     type: string
   created_at:
-    type: string
+    type: integer
   updated_at:
-    type: string
+    type: integer

--- a/equed-lms/Configuration/Schema/Domain/Model/Instructoreligibility.yaml
+++ b/equed-lms/Configuration/Schema/Domain/Model/Instructoreligibility.yaml
@@ -19,14 +19,14 @@ columns:
   is_active:
     type: boolean
   approved_at:
-    type: string
+    type: integer
   expires_at:
-    type: string
+    type: integer
   note:
     type: text
   uuid:
     type: string
   created_at:
-    type: string
+    type: integer
   updated_at:
-    type: string
+    type: integer

--- a/equed-lms/Configuration/Schema/Domain/Model/Lessonattempt.yaml
+++ b/equed-lms/Configuration/Schema/Domain/Model/Lessonattempt.yaml
@@ -19,9 +19,9 @@ columns:
   passed:
     type: boolean
   start_time:
-    type: string
+    type: integer
   end_time:
-    type: string
+    type: integer
   duration_sec:
     type: string
   attempt_status:

--- a/equed-lms/Configuration/Schema/Domain/Model/Notification.yaml
+++ b/equed-lms/Configuration/Schema/Domain/Model/Notification.yaml
@@ -21,7 +21,7 @@ columns:
   is_archived:
     type: boolean
   created_at:
-    type: string
+    type: integer
   uuid:
     type: string
   language:
@@ -31,4 +31,4 @@ columns:
   custom_message:
     type: text
   updated_at:
-    type: string
+    type: integer

--- a/equed-lms/Configuration/Schema/Domain/Model/Paymentlog.yaml
+++ b/equed-lms/Configuration/Schema/Domain/Model/Paymentlog.yaml
@@ -17,6 +17,6 @@ columns:
   uuid:
     type: string
   created_at:
-    type: string
+    type: integer
   updated_at:
-    type: string
+    type: integer

--- a/equed-lms/Configuration/Schema/Domain/Model/Practicetest.yaml
+++ b/equed-lms/Configuration/Schema/Domain/Model/Practicetest.yaml
@@ -27,9 +27,9 @@ columns:
   uuid:
     type: string
   created_at:
-    type: string
+    type: integer
   updated_at:
-    type: string
+    type: integer
   title_key:
     type: string
   description_key:

--- a/equed-lms/Configuration/Schema/Domain/Model/Recognitionaward.yaml
+++ b/equed-lms/Configuration/Schema/Domain/Model/Recognitionaward.yaml
@@ -27,9 +27,9 @@ columns:
   uuid:
     type: string
   created_at:
-    type: string
+    type: integer
   updated_at:
-    type: string
+    type: integer
   title_key:
     type: string
   description_key:

--- a/equed-lms/Configuration/Schema/Domain/Model/Searchlog.yaml
+++ b/equed-lms/Configuration/Schema/Domain/Model/Searchlog.yaml
@@ -19,7 +19,7 @@ columns:
   referer:
     type: string
   timestamp:
-    type: string
+    type: integer
   uuid:
     type: string
   created_at:

--- a/equed-lms/Configuration/Schema/Domain/Model/Systemsettings.yaml
+++ b/equed-lms/Configuration/Schema/Domain/Model/Systemsettings.yaml
@@ -21,8 +21,8 @@ columns:
   uuid:
     type: string
   created_at:
-    type: string
+    type: integer
   updated_at:
-    type: string
+    type: integer
   description_key:
     type: string

--- a/equed-lms/Configuration/Schema/Domain/Model/Userprogressrecord.yaml
+++ b/equed-lms/Configuration/Schema/Domain/Model/Userprogressrecord.yaml
@@ -31,6 +31,6 @@ columns:
   uuid:
     type: string
   created_at:
-    type: string
+    type: integer
   updated_at:
-    type: string
+    type: integer

--- a/equed-lms/Migrations/Version20250801006000.php
+++ b/equed-lms/Migrations/Version20250801006000.php
@@ -33,8 +33,8 @@ final class Version20250801006000 extends AbstractMigration
         $table->addColumn('image', 'integer');
         $table->addColumn('recommended_after', 'integer');
         $table->addColumn('uuid', 'string');
-        $table->addColumn('created_at', 'string');
-        $table->addColumn('updated_at', 'string');
+        $table->addColumn('created_at', 'integer');
+        $table->addColumn('updated_at', 'integer');
         $table->setPrimaryKey(['uid']);
 
         $mm = $schema->createTable('tx_equedlms_coursebundle_courseprogram_mm');


### PR DESCRIPTION
## Summary
- use integer timestamps for event and log tables
- adjust course bundle migration to use integer timestamps

## Testing
- `composer lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bc1b282508324bb5294732399df96