### PR TITLE
Fix date fields to use integer timestamps

### DIFF
--- a/equed-lms/Configuration/Schema/Domain/Model/Instructorfeedback.yaml
+++ b/equed-lms/Configuration/Schema/Domain/Model/Instructorfeedback.yaml
@@ -29,7 +29,7 @@ columns:
   attachment:
     type: integer
   submitted_at:
-    type: string
+    type: integer
   visible_to_user:
     type: boolean
   qms_flagged:

--- a/equed-lms/Configuration/Schema/Domain/Model/Quizresult.yaml
+++ b/equed-lms/Configuration/Schema/Domain/Model/Quizresult.yaml
@@ -17,7 +17,7 @@ columns:
   mode:
     type: integer
   submitted_at:
-    type: string
+    type: integer
   lang:
     type: string
   uuid:

--- a/equed-lms/Configuration/Schema/Domain/Model/Trainingrecord.yaml
+++ b/equed-lms/Configuration/Schema/Domain/Model/Trainingrecord.yaml
@@ -15,7 +15,7 @@ columns:
   duration_hours:
     type: string
   date:
-    type: string
+    type: integer
   proof_document:
     type: integer
   is_validated:
@@ -33,7 +33,7 @@ columns:
   certificate_number:
     type: string
   certificate_issued_at:
-    type: string
+    type: integer
   gpt_evaluation_data:
     type: text
   feedback_received:

--- a/equed-lms/Migrations/Version20250801016000.php
+++ b/equed-lms/Migrations/Version20250801016000.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250801016000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Store instructor feedback and quiz timestamps as UNIX integers';
+    }
+
+    public function up(Schema $schema): void
+    {
+        if ($schema->hasTable('tx_equedlms_domain_model_instructorfeedback')) {
+            $table = $schema->getTable('tx_equedlms_domain_model_instructorfeedback');
+            if ($table->hasColumn('submitted_at')) {
+                $table->changeColumn('submitted_at', ['type' => 'integer']);
+            }
+        }
+
+        if ($schema->hasTable('tx_equedlms_domain_model_quizresult')) {
+            $table = $schema->getTable('tx_equedlms_domain_model_quizresult');
+            if ($table->hasColumn('submitted_at')) {
+                $table->changeColumn('submitted_at', ['type' => 'integer']);
+            }
+        }
+
+        if ($schema->hasTable('tx_equedlms_domain_model_trainingrecord')) {
+            $table = $schema->getTable('tx_equedlms_domain_model_trainingrecord');
+            if ($table->hasColumn('certificate_issued_at')) {
+                $table->changeColumn('certificate_issued_at', ['type' => 'integer']);
+            }
+            if ($table->hasColumn('date')) {
+                $table->changeColumn('date', ['type' => 'integer']);
+            }
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        if ($schema->hasTable('tx_equedlms_domain_model_instructorfeedback')) {
+            $table = $schema->getTable('tx_equedlms_domain_model_instructorfeedback');
+            if ($table->hasColumn('submitted_at')) {
+                $table->changeColumn('submitted_at', ['type' => 'string']);
+            }
+        }
+
+        if ($schema->hasTable('tx_equedlms_domain_model_quizresult')) {
+            $table = $schema->getTable('tx_equedlms_domain_model_quizresult');
+            if ($table->hasColumn('submitted_at')) {
+                $table->changeColumn('submitted_at', ['type' => 'string']);
+            }
+        }
+
+        if ($schema->hasTable('tx_equedlms_domain_model_trainingrecord')) {
+            $table = $schema->getTable('tx_equedlms_domain_model_trainingrecord');
+            if ($table->hasColumn('certificate_issued_at')) {
+                $table->changeColumn('certificate_issued_at', ['type' => 'string']);
+            }
+            if ($table->hasColumn('date')) {
+                $table->changeColumn('date', ['type' => 'string']);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- use integer timestamps for submitted_at and certificate date fields
- migrate the database columns accordingly

## Testing
- `composer phpstan` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bfec3c1508324a2411f5b02f4e35d