### PR TITLE
Refactor ProgressTrackingService record creation

### DIFF
--- a/equed-lms/Classes/Factory/DefaultFrontendUserFactory.php
+++ b/equed-lms/Classes/Factory/DefaultFrontendUserFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Factory;
+
+use Equed\EquedLms\Domain\Model\FrontendUser;
+
+final class DefaultFrontendUserFactory implements FrontendUserFactoryInterface
+{
+    public function createWithUid(int $uid): FrontendUser
+    {
+        $user = new FrontendUser();
+        $user->_setProperty('uid', $uid);
+
+        return $user;
+    }
+}

--- a/equed-lms/Classes/Factory/DefaultUserCourseRecordFactory.php
+++ b/equed-lms/Classes/Factory/DefaultUserCourseRecordFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Factory;
+
+use Equed\EquedLms\Domain\Model\CourseInstance;
+use Equed\EquedLms\Domain\Model\UserCourseRecord;
+
+final class DefaultUserCourseRecordFactory implements UserCourseRecordFactoryInterface
+{
+    public function __construct(private readonly FrontendUserFactoryInterface $frontendUserFactory)
+    {
+    }
+
+    public function createForUserAndInstance(int $userId, CourseInstance $instance): UserCourseRecord
+    {
+        $record = new UserCourseRecord();
+        $record->setUser($this->frontendUserFactory->createWithUid($userId));
+        $record->setCourseInstance($instance);
+
+        return $record;
+    }
+}

--- a/equed-lms/Classes/Factory/FrontendUserFactoryInterface.php
+++ b/equed-lms/Classes/Factory/FrontendUserFactoryInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Factory;
+
+use Equed\EquedLms\Domain\Model\FrontendUser;
+
+interface FrontendUserFactoryInterface
+{
+    public function createWithUid(int $uid): FrontendUser;
+}

--- a/equed-lms/Classes/Factory/UserCourseRecordFactoryInterface.php
+++ b/equed-lms/Classes/Factory/UserCourseRecordFactoryInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Factory;
+
+use Equed\EquedLms\Domain\Model\CourseInstance;
+use Equed\EquedLms\Domain\Model\UserCourseRecord;
+
+interface UserCourseRecordFactoryInterface
+{
+    public function createForUserAndInstance(int $userId, CourseInstance $instance): UserCourseRecord;
+}

--- a/equed-lms/Classes/Service/ProgressTrackingService.php
+++ b/equed-lms/Classes/Service/ProgressTrackingService.php
@@ -6,7 +6,7 @@ namespace Equed\EquedLms\Service;
 
 use Equed\EquedLms\Domain\Model\CourseInstance;
 use Equed\EquedLms\Domain\Model\UserCourseRecord;
-use Equed\EquedLms\Domain\Model\FrontendUser;
+use Equed\EquedLms\Factory\UserCourseRecordFactoryInterface;
 use Equed\EquedLms\Domain\Repository\CourseInstanceRepositoryInterface;
 use Equed\EquedLms\Domain\Repository\UserCourseRecordRepositoryInterface;
 use Psr\Cache\CacheItemPoolInterface;
@@ -23,7 +23,8 @@ final class ProgressTrackingService
         private readonly CourseInstanceRepositoryInterface $courseInstanceRepository,
         private readonly PersistenceManagerInterface $persistenceManager,
         private readonly CacheItemPoolInterface $cachePool,
-        private readonly LanguageServiceInterface $languageService
+        private readonly LanguageServiceInterface $languageService,
+        private readonly UserCourseRecordFactoryInterface $recordFactory
     ) {
     }
 
@@ -67,12 +68,7 @@ final class ProgressTrackingService
      */
     private function createUserCourseRecord(int $userId, CourseInstance $instance): UserCourseRecord
     {
-        $record = new UserCourseRecord();
-        $user = new \Equed\EquedLms\Domain\Model\FrontendUser();
-        $user->_setProperty('uid', $userId);
-        $record->setUser($user);
-        $record->setCourseInstance($instance);
-
+        $record = $this->recordFactory->createForUserAndInstance($userId, $instance);
         $this->recordRepository->add($record);
 
         return $record;

--- a/equed-lms/Configuration/Services/Services.yaml
+++ b/equed-lms/Configuration/Services/Services.yaml
@@ -87,6 +87,12 @@ services:
   Equed\EquedLms\Domain\Repository\SubmissionRepositoryInterface:
     class: Equed\EquedLms\Domain\Repository\SubmissionRepository
 
+  Equed\EquedLms\Factory\FrontendUserFactoryInterface:
+    class: Equed\EquedLms\Factory\DefaultFrontendUserFactory
+
+  Equed\EquedLms\Factory\UserCourseRecordFactoryInterface:
+    class: Equed\EquedLms\Factory\DefaultUserCourseRecordFactory
+
   Equed\EquedLms\Domain\Service\JwtServiceInterface:
     class: Equed\EquedLms\Service\JwtService
 

--- a/equed-lms/Tests/Unit/Service/ProgressTrackingServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/ProgressTrackingServiceTest.php
@@ -8,6 +8,7 @@ use Equed\EquedLms\Domain\Model\CourseInstance;
 use Equed\EquedLms\Domain\Model\UserCourseRecord;
 use Equed\EquedLms\Domain\Repository\CourseInstanceRepositoryInterface;
 use Equed\EquedLms\Domain\Repository\UserCourseRecordRepositoryInterface;
+use Equed\EquedLms\Factory\UserCourseRecordFactoryInterface;
 use Equed\EquedLms\Enum\UserCourseStatus;
 use Equed\EquedLms\Domain\Service\LanguageServiceInterface;
 use Equed\EquedLms\Service\ProgressTrackingService;
@@ -26,6 +27,7 @@ class ProgressTrackingServiceTest extends TestCase
     private $persistence;
     private $cache;
     private $language;
+    private $recordFactory;
 
     protected function setUp(): void
     {
@@ -34,22 +36,28 @@ class ProgressTrackingServiceTest extends TestCase
         $this->persistence  = $this->prophesize(PersistenceManagerInterface::class);
         $this->cache        = $this->prophesize(CacheItemPoolInterface::class);
         $this->language     = $this->prophesize(LanguageServiceInterface::class);
+        $this->recordFactory = $this->prophesize(UserCourseRecordFactoryInterface::class);
 
         $this->subject = new ProgressTrackingService(
             $this->recordRepo->reveal(),
             $this->instanceRepo->reveal(),
             $this->persistence->reveal(),
             $this->cache->reveal(),
-            $this->language->reveal()
+            $this->language->reveal(),
+            $this->recordFactory->reveal()
         );
     }
 
     public function testTrackProgressCreatesRecord(): void
     {
         $instance = new CourseInstance();
+        $record   = new UserCourseRecord();
+        $record->setCourseInstance($instance);
+
         $this->instanceRepo->findByUid(7)->willReturn($instance);
         $this->recordRepo->findOneByUserAndCourseInstance(5, 7)->willReturn(null);
-        $this->recordRepo->add(\Prophecy\Argument::type(UserCourseRecord::class))->shouldBeCalled();
+        $this->recordFactory->createForUserAndInstance(5, $instance)->willReturn($record);
+        $this->recordRepo->add($record)->shouldBeCalled();
         $this->recordRepo->update(\Prophecy\Argument::type(UserCourseRecord::class))->shouldBeCalled();
         $this->persistence->persistAll()->shouldBeCalled();
         $this->cache->deleteItem('progress_5_7')->shouldBeCalled();


### PR DESCRIPTION
## Summary
- add small factories for creating `FrontendUser` and `UserCourseRecord`
- wire up factories via DI configuration
- use new factory in `ProgressTrackingService`
- update unit tests for new dependency

## Testing
- `composer --working-dir=equed-lms test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c34b4efe48324ad271258338a6864