### PR TITLE
Add TTL for recognition cache

### DIFF
--- a/equed-lms/Classes/Service/RecognitionAwardService.php
+++ b/equed-lms/Classes/Service/RecognitionAwardService.php
@@ -16,6 +16,7 @@ use Equed\EquedLms\Domain\Service\ClockInterface;
  */
 final class RecognitionAwardService
 {
+    private const CACHE_TTL_SECONDS = 3600;
 
     public function __construct(
         private readonly UserBadgeRepositoryInterface $userBadgeRepository,
@@ -37,7 +38,7 @@ final class RecognitionAwardService
         $count = $this->userBadgeRepository->countValidBadges($userId);
         $qualifies = $count >= 4;
 
-        $cacheItem->set($qualifies);
+        $cacheItem->set($qualifies)->expiresAfter(self::CACHE_TTL_SECONDS);
         $this->cachePool->save($cacheItem);
 
         return $qualifies;

--- a/equed-lms/Tests/Unit/Service/RecognitionAwardServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/RecognitionAwardServiceTest.php
@@ -54,6 +54,19 @@ class RecognitionAwardServiceTest extends TestCase
         $this->assertTrue($this->subject->qualifiesForAdvancedTitle(5));
     }
 
+    public function testQualifiesForAdvancedTitleCachesResult(): void
+    {
+        $item = $this->prophesize(CacheItemInterface::class);
+        $item->isHit()->willReturn(false);
+        $item->set(true)->willReturn($item->reveal())->shouldBeCalled();
+        $item->expiresAfter(RecognitionAwardService::CACHE_TTL_SECONDS)->shouldBeCalled();
+        $this->cache->getItem('qualifyAdvanced_3')->willReturn($item->reveal());
+        $this->repo->countValidBadges(3)->willReturn(5);
+        $this->cache->save($item->reveal())->shouldBeCalled();
+
+        $this->assertTrue($this->subject->qualifiesForAdvancedTitle(3));
+    }
+
     public function testAssignRecognitionBadgeCreatesNewBadge(): void
     {
         $this->repo->findByUserAndType(7, 'foo')->willReturn(null);


### PR DESCRIPTION
## Summary
- add cache TTL to `RecognitionAwardService`
- ensure cached items expire using that TTL
- test new caching behaviour

## Testing
- `phpunit -c equed-lms/phpunit.xml.dist` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c7352053483248abf340e9e63f119