### PR TITLE
Use LanguageService for translations

### DIFF
--- a/equed-lms/Classes/Service/NotificationService.php
+++ b/equed-lms/Classes/Service/NotificationService.php
@@ -5,24 +5,22 @@ declare(strict_types=1);
 namespace Equed\EquedLms\Service;
 
 use Equed\EquedLms\Service\MailServiceInterface;
-use Equed\EquedLms\Service\GptTranslationServiceInterface;
+use Equed\EquedLms\Domain\Service\LanguageServiceInterface;
 use Equed\EquedLms\Domain\Repository\NotificationRepositoryInterface;
 use Equed\EquedLms\Domain\Repository\FrontendUserRepositoryInterface;
 use Equed\EquedLms\Domain\Model\FrontendUser;
 use Equed\EquedLms\Domain\Service\NotificationServiceInterface;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
-use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
 /**
  * Handles sending notifications via email or push.
  */
 final class NotificationService implements NotificationServiceInterface
 {
-    private const EXTENSION_KEY = 'equed_lms';
 
     public function __construct(
         private readonly MailServiceInterface $mailService,
-        private readonly GptTranslationServiceInterface $translationService,
+        private readonly LanguageServiceInterface $languageService,
         private readonly NotificationRepositoryInterface $notificationRepository,
         private readonly FrontendUserRepositoryInterface $frontendUserRepository,
         private readonly PersistenceManagerInterface $persistenceManager
@@ -31,22 +29,22 @@ final class NotificationService implements NotificationServiceInterface
 
     public function notifyCertifier(string $email, string $courseTitle): void
     {
-        $subject = $this->translate('notification.certifier.subject', ['course' => $courseTitle]);
-        $body = $this->translate('notification.certifier.body', ['course' => $courseTitle]);
+        $subject = $this->languageService->translate('notification.certifier.subject', ['course' => $courseTitle]);
+        $body = $this->languageService->translate('notification.certifier.body', ['course' => $courseTitle]);
         $this->mailService->sendMail($email, $subject, $body);
     }
 
     public function notifyInstructorOfSubmission(string $email, string $submissionId): void
     {
-        $subject = $this->translate('notification.instructor.subject', ['submission' => $submissionId]);
-        $body = $this->translate('notification.instructor.body', ['submission' => $submissionId]);
+        $subject = $this->languageService->translate('notification.instructor.subject', ['submission' => $submissionId]);
+        $body = $this->languageService->translate('notification.instructor.body', ['submission' => $submissionId]);
         $this->mailService->sendMail($email, $subject, $body);
     }
 
     public function notifyUserCertificateReady(string $email, string $certificateNumber): void
     {
-        $subject = $this->translate('notification.user.subject', ['certificate' => $certificateNumber]);
-        $body = $this->translate('notification.user.body', ['certificate' => $certificateNumber]);
+        $subject = $this->languageService->translate('notification.user.subject', ['certificate' => $certificateNumber]);
+        $body = $this->languageService->translate('notification.user.body', ['certificate' => $certificateNumber]);
         $this->mailService->sendMail($email, $subject, $body);
     }
 
@@ -57,8 +55,8 @@ final class NotificationService implements NotificationServiceInterface
             return;
         }
 
-        $subject = $this->translate('notification.course_completed.subject', ['course' => $courseInstanceId]);
-        $body    = $this->translate('notification.course_completed.body', ['course' => $courseInstanceId]);
+        $subject = $this->languageService->translate('notification.course_completed.subject', ['course' => $courseInstanceId]);
+        $body    = $this->languageService->translate('notification.course_completed.body', ['course' => $courseInstanceId]);
 
         $this->mailService->sendMail($email, $subject, $body);
     }
@@ -70,8 +68,8 @@ final class NotificationService implements NotificationServiceInterface
             return;
         }
 
-        $subject = $this->translate('notification.certificate_issued.subject');
-        $body    = $this->translate('notification.certificate_issued.body', ['url' => $qrCodeUrl]);
+        $subject = $this->languageService->translate('notification.certificate_issued.subject');
+        $body    = $this->languageService->translate('notification.certificate_issued.body', ['url' => $qrCodeUrl]);
 
         $this->mailService->sendMail($email, $subject, $body);
     }
@@ -104,16 +102,4 @@ final class NotificationService implements NotificationServiceInterface
         $this->persistenceManager->persistAll();
     }
 
-    private function translate(string $key, array $arguments = []): string
-    {
-        $translated = $this->translationService->isEnabled()
-            ? $this->translationService->translate($key, $arguments, self::EXTENSION_KEY)
-            : null;
-
-        if ($translated !== null && $translated !== $key) {
-            return $translated;
-        }
-
-        return LocalizationUtility::translate($key, self::EXTENSION_KEY, $arguments) ?? $key;
-    }
 }

--- a/equed-lms/Classes/Service/ProgressCalculationService.php
+++ b/equed-lms/Classes/Service/ProgressCalculationService.php
@@ -7,21 +7,19 @@ namespace Equed\EquedLms\Service;
 use Equed\EquedLms\Domain\Repository\CourseInstanceRepositoryInterface;
 use Equed\EquedLms\Domain\Repository\UserCourseRecordRepositoryInterface;
 use Psr\Cache\CacheItemPoolInterface;
-use Equed\EquedLms\Service\GptTranslationServiceInterface;
-use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
+use Equed\EquedLms\Domain\Service\LanguageServiceInterface;
 
 /**
  * Service for calculating user progress in courses.
  */
 final class ProgressCalculationService
 {
-    private const EXTENSION_KEY = 'equed_lms';
 
     public function __construct(
         private readonly CourseInstanceRepositoryInterface $courseInstanceRepository,
         private readonly UserCourseRecordRepositoryInterface $userCourseRecordRepository,
         private readonly CacheItemPoolInterface $cachePool,
-        private readonly GptTranslationServiceInterface $translationService
+        private readonly LanguageServiceInterface $languageService
     ) {
     }
 
@@ -78,18 +76,7 @@ final class ProgressCalculationService
             default => 'progress.notStarted',
         };
 
-        return $this->translate($key, ['progress' => (int)round($progress)]);
+        return $this->languageService->translate($key, ['progress' => (int)round($progress)]);
     }
 
-    private function translate(string $key, array $arguments = []): string
-    {
-        if ($this->translationService->isEnabled()) {
-            $translated = $this->translationService->translate($key, $arguments, self::EXTENSION_KEY);
-            if ($translated !== null && $translated !== $key) {
-                return $translated;
-            }
-        }
-
-        return LocalizationUtility::translate($key, self::EXTENSION_KEY, $arguments) ?? $key;
-    }
 }

--- a/equed-lms/Classes/Service/ProgressTrackingService.php
+++ b/equed-lms/Classes/Service/ProgressTrackingService.php
@@ -11,7 +11,7 @@ use Equed\EquedLms\Domain\Repository\CourseInstanceRepositoryInterface;
 use Equed\EquedLms\Domain\Repository\UserCourseRecordRepositoryInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
-use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
+use Equed\EquedLms\Domain\Service\LanguageServiceInterface;
 
 /**
  * Service for tracking and persisting user course progress.
@@ -23,8 +23,7 @@ final class ProgressTrackingService
         private readonly CourseInstanceRepositoryInterface $courseInstanceRepository,
         private readonly PersistenceManagerInterface $persistenceManager,
         private readonly CacheItemPoolInterface $cachePool,
-        private readonly GptTranslationServiceInterface $translationService,
-        private readonly string $extensionKey = 'equed_lms'
+        private readonly LanguageServiceInterface $languageService
     ) {
     }
 
@@ -115,13 +114,7 @@ final class ProgressTrackingService
     public function getStatusLabel(string $statusCode): string
     {
         $key = sprintf('status.%s', $statusCode);
-        if ($this->translationService->isEnabled()) {
-            $translated = $this->translationService->translate($key, [], $this->extensionKey);
-            if ($translated !== null && $translated !== $key) {
-                return $translated;
-            }
-        }
 
-        return LocalizationUtility::translate($key, $this->extensionKey) ?? $statusCode;
+        return $this->languageService->translate($key);
     }
 }

--- a/equed-lms/Classes/Service/RecognitionAwardService.php
+++ b/equed-lms/Classes/Service/RecognitionAwardService.php
@@ -8,22 +8,20 @@ use Equed\EquedLms\Domain\Model\UserBadge;
 use Equed\EquedLms\Domain\Repository\UserBadgeRepositoryInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
-use Equed\EquedLms\Service\GptTranslationServiceInterface;
+use Equed\EquedLms\Domain\Service\LanguageServiceInterface;
 use Equed\EquedLms\Domain\Service\ClockInterface;
-use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
 /**
  * Service for recognizing and awarding badges to users.
  */
 final class RecognitionAwardService
 {
-    private const EXTENSION_KEY = 'equed_lms';
 
     public function __construct(
         private readonly UserBadgeRepositoryInterface $userBadgeRepository,
         private readonly PersistenceManagerInterface $persistenceManager,
         private readonly CacheItemPoolInterface $cachePool,
-        private readonly GptTranslationServiceInterface $translationService,
+        private readonly LanguageServiceInterface $languageService,
         private readonly ClockInterface $clock
     ) {
     }
@@ -55,7 +53,7 @@ final class RecognitionAwardService
         $badge = new UserBadge();
         $badge->setFeUserId($userId);
         $badge->setType($type);
-        $badge->setTitle($this->translate("badge.{$type}.title"));
+        $badge->setTitle($this->languageService->translate("badge.{$type}.title"));
         $badge->setAwardedAt($this->clock->now());
 
         $this->userBadgeRepository->add($badge);
@@ -65,15 +63,4 @@ final class RecognitionAwardService
         return $badge;
     }
 
-    private function translate(string $key, array $arguments = []): string
-    {
-        if ($this->translationService->isEnabled()) {
-            $translated = $this->translationService->translate($key, $arguments, self::EXTENSION_KEY);
-            if ($translated !== null && $translated !== $key) {
-                return $translated;
-            }
-        }
-
-        return LocalizationUtility::translate($key, self::EXTENSION_KEY, $arguments) ?? $key;
-    }
 }

--- a/equed-lms/Tests/Unit/Service/ProgressTrackingServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/ProgressTrackingServiceTest.php
@@ -9,7 +9,7 @@ use Equed\EquedLms\Domain\Model\UserCourseRecord;
 use Equed\EquedLms\Domain\Repository\CourseInstanceRepositoryInterface;
 use Equed\EquedLms\Domain\Repository\UserCourseRecordRepositoryInterface;
 use Equed\EquedLms\Enum\UserCourseStatus;
-use Equed\EquedLms\Service\GptTranslationServiceInterface;
+use Equed\EquedLms\Domain\Service\LanguageServiceInterface;
 use Equed\EquedLms\Service\ProgressTrackingService;
 use Equed\EquedLms\Tests\Traits\ProphecyTrait;
 use PHPUnit\Framework\TestCase;
@@ -25,7 +25,7 @@ class ProgressTrackingServiceTest extends TestCase
     private $instanceRepo;
     private $persistence;
     private $cache;
-    private $translation;
+    private $language;
 
     protected function setUp(): void
     {
@@ -33,14 +33,14 @@ class ProgressTrackingServiceTest extends TestCase
         $this->instanceRepo = $this->prophesize(CourseInstanceRepositoryInterface::class);
         $this->persistence  = $this->prophesize(PersistenceManagerInterface::class);
         $this->cache        = $this->prophesize(CacheItemPoolInterface::class);
-        $this->translation  = $this->prophesize(GptTranslationServiceInterface::class);
+        $this->language     = $this->prophesize(LanguageServiceInterface::class);
 
         $this->subject = new ProgressTrackingService(
             $this->recordRepo->reveal(),
             $this->instanceRepo->reveal(),
             $this->persistence->reveal(),
             $this->cache->reveal(),
-            $this->translation->reveal()
+            $this->language->reveal()
         );
     }
 
@@ -61,8 +61,7 @@ class ProgressTrackingServiceTest extends TestCase
 
     public function testGetStatusLabelUsesTranslator(): void
     {
-        $this->translation->isEnabled()->willReturn(true);
-        $this->translation->translate('status.completed', [], 'equed_lms')->willReturn('fertig');
+        $this->language->translate('status.completed')->willReturn('fertig');
 
         $this->assertSame('fertig', $this->subject->getStatusLabel('completed'));
     }

--- a/equed-lms/Tests/Unit/Service/RecognitionAwardServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/RecognitionAwardServiceTest.php
@@ -6,7 +6,7 @@ namespace Equed\EquedLms\Tests\Unit\Service;
 
 use Equed\EquedLms\Domain\Model\UserBadge;
 use Equed\EquedLms\Domain\Repository\UserBadgeRepositoryInterface;
-use Equed\EquedLms\Service\GptTranslationServiceInterface;
+use Equed\EquedLms\Domain\Service\LanguageServiceInterface;
 use Equed\EquedLms\Service\RecognitionAwardService;
 use Equed\EquedLms\Tests\Traits\ProphecyTrait;
 use PHPUnit\Framework\TestCase;
@@ -23,7 +23,7 @@ class RecognitionAwardServiceTest extends TestCase
     private $repo;
     private $persistence;
     private $cache;
-    private $translation;
+    private $language;
     private $clock;
 
     protected function setUp(): void
@@ -31,14 +31,14 @@ class RecognitionAwardServiceTest extends TestCase
         $this->repo = $this->prophesize(UserBadgeRepositoryInterface::class);
         $this->persistence = $this->prophesize(PersistenceManagerInterface::class);
         $this->cache = $this->prophesize(CacheItemPoolInterface::class);
-        $this->translation = $this->prophesize(GptTranslationServiceInterface::class);
+        $this->language = $this->prophesize(LanguageServiceInterface::class);
         $this->clock = $this->prophesize(ClockInterface::class);
 
         $this->subject = new RecognitionAwardService(
             $this->repo->reveal(),
             $this->persistence->reveal(),
             $this->cache->reveal(),
-            $this->translation->reveal(),
+            $this->language->reveal(),
             $this->clock->reveal()
         );
     }
@@ -57,7 +57,7 @@ class RecognitionAwardServiceTest extends TestCase
     public function testAssignRecognitionBadgeCreatesNewBadge(): void
     {
         $this->repo->findByUserAndType(7, 'foo')->willReturn(null);
-        $this->translation->isEnabled()->willReturn(false);
+        $this->language->translate(\Prophecy\Argument::any(), \Prophecy\Argument::cetera())->willReturn('');
         $this->repo->add(\Prophecy\Argument::type(UserBadge::class))->shouldBeCalled();
         $this->persistence->persistAll()->shouldBeCalled();
         $this->cache->deleteItem('qualifyAdvanced_7')->shouldBeCalled();


### PR DESCRIPTION
## Summary
- inject `LanguageServiceInterface` into several services
- remove custom translate helpers
- update calls to use the language service
- adjust unit tests to mock the language service

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_684c21474b8483249b7b48a4930f345e