### PR TITLE
Add LanguageService interface and alias

### DIFF
--- a/equed-lms/Classes/Domain/Service/LanguageServiceInterface.php
+++ b/equed-lms/Classes/Domain/Service/LanguageServiceInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Domain\Service;
+
+/**
+ * Interface for language translation services.
+ */
+interface LanguageServiceInterface
+{
+    /**
+     * Translate a localization key with optional placeholders.
+     */
+    public function translate(string $key, array $arguments = [], ?string $extension = null): string;
+}

--- a/equed-lms/Classes/Service/LanguageService.php
+++ b/equed-lms/Classes/Service/LanguageService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Equed\EquedLms\Service;
 
+use Equed\EquedLms\Domain\Service\LanguageServiceInterface;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
@@ -11,7 +12,7 @@ use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
  * Service for translating labels via GPT-based translation service
  * with fallback to TYPO3 core localization.
  */
-final class LanguageService
+final class LanguageService implements LanguageServiceInterface
 {
     private GptTranslationServiceInterface $gptTranslationService;
     private string $extensionKey;

--- a/equed-lms/Classes/ViewHelpers/BadgeLabelViewHelper.php
+++ b/equed-lms/Classes/ViewHelpers/BadgeLabelViewHelper.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Equed\EquedLms\ViewHelpers;
 
-use Equed\EquedLms\Service\LanguageServiceInterface;
+use Equed\EquedLms\Domain\Service\LanguageServiceInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**

--- a/equed-lms/Classes/ViewHelpers/BadgeViewHelper.php
+++ b/equed-lms/Classes/ViewHelpers/BadgeViewHelper.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Equed\EquedLms\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use Equed\EquedLms\Service\LanguageServiceInterface;
+use Equed\EquedLms\Domain\Service\LanguageServiceInterface;
 
 /**
  * ViewHelper to render a localized badge label based on its identifier.

--- a/equed-lms/Configuration/Services/Services.yaml
+++ b/equed-lms/Configuration/Services/Services.yaml
@@ -61,6 +61,9 @@ services:
   Equed\EquedLms\Domain\Service\DocumentServiceInterface:
     class: Equed\EquedLms\Service\DocumentService
 
+  Equed\EquedLms\Domain\Service\LanguageServiceInterface:
+    class: Equed\EquedLms\Service\LanguageService
+
   Equed\EquedLms\Domain\Service\ClockInterface:
     class: Equed\EquedLms\Service\SystemClock
   Equed\EquedLms\Domain\Repository\CourseInstanceRepositoryInterface:


### PR DESCRIPTION
## Summary
- introduce `LanguageServiceInterface`
- implement the interface in `LanguageService`
- adapt view helpers to use new namespace
- register alias in service configuration

## Testing
- `composer lint`
- `composer phpstan` *(fails: Invalid escaping sequence)*
- `composer test` *(fails: missing php extensions)*

------
https://chatgpt.com/codex/tasks/task_e_684c1e0b6ae8832480b7e5d6cbb23a3b