### PR TITLE
Remove obsolete description_key from Systemsettings

### DIFF
--- a/equed-lms/Configuration/Schema/Domain/Model/Systemsettings.yaml
+++ b/equed-lms/Configuration/Schema/Domain/Model/Systemsettings.yaml
@@ -24,5 +24,3 @@ columns:
     type: integer
   updated_at:
     type: integer
-  description_key:
-    type: string


### PR DESCRIPTION
## Summary
- remove unused `description_key` column from Systemsettings schema
- confirm remaining columns match SystemSettings class

## Testing
- `composer install` *(fails: missing PHP DOM extension)*

------
https://chatgpt.com/codex/tasks/task_e_684be2093b80832496ee3cc9ead4bbd4