### PR TITLE
Switch services to repository interfaces

### DIFF
--- a/equed-lms/Classes/EventListener/AutoCertificationListener.php
+++ b/equed-lms/Classes/EventListener/AutoCertificationListener.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Equed\EquedLms\EventListener;
 
-use Equed\EquedLms\Domain\Repository\CertificateDispatchRepository;
-use Equed\EquedLms\Domain\Repository\UserCourseRecordRepository;
+use Equed\EquedLms\Domain\Repository\CertificateDispatchRepositoryInterface;
+use Equed\EquedLms\Domain\Repository\UserCourseRecordRepositoryInterface;
 use Equed\EquedLms\Service\CertificateGeneratorInterface;
 use Equed\EquedLms\Enum\UserCourseStatus;
 use Equed\EquedLms\Event\Course\CourseCompletionValidatedEvent;
@@ -25,15 +25,15 @@ use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
  */
 final class AutoCertificationListener
 {
-    private CertificateDispatchRepository $dispatchRepository;
-    private UserCourseRecordRepository $recordRepository;
+    private CertificateDispatchRepositoryInterface $dispatchRepository;
+    private UserCourseRecordRepositoryInterface $recordRepository;
     private CertificateGeneratorInterface $generator;
     private PersistenceManagerInterface $persistenceManager;
     private FlashMessageService $flashMessageService;
 
     public function __construct(
-        CertificateDispatchRepository $dispatchRepository,
-        UserCourseRecordRepository $recordRepository,
+        CertificateDispatchRepositoryInterface $dispatchRepository,
+        UserCourseRecordRepositoryInterface $recordRepository,
         CertificateGeneratorInterface $generator,
         PersistenceManagerInterface $persistenceManager,
         FlashMessageService $flashMessageService

--- a/equed-lms/Classes/EventListener/CertificateNotificationListener.php
+++ b/equed-lms/Classes/EventListener/CertificateNotificationListener.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Equed\EquedLms\EventListener;
 
-use Equed\EquedLms\Domain\Repository\NotificationRepository;
+use Equed\EquedLms\Domain\Repository\NotificationRepositoryInterface;
 use Equed\EquedLms\Event\CertificateIssuedEvent;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
@@ -22,13 +22,13 @@ use TYPO3\CMS\Core\Annotations\EventListener;
  */
 final class CertificateNotificationListener
 {
-    private NotificationRepository $notificationRepository;
+    private NotificationRepositoryInterface $notificationRepository;
     private GptTranslationServiceInterface $translationService;
     private PersistenceManagerInterface $persistenceManager;
     private FlashMessageService $flashMessageService;
 
     public function __construct(
-        NotificationRepository $notificationRepository,
+        NotificationRepositoryInterface $notificationRepository,
         GptTranslationServiceInterface $translationService,
         PersistenceManagerInterface $persistenceManager,
         FlashMessageService $flashMessageService

--- a/equed-lms/Classes/EventListener/CourseCompletionListener.php
+++ b/equed-lms/Classes/EventListener/CourseCompletionListener.php
@@ -9,7 +9,7 @@ use Equed\EquedLms\Event\CertificateIssuedEvent;
 use Equed\EquedLms\Event\Course\CourseCompletionValidatedEvent;
 use Equed\EquedLms\Service\AutoCertificationServiceInterface;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
-use Equed\EquedLms\Domain\Repository\UserCourseRecordRepository;
+use Equed\EquedLms\Domain\Repository\UserCourseRecordRepositoryInterface;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 use TYPO3\CMS\Core\Annotations\EventListener;
@@ -26,14 +26,14 @@ use TYPO3\CMS\Core\Annotations\EventListener;
 final class CourseCompletionListener
 {
     private AutoCertificationServiceInterface $certificationService;
-    private UserCourseRecordRepository $userCourseRecordRepository;
+    private UserCourseRecordRepositoryInterface $userCourseRecordRepository;
     private PersistenceManagerInterface $persistenceManager;
     private EventDispatcherInterface $eventDispatcher;
     private GptTranslationServiceInterface $translationService;
 
     public function __construct(
         AutoCertificationServiceInterface $certificationService,
-        UserCourseRecordRepository $userCourseRecordRepository,
+        UserCourseRecordRepositoryInterface $userCourseRecordRepository,
         PersistenceManagerInterface $persistenceManager,
         EventDispatcherInterface $eventDispatcher,
         GptTranslationServiceInterface $translationService

--- a/equed-lms/Classes/Service/AuthService.php
+++ b/equed-lms/Classes/Service/AuthService.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace Equed\EquedLms\Service;
 
 use Equed\EquedLms\Domain\Model\UserProfile;
-use Equed\EquedLms\Domain\Repository\UserProfileRepository;
+use Equed\EquedLms\Domain\Repository\UserProfileRepositoryInterface;
 
 final class AuthService
 {
     public function __construct(
-        private readonly UserProfileRepository $userProfileRepository
+        private readonly UserProfileRepositoryInterface $userProfileRepository
     ) {
     }
 

--- a/equed-lms/Classes/Service/CertificateService.php
+++ b/equed-lms/Classes/Service/CertificateService.php
@@ -8,7 +8,7 @@ use DateTimeImmutable;
 use Equed\EquedLms\Domain\Service\ClockInterface;
 use Equed\EquedLms\Domain\Model\CertificateDispatch;
 use Equed\EquedLms\Domain\Model\UserCourseRecord;
-use Equed\EquedLms\Domain\Repository\CertificateDispatchRepository;
+use Equed\EquedLms\Domain\Repository\CertificateDispatchRepositoryInterface;
 use Equed\EquedLms\Factory\CertificateDispatchFactoryInterface;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 use Equed\EquedLms\Service\NotificationService;
@@ -18,7 +18,7 @@ final class CertificateService
     private string $qrCodeBaseUrl;
 
     public function __construct(
-        private readonly CertificateDispatchRepository $certificateDispatchRepository,
+        private readonly CertificateDispatchRepositoryInterface $certificateDispatchRepository,
         private readonly CertificateDispatchFactoryInterface $dispatchFactory,
         private readonly GptTranslationServiceInterface $translationService,
         private readonly NotificationService $notificationService,

--- a/equed-lms/Classes/Service/CourseAccessService.php
+++ b/equed-lms/Classes/Service/CourseAccessService.php
@@ -6,7 +6,7 @@ namespace Equed\EquedLms\Service;
 
 use Equed\EquedLms\Domain\Model\Lesson;
 use Equed\EquedLms\Domain\Model\UserCourseRecord;
-use Equed\EquedLms\Domain\Repository\UserCourseRecordRepository;
+use Equed\EquedLms\Domain\Repository\UserCourseRecordRepositoryInterface;
 
 /**
  * Service to check access permissions for courses and lessons.
@@ -16,7 +16,7 @@ final class CourseAccessService
     private array $userRecordsCache = [];
 
     public function __construct(
-        private readonly UserCourseRecordRepository $userCourseRecordRepository
+        private readonly UserCourseRecordRepositoryInterface $userCourseRecordRepository
     ) {
     }
 

--- a/equed-lms/Classes/Service/CourseCompletionService.php
+++ b/equed-lms/Classes/Service/CourseCompletionService.php
@@ -7,7 +7,7 @@ namespace Equed\EquedLms\Service;
 use DateTimeImmutable;
 use Equed\EquedLms\Domain\Service\ClockInterface;
 use Equed\EquedLms\Domain\Model\UserCourseRecord;
-use Equed\EquedLms\Domain\Repository\UserCourseRecordRepository;
+use Equed\EquedLms\Domain\Repository\UserCourseRecordRepositoryInterface;
 use Equed\EquedLms\Factory\UserCourseRecordFactoryInterface;
 use Equed\EquedLms\Event\Course\CourseCompletedEvent;
 use Equed\EquedLms\Domain\Service\CourseCompletionServiceInterface;
@@ -20,7 +20,7 @@ use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 final class CourseCompletionService implements CourseCompletionServiceInterface
 {
     public function __construct(
-        private readonly UserCourseRecordRepository        $recordRepository,
+        private readonly UserCourseRecordRepositoryInterface $recordRepository,
         private readonly UserCourseRecordFactoryInterface  $recordFactory,
         private readonly PersistenceManagerInterface       $persistenceManager,
         private readonly EventDispatcherInterface          $eventDispatcher,

--- a/equed-lms/Classes/Service/CourseStatusUpdaterService.php
+++ b/equed-lms/Classes/Service/CourseStatusUpdaterService.php
@@ -7,7 +7,7 @@ namespace Equed\EquedLms\Service;
 use DateTimeImmutable;
 use Equed\EquedLms\Domain\Service\ClockInterface;
 use Equed\EquedLms\Domain\Model\UserCourseRecord;
-use Equed\EquedLms\Domain\Repository\UserCourseRecordRepository;
+use Equed\EquedLms\Domain\Repository\UserCourseRecordRepositoryInterface;
 use Equed\EquedLms\Enum\CourseStatus;
 use Equed\EquedLms\Service\CertificateService;
 use Equed\EquedLms\Service\NotificationService;
@@ -21,7 +21,7 @@ final class CourseStatusUpdaterService
     public function __construct(
         private readonly CertificateService    $certificateService,
         private readonly NotificationService   $notificationService,
-        private readonly UserCourseRecordRepository     $userCourseRecordRepository,
+        private readonly UserCourseRecordRepositoryInterface $userCourseRecordRepository,
         private readonly ClockInterface        $clock
     ) {
     }

--- a/equed-lms/Classes/Service/DashboardService.php
+++ b/equed-lms/Classes/Service/DashboardService.php
@@ -8,7 +8,7 @@ use DateTimeImmutable;
 use Equed\EquedLms\Domain\Service\ClockInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use Equed\EquedLms\Domain\Model\FrontendUser;
-use Equed\EquedLms\Domain\Repository\UserCourseRecordRepository;
+use Equed\EquedLms\Domain\Repository\UserCourseRecordRepositoryInterface;
 use Equed\EquedLms\Domain\Repository\CourseInstanceRepositoryInterface;
 use Equed\EquedLms\Domain\Repository\CertificateDispatchRepositoryInterface;
 use Equed\EquedLms\Domain\Repository\NotificationRepositoryInterface;
@@ -27,7 +27,7 @@ final class DashboardService implements DashboardServiceInterface
     private const CACHE_TTL_SECONDS = 600;
 
     public function __construct(
-        private readonly UserCourseRecordRepository    $userCourseRecordRepo,
+        private readonly UserCourseRecordRepositoryInterface $userCourseRecordRepo,
         private readonly CourseInstanceRepositoryInterface      $courseInstanceRepo,
         private readonly CertificateDispatchRepositoryInterface $certificateRepo,
         private readonly NotificationRepositoryInterface        $notificationRepo,

--- a/equed-lms/Classes/Service/SubmissionSyncService.php
+++ b/equed-lms/Classes/Service/SubmissionSyncService.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Equed\EquedLms\Service;
 
 use Equed\EquedLms\Domain\Model\UserSubmission;
-use Equed\EquedLms\Domain\Repository\UserSubmissionRepository;
+use Equed\EquedLms\Domain\Repository\UserSubmissionRepositoryInterface;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 use Ramsey\Uuid\Uuid;
 use Equed\EquedLms\Domain\Service\ClockInterface;
@@ -13,7 +13,7 @@ use Equed\EquedLms\Domain\Service\ClockInterface;
 final class SubmissionSyncService
 {
     public function __construct(
-        private readonly UserSubmissionRepository $submissionRepository,
+        private readonly UserSubmissionRepositoryInterface $submissionRepository,
         private readonly PersistenceManagerInterface $persistenceManager,
         private readonly ClockInterface $clock
     ) {


### PR DESCRIPTION
## Summary
- use `...RepositoryInterface` instead of concrete classes in services and listeners
- rely on existing DI mappings for interface dependencies

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c80217b788324a4fd9a2665aa20f8