### PR TITLE
Rename lesson progress user column

### DIFF
--- a/equed-lms/Configuration/Schema/Domain/Model/Lessonprogress.yaml
+++ b/equed-lms/Configuration/Schema/Domain/Model/Lessonprogress.yaml
@@ -18,7 +18,7 @@ columns:
     type: integer
   lesson:
     type: integer
-  user:
+  fe_user:
     type: integer
   progress:
     type: integer

--- a/equed-lms/Configuration/TCA/tx_equedlms_domain_model_lessonprogress.php
+++ b/equed-lms/Configuration/TCA/tx_equedlms_domain_model_lessonprogress.php
@@ -31,7 +31,7 @@ return [
             'l10n_diffsource',
             'hidden',
             'lesson',
-            'user',
+            'fe_user',
             'progress',
             'status',
             'uuid',
@@ -111,9 +111,9 @@ return [
                 'maxitems'      => 1,
             ],
         ],
-        'user' => [
+        'fe_user' => [
             'exclude' => false,
-            'label'   => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_lessonprogress.user',
+            'label'   => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_lessonprogress.fe_user',
             'config'  => [
                 'type'          => 'select',
                 'renderType'    => 'selectSingle',
@@ -175,7 +175,7 @@ return [
         '1' => [
             'showitem' => '
                 sys_language_uid, l10n_parent, l10n_diffsource,
-                hidden, lesson, user, progress, status, uuid, created_at, updated_at, completed,
+                hidden, lesson, fe_user, progress, status, uuid, created_at, updated_at, completed,
                 --div--;LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:tabs.access,
                   starttime, endtime
             ',

--- a/equed-lms/Migrations/Version20250801014000.php
+++ b/equed-lms/Migrations/Version20250801014000.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250801014000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Rename user column to fe_user in lesson progress table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        if ($schema->hasTable('tx_equedlms_domain_model_lessonprogress')) {
+            $table = $schema->getTable('tx_equedlms_domain_model_lessonprogress');
+            if ($table->hasColumn('user') && !$table->hasColumn('fe_user')) {
+                $table->renameColumn('user', 'fe_user');
+            }
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        if ($schema->hasTable('tx_equedlms_domain_model_lessonprogress')) {
+            $table = $schema->getTable('tx_equedlms_domain_model_lessonprogress');
+            if ($table->hasColumn('fe_user') && !$table->hasColumn('user')) {
+                $table->renameColumn('fe_user', 'user');
+            }
+        }
+    }
+}

--- a/equed-lms/Resources/Private/Language/locallang_db.de.xlf
+++ b/equed-lms/Resources/Private/Language/locallang_db.de.xlf
@@ -411,7 +411,7 @@
 
       <trans-unit id="tx_equedlms_domain_model_lessonprogress.lesson">
         <source>Lesson</source><target></target></trans-unit>
-      <trans-unit id="tx_equedlms_domain_model_lessonprogress.user">
+      <trans-unit id="tx_equedlms_domain_model_lessonprogress.fe_user">
         <source>User</source><target></target></trans-unit>
       <trans-unit id="tx_equedlms_domain_model_lessonprogress.progress">
         <source>Progress</source><target></target></trans-unit>

--- a/equed-lms/Resources/Private/Language/locallang_db.easy.xlf
+++ b/equed-lms/Resources/Private/Language/locallang_db.easy.xlf
@@ -376,7 +376,7 @@
 
       <trans-unit id="tx_equedlms_domain_model_lessonprogress.lesson">
         <source>Lesson</source><target></target></trans-unit>
-      <trans-unit id="tx_equedlms_domain_model_lessonprogress.user">
+      <trans-unit id="tx_equedlms_domain_model_lessonprogress.fe_user">
         <source>User</source><target></target></trans-unit>
       <trans-unit id="tx_equedlms_domain_model_lessonprogress.progress">
         <source>Progress</source><target></target></trans-unit>

--- a/equed-lms/Resources/Private/Language/locallang_db.en.xlf
+++ b/equed-lms/Resources/Private/Language/locallang_db.en.xlf
@@ -145,7 +145,7 @@
       <trans-unit id="tx_equedlms_domain_model_lessonprogress.lesson">
         <source>Lesson</source>
       </trans-unit>
-      <trans-unit id="tx_equedlms_domain_model_lessonprogress.user">
+      <trans-unit id="tx_equedlms_domain_model_lessonprogress.fe_user">
         <source>User</source>
       </trans-unit>
       <trans-unit id="tx_equedlms_domain_model_lessonprogress.progress">

--- a/equed-lms/Resources/Private/Language/locallang_db.es.xlf
+++ b/equed-lms/Resources/Private/Language/locallang_db.es.xlf
@@ -390,7 +390,7 @@
 
       <trans-unit id="tx_equedlms_domain_model_lessonprogress.lesson">
         <source>Lesson</source><target></target></trans-unit>
-      <trans-unit id="tx_equedlms_domain_model_lessonprogress.user">
+      <trans-unit id="tx_equedlms_domain_model_lessonprogress.fe_user">
         <source>User</source><target></target></trans-unit>
       <trans-unit id="tx_equedlms_domain_model_lessonprogress.progress">
         <source>Progress</source><target></target></trans-unit>

--- a/equed-lms/Resources/Private/Language/locallang_db.fr.xlf
+++ b/equed-lms/Resources/Private/Language/locallang_db.fr.xlf
@@ -390,7 +390,7 @@
 
       <trans-unit id="tx_equedlms_domain_model_lessonprogress.lesson">
         <source>Lesson</source><target></target></trans-unit>
-      <trans-unit id="tx_equedlms_domain_model_lessonprogress.user">
+      <trans-unit id="tx_equedlms_domain_model_lessonprogress.fe_user">
         <source>User</source><target></target></trans-unit>
       <trans-unit id="tx_equedlms_domain_model_lessonprogress.progress">
         <source>Progress</source><target></target></trans-unit>

--- a/equed-lms/Resources/Private/Language/locallang_db.sw.xlf
+++ b/equed-lms/Resources/Private/Language/locallang_db.sw.xlf
@@ -390,7 +390,7 @@
 
       <trans-unit id="tx_equedlms_domain_model_lessonprogress.lesson">
         <source>Lesson</source><target></target></trans-unit>
-      <trans-unit id="tx_equedlms_domain_model_lessonprogress.user">
+      <trans-unit id="tx_equedlms_domain_model_lessonprogress.fe_user">
         <source>User</source><target></target></trans-unit>
       <trans-unit id="tx_equedlms_domain_model_lessonprogress.progress">
         <source>Progress</source><target></target></trans-unit>


### PR DESCRIPTION
## Summary
- rename `user` column to `fe_user` in Doctrine schema
- update TCA field definitions to use `fe_user`
- adjust language labels for the new field name
- add migration to rename the database column

## Testing
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bc48c02d083249200095ee3433af9