### PR TITLE
Add visible materials query

### DIFF
--- a/equed-lms/Classes/Domain/Repository/CourseMaterialRepository.php
+++ b/equed-lms/Classes/Domain/Repository/CourseMaterialRepository.php
@@ -6,6 +6,7 @@ namespace Equed\EquedLms\Domain\Repository;
 
 use Equed\EquedLms\Domain\Model\CourseMaterial;
 use TYPO3\CMS\Extbase\Persistence\Repository;
+use Equed\EquedLms\Domain\Repository\CourseMaterialRepositoryInterface;
 
 /**
  * Repository for CourseMaterial entities.
@@ -13,7 +14,7 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
  *
  * @extends Repository<CourseMaterial>
  */
-final class CourseMaterialRepository extends Repository
+final class CourseMaterialRepository extends Repository implements CourseMaterialRepositoryInterface
 {
     /**
      * Find a CourseMaterial by its UUID.
@@ -42,5 +43,18 @@ final class CourseMaterialRepository extends Repository
         return $this->createQuery()
             ->execute()
             ->toArray();
+    }
+
+    /**
+     * Find all CourseMaterial records that are visible.
+     *
+     * @return CourseMaterial[]
+     */
+    public function findAllVisible(): array
+    {
+        return array_filter(
+            $this->findAllActive(),
+            static fn (CourseMaterial $material): bool => !$material->getHidden()
+        );
     }
 }

--- a/equed-lms/Classes/Domain/Repository/CourseMaterialRepositoryInterface.php
+++ b/equed-lms/Classes/Domain/Repository/CourseMaterialRepositoryInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Domain\Repository;
+
+use Equed\EquedLms\Domain\Model\CourseMaterial;
+
+interface CourseMaterialRepositoryInterface
+{
+    /**
+     * Find a CourseMaterial by its UUID.
+     *
+     * @param string $uuid
+     * @return CourseMaterial|null
+     */
+    public function findByUuid(string $uuid): ?CourseMaterial;
+
+    /**
+     * Find all CourseMaterial records that are not deleted.
+     *
+     * @return CourseMaterial[]
+     */
+    public function findAllActive(): array;
+
+    /**
+     * Find all CourseMaterial records that are visible.
+     *
+     * @return CourseMaterial[]
+     */
+    public function findAllVisible(): array;
+}

--- a/equed-lms/Classes/Service/MaterialService.php
+++ b/equed-lms/Classes/Service/MaterialService.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Equed\EquedLms\Service;
 
 use Equed\EquedLms\Domain\Model\CourseMaterial;
-use Equed\EquedLms\Domain\Repository\CourseMaterialRepository;
+use Equed\EquedLms\Domain\Repository\CourseMaterialRepositoryInterface;
 
 /**
  * Service to retrieve course materials for lessons and content pages.
@@ -13,7 +13,7 @@ use Equed\EquedLms\Domain\Repository\CourseMaterialRepository;
 final class MaterialService
 {
     public function __construct(
-        private readonly CourseMaterialRepository $materialRepository
+        private readonly CourseMaterialRepositoryInterface $materialRepository
     ) {
     }
 
@@ -46,11 +46,6 @@ final class MaterialService
      */
     public function getAllVisibleMaterials(): array
     {
-        $materials = $this->materialRepository->findAll();
-
-        return array_filter(
-            $materials,
-            fn (CourseMaterial $material): bool => !$material->getHidden()
-        );
+        return $this->materialRepository->findAllVisible();
     }
 }

--- a/equed-lms/Tests/Unit/Service/MaterialServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/MaterialServiceTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Tests\Unit\Service;
+
+use Equed\EquedLms\Domain\Repository\CourseMaterialRepositoryInterface;
+use Equed\EquedLms\Domain\Model\CourseMaterial;
+use Equed\EquedLms\Service\MaterialService;
+use Equed\EquedLms\Tests\Traits\ProphecyTrait;
+use PHPUnit\Framework\TestCase;
+
+final class MaterialServiceTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private MaterialService $subject;
+    private $repository;
+
+    protected function setUp(): void
+    {
+        $this->repository = $this->prophesize(CourseMaterialRepositoryInterface::class);
+        $this->subject = new MaterialService(
+            $this->repository->reveal()
+        );
+    }
+
+    public function testReturnsOnlyVisibleMaterials(): void
+    {
+        $visible = new CourseMaterial();
+
+        $this->repository->findAllVisible()->willReturn([
+            $visible,
+        ]);
+
+        $result = $this->subject->getAllVisibleMaterials();
+
+        $this->assertSame([$visible], $result);
+    }
+}


### PR DESCRIPTION
## Summary
- add `CourseMaterialRepositoryInterface` with visibility lookup
- implement `findAllVisible()` in repository
- inject the interface in `MaterialService`
- simplify `getAllVisibleMaterials()`
- cover new logic with unit test

## Testing
- `vendor/bin/phpunit --bootstrap vendor/autoload.php --colors=never Tests/Unit/Service/MaterialServiceTest.php`

------
https://chatgpt.com/codex/tasks/task_e_684c82aface08324810fb61dea60c271