### PR TITLE
Add unit tests for LMS services

### DIFF
--- a/equed-lms/Tests/Unit/Service/DocumentServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/DocumentServiceTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Tests\Unit\Service;
+
+use Equed\EquedLms\Service\DocumentService;
+use Equed\EquedLms\Exception\InvalidFileTypeException;
+use PHPUnit\Framework\TestCase;
+
+final class DocumentServiceTest extends TestCase
+{
+    public function testGenerateDownloadLinkWithAllowedExtension(): void
+    {
+        $service = new DocumentService('https://files.example.com', 'https://tpl.example.com');
+        $result = $service->generateDownloadLink('invoice.pdf');
+        $this->assertSame('https://files.example.com/invoice.pdf', $result);
+    }
+
+    public function testGenerateDownloadLinkThrowsOnInvalidExtension(): void
+    {
+        $this->expectException(InvalidFileTypeException::class);
+        $service = new DocumentService('https://files.example.com', 'https://tpl.example.com');
+        $service->generateDownloadLink('malware.exe');
+    }
+
+    public function testGetTemplatePathSanitizesName(): void
+    {
+        $service = new DocumentService('https://files.example.com', 'https://tpl.example.com');
+        $result = $service->getTemplatePath('Danger 123!');
+        $this->assertSame('https://tpl.example.com/Danger123.pdf', $result);
+    }
+}

--- a/equed-lms/Tests/Unit/Service/NotificationServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/NotificationServiceTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TYPO3\CMS\Extbase\Domain\Model {
+    if (!class_exists(FrontendUser::class)) {
+        class FrontendUser {
+            private string $email;
+            public function __construct(string $email = '') { $this->email = $email; }
+            public function getEmail(): string { return $this->email; }
+        }
+    }
+}
+
+namespace Equed\EquedLms\Tests\Unit\Service;
+
+use Equed\EquedLms\Service\NotificationService;
+use Equed\EquedLms\Service\MailServiceInterface;
+use Equed\EquedLms\Domain\Service\LanguageServiceInterface;
+use Equed\EquedLms\Domain\Repository\NotificationRepositoryInterface;
+use Equed\EquedLms\Domain\Repository\FrontendUserRepositoryInterface;
+use PHPUnit\Framework\TestCase;
+use Equed\EquedLms\Tests\Traits\ProphecyTrait;
+use TYPO3\CMS\Extbase\Domain\Model\FrontendUser;
+use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
+
+if (!interface_exists(PersistenceManagerInterface::class)) {
+    interface PersistenceManagerInterface { public function persistAll(); }
+}
+
+final class NotificationServiceTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private NotificationService $subject;
+    private $mail;
+    private $language;
+
+    protected function setUp(): void
+    {
+        $this->mail = $this->prophesize(MailServiceInterface::class);
+        $this->language = $this->prophesize(LanguageServiceInterface::class);
+        $repo = $this->prophesize(NotificationRepositoryInterface::class);
+        $userRepo = $this->prophesize(FrontendUserRepositoryInterface::class);
+        $pm = $this->prophesize(PersistenceManagerInterface::class);
+
+        $this->subject = new NotificationService(
+            $this->mail->reveal(),
+            $this->language->reveal(),
+            $repo->reveal(),
+            $userRepo->reveal(),
+            $pm->reveal(),
+        );
+    }
+
+    public function testNotifyCertifierSendsTranslatedMail(): void
+    {
+        $this->language->translate('notification.certifier.subject', ['course' => 'Basics'])
+            ->willReturn('subj');
+        $this->language->translate('notification.certifier.body', ['course' => 'Basics'])
+            ->willReturn('body');
+        $this->mail->sendMail('cert@example.com', 'subj', 'body')->shouldBeCalled();
+
+        $this->subject->notifyCertifier('cert@example.com', 'Basics');
+    }
+
+    public function testSendCourseCompletedNoticeSkipsWhenNoEmail(): void
+    {
+        $user = new FrontendUser('');
+        $this->mail->sendMail(\Prophecy\Argument::cetera())->shouldNotBeCalled();
+        $this->subject->sendCourseCompletedNotice($user, 1);
+    }
+
+    public function testSendCertificateIssuedInfoUsesTranslations(): void
+    {
+        $user = new FrontendUser('john@example.com');
+        $this->language->translate('notification.certificate_issued.subject')
+            ->willReturn('sub');
+        $this->language->translate('notification.certificate_issued.body', ['url' => 'http://qrcode'])
+            ->willReturn('bod');
+        $this->mail->sendMail('john@example.com', 'sub', 'bod')->shouldBeCalled();
+
+        $this->subject->sendCertificateIssuedInfo($user, 'http://qrcode');
+    }
+}

--- a/equed-lms/Tests/Unit/Service/QmsServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/QmsServiceTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Domain\Model {
+    class QmsCase {
+        private bool $escalated = false;
+        public function setEscalated(bool $flag): void { $this->escalated = $flag; }
+        public function isEscalated(): bool { return $this->escalated; }
+    }
+}
+
+namespace Equed\EquedLms\Domain\Repository {
+    interface QmsCaseRepositoryInterface {
+        public function findOpenCases(): array;
+        public function findByInstructor(int $id): array;
+        public function findByUid(int $id): ?\Equed\EquedLms\Domain\Model\QmsCase;
+        public function update(\Equed\EquedLms\Domain\Model\QmsCase $case): void;
+    }
+}
+
+namespace TYPO3\CMS\Extbase\Persistence {
+    if (!interface_exists(PersistenceManagerInterface::class)) {
+        interface PersistenceManagerInterface { public function persistAll(); }
+    }
+}
+
+namespace Equed\EquedLms\Tests\Unit\Service;
+
+use Equed\EquedLms\Service\QmsService;
+use PHPUnit\Framework\TestCase;
+use Equed\EquedLms\Tests\Traits\ProphecyTrait;
+use Equed\EquedLms\Domain\Repository\QmsCaseRepositoryInterface;
+use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
+use Equed\EquedLms\Domain\Model\QmsCase;
+
+final class QmsServiceTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private QmsService $subject;
+    private $repo;
+    private $pm;
+
+    protected function setUp(): void
+    {
+        $this->repo = $this->prophesize(QmsCaseRepositoryInterface::class);
+        $this->pm = $this->prophesize(PersistenceManagerInterface::class);
+        $this->subject = new QmsService($this->repo->reveal(), $this->pm->reveal());
+    }
+
+    public function testGetOpenCasesDelegatesToRepository(): void
+    {
+        $cases = [new QmsCase()];
+        $this->repo->findOpenCases()->willReturn($cases);
+        $this->assertSame($cases, $this->subject->getOpenCases());
+    }
+
+    public function testGetCasesByInstructorDelegatesToRepository(): void
+    {
+        $cases = [new QmsCase()];
+        $this->repo->findByInstructor(5)->willReturn($cases);
+        $this->assertSame($cases, $this->subject->getCasesByInstructor(5));
+    }
+
+    public function testEscalateCaseUpdatesRecord(): void
+    {
+        $case = new QmsCase();
+        $this->repo->findByUid(2)->willReturn($case);
+        $this->repo->update($case)->shouldBeCalled();
+        $this->pm->persistAll()->shouldBeCalled();
+
+        $result = $this->subject->escalateCase(2);
+        $this->assertTrue($result);
+        $this->assertTrue($case->isEscalated());
+    }
+
+    public function testEscalateCaseReturnsFalseWhenNotFound(): void
+    {
+        $this->repo->findByUid(9)->willReturn(null);
+        $this->pm->persistAll()->shouldNotBeCalled();
+        $this->repo->update(\Prophecy\Argument::any())->shouldNotBeCalled();
+
+        $this->assertFalse($this->subject->escalateCase(9));
+    }
+}

--- a/equed-lms/phpunit.xml.dist
+++ b/equed-lms/phpunit.xml.dist
@@ -20,9 +20,12 @@
             <file>./Tests/Unit/Service/CourseAccessServiceTest.php</file>
             <file>./Tests/Unit/Service/ProgressTrackingServiceTest.php</file>
             <file>./Tests/Unit/Service/RecognitionAwardServiceTest.php</file>
-            <file>./Tests/Unit/Service/QmsEscalationServiceTest.php</file>
-            <file>./Tests/Unit/Service/SubmissionSyncServiceTest.php</file>
-            <file>./Tests/Unit/Service/UserProgressSyncServiceTest.php</file>
+        <file>./Tests/Unit/Service/QmsEscalationServiceTest.php</file>
+        <file>./Tests/Unit/Service/SubmissionSyncServiceTest.php</file>
+        <file>./Tests/Unit/Service/UserProgressSyncServiceTest.php</file>
+        <file>./Tests/Unit/Service/DocumentServiceTest.php</file>
+        <file>./Tests/Unit/Service/NotificationServiceTest.php</file>
+        <file>./Tests/Unit/Service/QmsServiceTest.php</file>
         </testsuite>
         <testsuite name="functional">
             <directory>./Tests/Functional/</directory>


### PR DESCRIPTION
## Summary
- add missing tests for DocumentService, NotificationService and QmsService
- register new tests in phpunit configuration

## Testing
- `phpunit -c equed-lms/phpunit.xml.dist --colors=never` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c331fd5588324acb2c804cf1693e6