### PR TITLE
Switch QmsReminder task to new MailService API

### DIFF
--- a/equed-lms/Classes/Service/Email/MailService.php
+++ b/equed-lms/Classes/Service/Email/MailService.php
@@ -84,6 +84,26 @@ final class MailService implements MailServiceInterface
     }
 
     /**
+     * Send a reminder about an open QMS case.
+     */
+    public function sendQmsReminder(string $recipientEmail, string $caseId): void
+    {
+        $subject = $this->t(
+            'email.qms_reminder.subject',
+            ['caseId' => $caseId],
+            'Reminder: QMS case #{caseId} is still open'
+        );
+        $body = $this->t(
+            'email.qms_reminder.body',
+            ['caseId' => $caseId],
+            'Please review the open QMS case #{caseId}.'
+        );
+
+        $mail = $this->prepareMail($recipientEmail, $subject, $body);
+        $this->deliverMail($mail);
+    }
+
+    /**
      * Send a generic email with optional attachment.
      *
      * @param string[]    $recipients

--- a/equed-lms/Classes/Service/MailServiceInterface.php
+++ b/equed-lms/Classes/Service/MailServiceInterface.php
@@ -15,6 +15,8 @@ interface MailServiceInterface
 
     public function sendQmsNotification(string $recipientEmail, string $caseId): void;
 
+    public function sendQmsReminder(string $recipientEmail, string $caseId): void;
+
     /**
      * @param string[]    $recipients
      * @param string      $subject

--- a/equed-lms/Classes/Task/QmsReminderTask.php
+++ b/equed-lms/Classes/Task/QmsReminderTask.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Equed\EquedLms\Task;
 
-use Equed\EquedLms\Service\Email\MailServiceInterface;
+use Equed\EquedLms\Service\MailServiceInterface;
 use Equed\EquedLms\Service\QmsServiceInterface;
 use TYPO3\CMS\Scheduler\Task\AbstractTask;
 


### PR DESCRIPTION
## Summary
- use the global `MailServiceInterface` in the Qms reminder task
- add a dedicated `sendQmsReminder` method to the mail service interface
- implement QMS reminder email sending

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c373ef39483248be178f3eccf2cef