### PR TITLE
Introduce ProgressStatus enum

### DIFF
--- a/equed-lms/Classes/Enum/ProgressStatus.php
+++ b/equed-lms/Classes/Enum/ProgressStatus.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Enum;
+
+/**
+ * Basic progress states for lessons or courses.
+ */
+enum ProgressStatus: string
+{
+    case NotStarted = 'notStarted';
+    case InProgress = 'inProgress';
+    case Completed  = 'completed';
+}

--- a/equed-lms/Classes/Service/ProgressCalculationService.php
+++ b/equed-lms/Classes/Service/ProgressCalculationService.php
@@ -8,6 +8,7 @@ use Equed\EquedLms\Domain\Repository\CourseInstanceRepositoryInterface;
 use Equed\EquedLms\Domain\Repository\UserCourseRecordRepositoryInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use Equed\EquedLms\Domain\Service\LanguageServiceInterface;
+use Equed\EquedLms\Enum\ProgressStatus;
 
 /**
  * Service for calculating user progress in courses.
@@ -70,11 +71,13 @@ final class ProgressCalculationService
 
     public function getProgressLabel(float $progress): string
     {
-        $key = match (true) {
-            $progress >= 100.0 => 'progress.completed',
-            $progress > 0.0 => 'progress.inProgress',
-            default => 'progress.notStarted',
+        $status = match (true) {
+            $progress >= 100.0 => ProgressStatus::Completed,
+            $progress > 0.0    => ProgressStatus::InProgress,
+            default            => ProgressStatus::NotStarted,
         };
+
+        $key = sprintf('progress.%s', $status->value);
 
         return $this->languageService->translate($key, ['progress' => (int)round($progress)]);
     }

--- a/equed-lms/Classes/Service/ProgressService.php
+++ b/equed-lms/Classes/Service/ProgressService.php
@@ -11,6 +11,7 @@ use Equed\EquedLms\Domain\Model\CourseInstance;
 use Equed\EquedLms\Domain\Model\CourseProgram;
 use Equed\EquedLms\Domain\Model\FrontendUser;
 use Equed\EquedLms\Enum\UserCourseStatus;
+use Equed\EquedLms\Enum\ProgressStatus;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use Equed\EquedLms\Domain\Service\ClockInterface;
@@ -65,9 +66,9 @@ final class ProgressService implements ProgressServiceInterface
                 'progress'    => $progress,
                 'status'      => $this->languageService->translate(
                     match ($record->getStatus()->value) {
-                        'completed'   => 'status.completed',
-                        'inProgress'  => 'status.inProgress',
-                        default       => 'status.notStarted',
+                        ProgressStatus::Completed->value  => 'status.completed',
+                        ProgressStatus::InProgress->value => 'status.inProgress',
+                        default                          => 'status.notStarted',
                     }
                 ),
             ];

--- a/equed-lms/Tests/Unit/Service/ProgressTrackingServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/ProgressTrackingServiceTest.php
@@ -10,6 +10,7 @@ use Equed\EquedLms\Domain\Repository\CourseInstanceRepositoryInterface;
 use Equed\EquedLms\Domain\Repository\UserCourseRecordRepositoryInterface;
 use Equed\EquedLms\Factory\UserCourseRecordFactoryInterface;
 use Equed\EquedLms\Enum\UserCourseStatus;
+use Equed\EquedLms\Enum\ProgressStatus;
 use Equed\EquedLms\Domain\Service\LanguageServiceInterface;
 use Equed\EquedLms\Service\ProgressTrackingService;
 use Equed\EquedLms\Tests\Traits\ProphecyTrait;
@@ -71,6 +72,6 @@ class ProgressTrackingServiceTest extends TestCase
     {
         $this->language->translate('status.completed')->willReturn('fertig');
 
-        $this->assertSame('fertig', $this->subject->getStatusLabel('completed'));
+        $this->assertSame('fertig', $this->subject->getStatusLabel(\Equed\EquedLms\Enum\ProgressStatus::Completed));
     }
 }


### PR DESCRIPTION
## Summary
- add `ProgressStatus` enum
- switch services to use the enum for progress states
- update tests accordingly

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c6fed9e98832499bac7777f10fbd5