### PR TITLE
Use readonly properties for DocumentService

### DIFF
--- a/equed-lms/Classes/Service/DocumentService.php
+++ b/equed-lms/Classes/Service/DocumentService.php
@@ -15,16 +15,11 @@ final class DocumentService implements DocumentServiceInterface
 {
     private const ALLOWED_EXTENSIONS = ['pdf', 'jpg', 'jpeg', 'png', 'docx'];
 
-    private SettingsService|null $settingsService = null;
-
-    private string $documentsBaseUri;
-    private string $templatesBaseUri;
-
-    public function __construct(string $documentsBaseUri, string $templatesBaseUri, ?SettingsService $settingsService = null)
-    {
-        $this->documentsBaseUri = rtrim($documentsBaseUri, '/') . '/';
-        $this->templatesBaseUri = rtrim($templatesBaseUri, '/') . '/';
-        $this->settingsService = $settingsService;
+    public function __construct(
+        private readonly string $documentsBaseUri,
+        private readonly string $templatesBaseUri,
+        private readonly ?SettingsService $settingsService = null
+    ) {
     }
 
     /**
@@ -44,7 +39,7 @@ final class DocumentService implements DocumentServiceInterface
         }
 
         $safeName = basename($fileName);
-        return $this->documentsBaseUri . $safeName;
+        return rtrim($this->documentsBaseUri, '/') . '/' . $safeName;
     }
 
     /**
@@ -56,7 +51,7 @@ final class DocumentService implements DocumentServiceInterface
     public function getTemplatePath(string $templateName): string
     {
         $safeName = preg_replace('/[^a-zA-Z0-9_\-]/', '', $templateName);
-        return $this->templatesBaseUri . $safeName . '.pdf';
+        return rtrim($this->templatesBaseUri, '/') . '/' . $safeName . '.pdf';
     }
 
     /**


### PR DESCRIPTION
## Summary
- update `DocumentService` constructor to promote readonly dependencies
- access the URIs via promoted readonly properties

## Testing
- `vendor/bin/phpcs --standard=PSR12 Classes/Service/DocumentService.php` *(fails: No such file or directory)*
- `phpcs --standard=PSR12 Classes/Service/DocumentService.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c87c9cf4c8324a9cde99526847dcf