### PR TITLE
Update PracticeTest schema

### DIFF
--- a/equed-lms/Configuration/Schema/Domain/Model/Practicetest.yaml
+++ b/equed-lms/Configuration/Schema/Domain/Model/Practicetest.yaml
@@ -4,33 +4,25 @@ columns:
     type: integer
   pid:
     type: integer
+  uuid:
+    type: string
   title:
     type: string
   description:
     type: text
   course_program:
     type: integer
-  lesson:
+  gpt_evaluation_enabled:
+    type: boolean
+  evaluation_scheme:
+    type: text
+  expected_file_types:
+    type: string
+  visible_from:
     type: integer
-  is_active:
-    type: boolean
-  is_mandatory_for_progress:
-    type: boolean
-  estimated_duration:
-    type: string
-  shuffle_questions:
-    type: boolean
-  max_attempts:
-    type: string
-  language:
-    type: string
-  uuid:
-    type: string
+  visible_until:
+    type: integer
   created_at:
     type: integer
   updated_at:
     type: integer
-  title_key:
-    type: string
-  description_key:
-    type: string

--- a/equed-lms/Configuration/TCA/Overrides/tx_equedlms_domain_model_practicetest.php
+++ b/equed-lms/Configuration/TCA/Overrides/tx_equedlms_domain_model_practicetest.php
@@ -29,54 +29,41 @@ use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
                 'renderType' => 'selectSingle',
             ],
         ],
-        'lesson' => [
-            'label' => 'Related Lesson (optional)',
-            'config' => [
-                'type' => 'select',
-                'foreign_table' => 'tx_equedlms_domain_model_lesson',
-                'renderType' => 'selectSingle',
-            ],
-        ],
-        'is_active' => [
-            'label' => 'Active',
-            'config' => [
-                'type' => 'check',
-                'default' => 1,
-            ],
-        ],
-        'is_mandatory_for_progress' => [
-            'label' => 'Affects Progress Tracking',
+        'gpt_evaluation_enabled' => [
+            'label' => 'GPT Evaluation Enabled',
             'config' => [
                 'type' => 'check',
                 'default' => 0,
             ],
         ],
-        'estimated_duration' => [
-            'label' => 'Estimated Duration (minutes)',
+        'evaluation_scheme' => [
+            'label' => 'Evaluation Scheme',
             'config' => [
-                'type' => 'number',
+                'type' => 'text',
+                'rows' => 4,
             ],
         ],
-        'shuffle_questions' => [
-            'label' => 'Shuffle Questions',
-            'config' => [
-                'type' => 'check',
-                'default' => 1,
-            ],
-        ],
-        'max_attempts' => [
-            'label' => 'Max Attempts (0 = unlimited)',
-            'config' => [
-                'type' => 'number',
-                'default' => 0,
-            ],
-        ],
-        'language' => [
-            'label' => 'Language',
+        'expected_file_types' => [
+            'label' => 'Expected File Types',
             'config' => [
                 'type' => 'input',
                 'eval' => 'trim',
-                'default' => 'en',
+            ],
+        ],
+        'visible_from' => [
+            'label' => 'Visible From',
+            'config' => [
+                'type' => 'input',
+                'renderType' => 'inputDateTime',
+                'eval' => 'datetime',
+            ],
+        ],
+        'visible_until' => [
+            'label' => 'Visible Until',
+            'config' => [
+                'type' => 'input',
+                'renderType' => 'inputDateTime',
+                'eval' => 'datetime',
             ],
         ],
         'uuid' => [
@@ -103,8 +90,7 @@ use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
     ExtensionManagementUtility::addToAllTCAtypes(
         'tx_equedlms_domain_model_practicetest',
         '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,
-        title, description, course_program, lesson, is_active, is_mandatory_for_progress,
-        estimated_duration, shuffle_questions, max_attempts,
-        language, uuid, created_at, updated_at'
+        title, description, course_program, gpt_evaluation_enabled, evaluation_scheme, expected_file_types,
+        visible_from, visible_until, uuid, created_at, updated_at'
     );
 })();

--- a/equed-lms/Configuration/TCA/tx_equedlms_domain_model_practicetest.php
+++ b/equed-lms/Configuration/TCA/tx_equedlms_domain_model_practicetest.php
@@ -34,57 +34,42 @@ return [
                 'eval' => 'int'
             ]
         ],
-        'lesson' => [
+        'gpt_evaluation_enabled' => [
             'exclude' => true,
-            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_practicetest.lesson',
+            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_practicetest.gpt_evaluation_enabled',
+            'config' => [
+                'type' => 'check'
+            ]
+        ],
+        'evaluation_scheme' => [
+            'exclude' => true,
+            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_practicetest.evaluation_scheme',
+            'config' => [
+                'type' => 'text'
+            ]
+        ],
+        'expected_file_types' => [
+            'exclude' => true,
+            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_practicetest.expected_file_types',
+            'config' => [
+                'type' => 'input',
+                'eval' => 'trim'
+            ]
+        ],
+        'visible_from' => [
+            'exclude' => true,
+            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_practicetest.visible_from',
             'config' => [
                 'type' => 'input',
                 'eval' => 'int'
             ]
         ],
-        'is_active' => [
+        'visible_until' => [
             'exclude' => true,
-            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_practicetest.is_active',
-            'config' => [
-                'type' => 'check'
-            ]
-        ],
-        'is_mandatory_for_progress' => [
-            'exclude' => true,
-            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_practicetest.is_mandatory_for_progress',
-            'config' => [
-                'type' => 'check'
-            ]
-        ],
-        'estimated_duration' => [
-            'exclude' => true,
-            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_practicetest.estimated_duration',
+            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_practicetest.visible_until',
             'config' => [
                 'type' => 'input',
-                'eval' => 'trim'
-            ]
-        ],
-        'shuffle_questions' => [
-            'exclude' => true,
-            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_practicetest.shuffle_questions',
-            'config' => [
-                'type' => 'check'
-            ]
-        ],
-        'max_attempts' => [
-            'exclude' => true,
-            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_practicetest.max_attempts',
-            'config' => [
-                'type' => 'input',
-                'eval' => 'trim'
-            ]
-        ],
-        'language' => [
-            'exclude' => true,
-            'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_practicetest.language',
-            'config' => [
-                'type' => 'input',
-                'eval' => 'trim'
+                'eval' => 'int'
             ]
         ],
         'uuid' => [
@@ -114,10 +99,10 @@ return [
     ],
     'types' => [
         1 => [
-            'showitem' => 'title, description, course_program, lesson, is_active, is_mandatory_for_progress, estimated_duration, shuffle_questions, max_attempts, language, uuid, created_at, updated_at'
+            'showitem' => 'title, description, course_program, gpt_evaluation_enabled, evaluation_scheme, expected_file_types, visible_from, visible_until, uuid, created_at, updated_at'
         ]
     ],
     'interface' => [
-        'showRecordFieldList' => 'title,description,course_program,lesson,is_active,is_mandatory_for_progress,estimated_duration,shuffle_questions,max_attempts,language,uuid,created_at,updated_at'
+        'showRecordFieldList' => 'title,description,course_program,gpt_evaluation_enabled,evaluation_scheme,expected_file_types,visible_from,visible_until,uuid,created_at,updated_at'
     ]
 ];

--- a/equed-lms/Migrations/Version20250801015000.php
+++ b/equed-lms/Migrations/Version20250801015000.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250801015000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Update practice test table structure';
+    }
+
+    public function up(Schema $schema): void
+    {
+        if ($schema->hasTable('tx_equedlms_domain_model_practicetest')) {
+            $table = $schema->getTable('tx_equedlms_domain_model_practicetest');
+            foreach (['lesson', 'is_active', 'is_mandatory_for_progress', 'estimated_duration', 'shuffle_questions', 'max_attempts', 'language', 'title_key', 'description_key'] as $obsolete) {
+                if ($table->hasColumn($obsolete)) {
+                    $table->dropColumn($obsolete);
+                }
+            }
+            if (!$table->hasColumn('gpt_evaluation_enabled')) {
+                $table->addColumn('gpt_evaluation_enabled', 'boolean');
+            }
+            if (!$table->hasColumn('evaluation_scheme')) {
+                $table->addColumn('evaluation_scheme', 'text', ['notnull' => false]);
+            }
+            if (!$table->hasColumn('expected_file_types')) {
+                $table->addColumn('expected_file_types', 'string', ['notnull' => false]);
+            }
+            if (!$table->hasColumn('visible_from')) {
+                $table->addColumn('visible_from', 'integer', ['notnull' => false]);
+            }
+            if (!$table->hasColumn('visible_until')) {
+                $table->addColumn('visible_until', 'integer', ['notnull' => false]);
+            }
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        if ($schema->hasTable('tx_equedlms_domain_model_practicetest')) {
+            $table = $schema->getTable('tx_equedlms_domain_model_practicetest');
+            foreach (['gpt_evaluation_enabled', 'evaluation_scheme', 'expected_file_types', 'visible_from', 'visible_until'] as $new) {
+                if ($table->hasColumn($new)) {
+                    $table->dropColumn($new);
+                }
+            }
+            if (!$table->hasColumn('lesson')) {
+                $table->addColumn('lesson', 'integer', ['notnull' => false]);
+            }
+            if (!$table->hasColumn('is_active')) {
+                $table->addColumn('is_active', 'boolean');
+            }
+            if (!$table->hasColumn('is_mandatory_for_progress')) {
+                $table->addColumn('is_mandatory_for_progress', 'boolean');
+            }
+            if (!$table->hasColumn('estimated_duration')) {
+                $table->addColumn('estimated_duration', 'string', ['notnull' => false]);
+            }
+            if (!$table->hasColumn('shuffle_questions')) {
+                $table->addColumn('shuffle_questions', 'boolean');
+            }
+            if (!$table->hasColumn('max_attempts')) {
+                $table->addColumn('max_attempts', 'string', ['notnull' => false]);
+            }
+            if (!$table->hasColumn('language')) {
+                $table->addColumn('language', 'string', ['notnull' => false]);
+            }
+            if (!$table->hasColumn('title_key')) {
+                $table->addColumn('title_key', 'string', ['notnull' => false]);
+            }
+            if (!$table->hasColumn('description_key')) {
+                $table->addColumn('description_key', 'string', ['notnull' => false]);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- clean up practice test table definition
- update TCA configuration
- adjust TCA overrides for new fields
- add migration to drop old columns and add new ones

## Testing
- `composer phpstan` *(fails: error in Doctrine repo)*
- `composer test` *(fails: fatal error in DocumentUploadRepository)*

------
https://chatgpt.com/codex/tasks/task_e_684bcda463788324aa497bdf9e9bb52e