### PR TITLE
Inject clock into JwtService

### DIFF
--- a/equed-lms/Classes/Service/JwtService.php
+++ b/equed-lms/Classes/Service/JwtService.php
@@ -6,6 +6,7 @@ namespace Equed\EquedLms\Service;
 
 use Firebase\JWT\JWT;
 use Firebase\JWT\Key;
+use Equed\EquedLms\Domain\Service\ClockInterface;
 use Equed\EquedLms\Domain\Service\JwtServiceInterface;
 
 /**
@@ -19,7 +20,8 @@ final class JwtService implements JwtServiceInterface
      */
     public function __construct(
         private readonly string $jwtSecret,
-        private readonly int $tokenTtl
+        private readonly int $tokenTtl,
+        private readonly ClockInterface $clock
     ) {
     }
 
@@ -31,7 +33,7 @@ final class JwtService implements JwtServiceInterface
      */
     public function generateToken(array $userData): string
     {
-        $now     = time();
+        $now     = $this->clock->now()->getTimestamp();
         $payload = [
             'iat'   => $now,
             'exp'   => $now + $this->tokenTtl,

--- a/equed-lms/Configuration/Services/Services.yaml
+++ b/equed-lms/Configuration/Services/Services.yaml
@@ -95,6 +95,8 @@ services:
 
   Equed\EquedLms\Domain\Service\JwtServiceInterface:
     class: Equed\EquedLms\Service\JwtService
+    arguments:
+      $clock: '@Equed\EquedLms\Domain\Service\ClockInterface'
 
   Equed\EquedLms\Domain\Service\NotificationServiceInterface:
     class: Equed\EquedLms\Service\NotificationService


### PR DESCRIPTION
## Summary
- inject `ClockInterface` into `JwtService`
- use the clock when generating JWT timestamps
- wire up the clock dependency in DI configuration

## Testing
- `php -l Classes/Service/JwtService.php`
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684c77f579e4832487dbe726f8009513