### PR TITLE
Rename user column and fix integer fields

### DIFF
--- a/equed-lms/Configuration/Schema/Domain/Model/Certificate.yaml
+++ b/equed-lms/Configuration/Schema/Domain/Model/Certificate.yaml
@@ -4,7 +4,7 @@ columns:
     type: integer
   pid:
     type: integer
-  user:
+  fe_user:
     type: integer
   courseprogram:
     type: integer

--- a/equed-lms/Configuration/Schema/Domain/Model/Eventbooking.yaml
+++ b/equed-lms/Configuration/Schema/Domain/Model/Eventbooking.yaml
@@ -4,7 +4,7 @@ columns:
     type: integer
   pid:
     type: integer
-  user:
+  fe_user:
     type: integer
   event_schedule:
     type: integer

--- a/equed-lms/Configuration/Schema/Domain/Model/Examattempt.yaml
+++ b/equed-lms/Configuration/Schema/Domain/Model/Examattempt.yaml
@@ -4,7 +4,7 @@ columns:
     type: integer
   pid:
     type: integer
-  user:
+  fe_user:
     type: integer
   course_instance:
     type: integer

--- a/equed-lms/Configuration/Schema/Domain/Model/Feedbackentry.yaml
+++ b/equed-lms/Configuration/Schema/Domain/Model/Feedbackentry.yaml
@@ -6,7 +6,7 @@ columns:
     type: integer
   course_instance:
     type: integer
-  user:
+  fe_user:
     type: integer
   instructor_feedback:
     type: boolean

--- a/equed-lms/Configuration/Schema/Domain/Model/Paymentlog.yaml
+++ b/equed-lms/Configuration/Schema/Domain/Model/Paymentlog.yaml
@@ -4,7 +4,7 @@ columns:
     type: integer
   pid:
     type: integer
-  user:
+  fe_user:
     type: integer
   amount:
     type: string

--- a/equed-lms/Configuration/Schema/Domain/Model/Submission.yaml
+++ b/equed-lms/Configuration/Schema/Domain/Model/Submission.yaml
@@ -10,7 +10,7 @@ columns:
     type: text
   file:
     type: string
-  user:
+  fe_user:
     type: integer
   lesson:
     type: integer

--- a/equed-lms/Configuration/Schema/Domain/Model/Userbadge.yaml
+++ b/equed-lms/Configuration/Schema/Domain/Model/Userbadge.yaml
@@ -4,7 +4,7 @@ columns:
     type: integer
   pid:
     type: integer
-  user:
+  fe_user:
     type: integer
   badge_type:
     type: integer
@@ -13,7 +13,7 @@ columns:
   description:
     type: text
   awarded_at:
-    type: string
+    type: integer
   issuer:
     type: integer
   is_public:
@@ -27,7 +27,7 @@ columns:
   badge_level:
     type: integer
   expires_at:
-    type: string
+    type: integer
   renewal_required:
     type: boolean
   uuid:

--- a/equed-lms/Configuration/Schema/Domain/Model/Usercourserecord.yaml
+++ b/equed-lms/Configuration/Schema/Domain/Model/Usercourserecord.yaml
@@ -25,7 +25,7 @@ columns:
   status:
     type: integer
   progress_percent:
-    type: string
+    type: integer
   last_activity:
     type: integer
   certifier:

--- a/equed-lms/Configuration/Schema/Domain/Model/Userprofile.yaml
+++ b/equed-lms/Configuration/Schema/Domain/Model/Userprofile.yaml
@@ -6,7 +6,7 @@ columns:
     type: integer
   uuid:
     type: string
-  user:
+  fe_user:
     type: integer
   docu_level:
     type: string

--- a/equed-lms/Configuration/Schema/Domain/Model/Userprogressrecord.yaml
+++ b/equed-lms/Configuration/Schema/Domain/Model/Userprogressrecord.yaml
@@ -4,7 +4,7 @@ columns:
     type: integer
   pid:
     type: integer
-  user:
+  fe_user:
     type: integer
   course_instance:
     type: integer
@@ -15,15 +15,15 @@ columns:
   completed:
     type: boolean
   completed_at:
-    type: string
+    type: integer
   progress_percent:
-    type: string
+    type: integer
   last_accessed_at:
-    type: string
+    type: integer
   attempt_count:
-    type: string
+    type: integer
   time_spent_seconds:
-    type: string
+    type: integer
   feedback_submitted:
     type: boolean
   notes:


### PR DESCRIPTION
## Summary
- rename `user:` to `fe_user:` in schema definitions
- make time and progress fields integers

## Testing
- `composer install --no-interaction --no-progress` *(fails: ext-gd missing but installed and retested; install works)*
- `composer test` *(fails: fatal error from duplicate interface)*

------
https://chatgpt.com/codex/tasks/task_e_684bcbcd0b44832480e5bcfd9dfc9332