### PR TITLE
Add cache TTL constant to LessonService

### DIFF
--- a/equed-lms/Classes/Service/LessonService.php
+++ b/equed-lms/Classes/Service/LessonService.php
@@ -17,6 +17,7 @@ use Psr\Cache\CacheItemPoolInterface;
  */
 final class LessonService
 {
+    private const CACHE_TTL_SECONDS = 86400;
     public function __construct(
         private readonly LessonRepository $lessonRepository,
         private readonly CacheItemPoolInterface $cachePool
@@ -62,7 +63,7 @@ final class LessonService
             ),
         ];
 
-        $cacheItem->set($data);
+        $cacheItem->set($data)->expiresAfter(self::CACHE_TTL_SECONDS);
         $this->cachePool->save($cacheItem);
 
         return $data;

--- a/equed-lms/Tests/Unit/Service/LessonServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/LessonServiceTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Tests\Unit\Service;
+
+use Equed\EquedLms\Service\LessonService;
+use Equed\EquedLms\Domain\Repository\LessonRepository;
+use Equed\EquedLms\Domain\Model\Lesson;
+use Equed\EquedLms\Tests\Traits\ProphecyTrait;
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemPoolInterface;
+use Psr\Cache\CacheItemInterface;
+use Prophecy\Argument;
+
+final class LessonServiceTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private LessonService $subject;
+    private $repo;
+    private $cache;
+
+    protected function setUp(): void
+    {
+        $this->repo = $this->prophesize(LessonRepository::class);
+        $this->cache = $this->prophesize(CacheItemPoolInterface::class);
+
+        $this->subject = new LessonService(
+            $this->repo->reveal(),
+            $this->cache->reveal()
+        );
+    }
+
+    public function testGetLessonDataArrayCachesResultWithTtl(): void
+    {
+        $lesson = $this->prophesize(Lesson::class);
+        $lesson->getUid()->willReturn(5);
+        $lesson->getTitle()->willReturn('Foo');
+        $dt = new \DateTimeImmutable('2024-01-01 00:00:00');
+        $lesson->getLastModified()->willReturn($dt);
+
+        $course = new class {
+            public function getUid(): int { return 10; }
+        };
+        $lesson->getCourse()->willReturn($course);
+        $lesson->getAssets()->willReturn(new class {
+            public function toArray(): array { return []; }
+        });
+        $lesson->getPages()->willReturn(new class {
+            public function toArray(): array { return []; }
+        });
+
+        $cacheItem = $this->prophesize(CacheItemInterface::class);
+        $cacheItem->isHit()->willReturn(false);
+        $cacheItem->set(Argument::type('array'))->willReturn($cacheItem->reveal())->shouldBeCalled();
+        $cacheItem->expiresAfter(LessonService::CACHE_TTL_SECONDS)->shouldBeCalled();
+        $cacheKey = sprintf('lessonData_%d_%d', 5, $dt->getTimestamp());
+        $this->cache->getItem($cacheKey)->willReturn($cacheItem->reveal());
+        $this->cache->save($cacheItem->reveal())->shouldBeCalled();
+
+        $result = $this->subject->getLessonDataArray($lesson->reveal());
+        $this->assertSame(5, $result['id']);
+        $this->assertSame('Foo', $result['title']);
+    }
+}

--- a/equed-lms/phpunit.xml.dist
+++ b/equed-lms/phpunit.xml.dist
@@ -19,7 +19,8 @@
             <file>./Tests/Unit/Service/GptTranslationServiceTest.php</file>
             <file>./Tests/Unit/Service/CourseAccessServiceTest.php</file>
             <file>./Tests/Unit/Service/ProgressTrackingServiceTest.php</file>
-            <file>./Tests/Unit/Service/RecognitionAwardServiceTest.php</file>
+        <file>./Tests/Unit/Service/RecognitionAwardServiceTest.php</file>
+        <file>./Tests/Unit/Service/LessonServiceTest.php</file>
         <file>./Tests/Unit/Service/QmsEscalationServiceTest.php</file>
         <file>./Tests/Unit/Service/SubmissionSyncServiceTest.php</file>
         <file>./Tests/Unit/Service/UserProgressSyncServiceTest.php</file>


### PR DESCRIPTION
## Summary
- set `CACHE_TTL_SECONDS` constant in `LessonService`
- use TTL when storing lesson data
- test caching expiration via new `LessonServiceTest`
- register test in PHPUnit config

## Testing
- `vendor/bin/phpunit -c phpunit.xml.dist Tests/Unit/Service/LessonServiceTest.php` *(fails: vendor/bin/phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c77e660c08324a26ba133879518a1