### PR TITLE
Add tests for additional services

### DIFF
--- a/equed-lms/Tests/Unit/Service/CourseCompletionServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/CourseCompletionServiceTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Tests\Unit\Service;
+
+use Equed\EquedLms\Service\CourseCompletionService;
+use Equed\EquedLms\Domain\Repository\UserCourseRecordRepositoryInterface;
+use Equed\EquedLms\Factory\UserCourseRecordFactoryInterface;
+use Equed\EquedLms\Domain\Service\ClockInterface;
+use Equed\EquedLms\Event\Course\CourseCompletedEvent;
+use Equed\EquedLms\Domain\Model\UserCourseRecord;
+use PHPUnit\Framework\TestCase;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
+use DateTimeImmutable;
+use Prophecy\Argument;
+use Equed\EquedLms\Tests\Traits\ProphecyTrait;
+
+if (!interface_exists(PersistenceManagerInterface::class)) {
+    interface PersistenceManagerInterface { public function persistAll(); }
+}
+
+final class CourseCompletionServiceTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private CourseCompletionService $subject;
+    private $repo;
+    private $factory;
+    private $pm;
+    private $dispatcher;
+    private $clock;
+
+    protected function setUp(): void
+    {
+        $this->repo = $this->prophesize(UserCourseRecordRepositoryInterface::class);
+        $this->factory = $this->prophesize(UserCourseRecordFactoryInterface::class);
+        $this->pm = $this->prophesize(PersistenceManagerInterface::class);
+        $this->dispatcher = $this->prophesize(EventDispatcherInterface::class);
+        $this->clock = $this->prophesize(ClockInterface::class);
+
+        $this->subject = new CourseCompletionService(
+            $this->repo->reveal(),
+            $this->factory->reveal(),
+            $this->pm->reveal(),
+            $this->dispatcher->reveal(),
+            $this->clock->reveal(),
+        );
+    }
+
+    public function testMarksCompletedAndDispatchesEventWhenRecordMissing(): void
+    {
+        $record = $this->prophesize(UserCourseRecord::class);
+        $record->isCompleted()->willReturn(false);
+        $record->setCompleted(true)->shouldBeCalled();
+        $now = new DateTimeImmutable('2024-01-01 00:00:00');
+        $record->setCompletedAt($now)->shouldBeCalled();
+
+        $this->repo->findOneByUserAndCourse(3, 7)->willReturn(null);
+        $this->factory->createForUserAndCourse(3, 7)->willReturn($record->reveal());
+        $this->repo->add($record->reveal())->shouldBeCalled();
+        $this->pm->persistAll()->shouldBeCalled();
+        $this->clock->now()->willReturn($now);
+        $this->dispatcher->dispatch(Argument::type(CourseCompletedEvent::class))->shouldBeCalled();
+
+        $result = $this->subject->markCompletedIfNotYet(3, 7);
+        $this->assertTrue($result);
+    }
+
+    public function testReturnsFalseIfAlreadyCompleted(): void
+    {
+        $record = $this->prophesize(UserCourseRecord::class);
+        $record->isCompleted()->willReturn(true);
+        $record->setCompleted(Argument::any())->shouldNotBeCalled();
+
+        $this->repo->findOneByUserAndCourse(5, 9)->willReturn($record->reveal());
+        $this->pm->persistAll()->shouldNotBeCalled();
+        $this->dispatcher->dispatch(Argument::cetera())->shouldNotBeCalled();
+
+        $result = $this->subject->markCompletedIfNotYet(5, 9);
+        $this->assertFalse($result);
+    }
+}

--- a/equed-lms/Tests/Unit/Service/CourseGoalServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/CourseGoalServiceTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Tests\Unit\Service;
+
+use Equed\EquedLms\Service\CourseGoalService;
+use Equed\EquedLms\Domain\Repository\CourseGoalRepository;
+use Equed\EquedLms\Domain\Model\CourseGoal;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Equed\EquedLms\Tests\Traits\ProphecyTrait;
+
+final class CourseGoalServiceTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private CourseGoalService $subject;
+    private $repo;
+
+    protected function setUp(): void
+    {
+        $this->repo = $this->prophesize(CourseGoalRepository::class);
+        $this->subject = new CourseGoalService(
+            $this->repo->reveal()
+        );
+    }
+
+    public function testGoalsAreCachedPerProgram(): void
+    {
+        $goal = new CourseGoal();
+        $this->repo->findByCourseProgram(3)->willReturn([$goal])->shouldBeCalledTimes(1);
+
+        $first = $this->subject->getGoalsForCourseProgram(3);
+        $second = $this->subject->getGoalsForCourseProgram(3);
+
+        $this->assertSame([$goal], $first);
+        $this->assertSame([$goal], $second);
+    }
+
+    public function testIsGoalMetChecksProgressItems(): void
+    {
+        $goal = new CourseGoal();
+        $goal->_setProperty('uid', 5);
+
+        $lesson = new class($goal) {
+            private CourseGoal $goal; public function __construct($g) { $this->goal = $g; }
+            public function getCourseGoal(): CourseGoal { return $this->goal; }
+        };
+
+        $progress = new class($lesson) {
+            private $lesson; public function __construct($l) { $this->lesson = $l; }
+            public function getLesson() { return $this->lesson; }
+            public function getStatus() { return 'completed'; }
+        };
+
+        $this->assertTrue($this->subject->isGoalMet([$progress], 5));
+        $this->assertFalse($this->subject->isGoalMet([$progress], 6));
+    }
+}

--- a/equed-lms/Tests/Unit/Service/JwtServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/JwtServiceTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Tests\Unit\Service;
+
+use Equed\EquedLms\Service\JwtService;
+use Equed\EquedLms\Domain\Service\ClockInterface;
+use PHPUnit\Framework\TestCase;
+use DateTimeImmutable;
+use Firebase\JWT\Key;
+
+final class JwtServiceTest extends TestCase
+{
+    public function testGenerateTokenIncludesPayloadFields(): void
+    {
+        $clock = new class() implements ClockInterface {
+            public function now(): DateTimeImmutable { return new DateTimeImmutable('2024-01-01 00:00:00'); }
+        };
+
+        $service = new JwtService('secret', 3600, $clock);
+
+        $token = $service->generateToken(['uid' => 5, 'email' => 't@example.com', 'roles' => ['a']]);
+        $payload = (array) \Firebase\JWT\JWT::decode($token, new Key('secret', 'HS256'));
+
+        $this->assertSame(5, $payload['uid']);
+        $this->assertSame('t@example.com', $payload['email']);
+        $this->assertSame(['a'], $payload['roles']);
+        $this->assertSame(1704067200, $payload['iat']);
+        $this->assertSame(1704070800, $payload['exp']);
+    }
+
+    public function testVerifyTokenReturnsNullOnError(): void
+    {
+        $clock = new class() implements ClockInterface {
+            public function now(): DateTimeImmutable { return new DateTimeImmutable(); }
+        };
+
+        $service = new JwtService('secret', 3600, $clock);
+
+        $this->assertNull($service->verifyToken('invalid'));
+    }
+
+    public function testVerifyTokenReturnsDecodedData(): void
+    {
+        $clock = new class() implements ClockInterface {
+            public function now(): DateTimeImmutable { return new DateTimeImmutable(); }
+        };
+
+        $service = new JwtService('secret', 3600, $clock);
+        $token = $service->generateToken(['uid' => 1, 'email' => 'a@b.c', 'roles' => []]);
+
+        $data = $service->verifyToken($token);
+        $this->assertIsArray($data);
+        $this->assertSame(1, $data['uid']);
+    }
+}

--- a/equed-lms/Tests/Unit/Service/UserCourseServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/UserCourseServiceTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Tests\Unit\Service;
+
+use Equed\EquedLms\Service\UserCourseService;
+use Equed\EquedLms\Domain\Repository\UserCourseRecordRepositoryInterface;
+use Equed\EquedLms\Domain\Model\UserCourseRecord;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Equed\EquedLms\Tests\Traits\ProphecyTrait;
+
+final class UserCourseServiceTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private UserCourseService $subject;
+    private $repo;
+
+    protected function setUp(): void
+    {
+        $this->repo = $this->prophesize(UserCourseRecordRepositoryInterface::class);
+        $this->subject = new UserCourseService(
+            $this->repo->reveal()
+        );
+    }
+
+    public function testIsCourseActiveChecksRepository(): void
+    {
+        $this->repo->countByUserAndInstanceAndStatus(5, 10, 'active')->willReturn(1);
+        $this->assertTrue($this->subject->isCourseActive(5, 10));
+
+        $this->repo->countByUserAndInstanceAndStatus(5, 10, 'active')->willReturn(0);
+        $this->assertFalse($this->subject->isCourseActive(5, 10));
+    }
+
+    public function testGetCurrentCoursesDelegatesToRepository(): void
+    {
+        $record = new UserCourseRecord();
+        $this->repo->findByUserAndStatus(7, 'active')->willReturn([$record]);
+        $this->assertSame([$record], $this->subject->getCurrentCourses(7));
+    }
+
+    public function testGetCompletedCoursesDelegatesToRepository(): void
+    {
+        $record = new UserCourseRecord();
+        $this->repo->findByUserAndStatus(8, 'completed')->willReturn([$record]);
+        $this->assertSame([$record], $this->subject->getCompletedCourses(8));
+    }
+}

--- a/equed-lms/Tests/Unit/Service/UserProgressServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/UserProgressServiceTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Tests\Unit\Service;
+
+use Equed\EquedLms\Service\UserProgressService;
+use Equed\EquedLms\Domain\Repository\LessonRepositoryInterface;
+use Equed\EquedLms\Domain\Repository\UserSubmissionRepositoryInterface;
+use Equed\EquedLms\Domain\Model\Lesson;
+use Equed\EquedLms\Domain\Model\UserCourseRecord;
+use Equed\EquedLms\Dto\UserProgress;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Equed\EquedLms\Tests\Traits\ProphecyTrait;
+
+final class UserProgressServiceTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private UserProgressService $subject;
+    private $lessonRepo;
+    private $submissionRepo;
+
+    protected function setUp(): void
+    {
+        $this->lessonRepo = $this->prophesize(LessonRepositoryInterface::class);
+        $this->submissionRepo = $this->prophesize(UserSubmissionRepositoryInterface::class);
+        $this->subject = new UserProgressService(
+            $this->lessonRepo->reveal(),
+            $this->submissionRepo->reveal()
+        );
+    }
+
+    public function testCalculateReturnsZeroWhenNoProgram(): void
+    {
+        $ucr = new UserCourseRecord();
+        $result = $this->subject->calculate($ucr);
+        $this->assertEquals(new UserProgress(0, 0, 0), $result);
+    }
+
+    public function testCalculateComputesPercentages(): void
+    {
+        $lesson1 = new Lesson();
+        $lesson2 = new Lesson();
+
+        $program = new class { public function getUid() { return 2; } };
+        $instance = new class($program) { private $p; public function __construct($p){$this->p=$p;} public function getCourseProgram(){ return $this->p; } };
+        $ucr = new UserCourseRecord();
+        $ucr->_setProperty('courseInstance', $instance);
+        $ucr->setQuizScorePercent(50);
+        $ucr->setCompletedLessons([$lesson1]);
+
+        $this->lessonRepo->findRequiredByCourseProgram(2)->willReturn([$lesson1, $lesson2]);
+        $this->submissionRepo->findScoresByUserCourseRecord(Argument::cetera())->willReturn([
+            ['points' => 5, 'maxPoints' => 10],
+        ]);
+
+        $result = $this->subject->calculate($ucr);
+        $this->assertSame(60, $result->percent);
+        $this->assertSame(1, $result->completedLessons);
+        $this->assertSame(2, $result->totalLessons);
+    }
+}

--- a/equed-lms/phpunit.xml.dist
+++ b/equed-lms/phpunit.xml.dist
@@ -27,6 +27,12 @@
         <file>./Tests/Unit/Service/DocumentServiceTest.php</file>
         <file>./Tests/Unit/Service/NotificationServiceTest.php</file>
         <file>./Tests/Unit/Service/QmsServiceTest.php</file>
+        <file>./Tests/Unit/Service/CourseCompletionServiceTest.php</file>
+        <file>./Tests/Unit/Service/CourseGoalServiceTest.php</file>
+        <file>./Tests/Unit/Service/UserCourseServiceTest.php</file>
+        <file>./Tests/Unit/Service/TokenServiceTest.php</file>
+        <file>./Tests/Unit/Service/JwtServiceTest.php</file>
+        <file>./Tests/Unit/Service/UserProgressServiceTest.php</file>
         </testsuite>
         <testsuite name="functional">
             <directory>./Tests/Functional/</directory>


### PR DESCRIPTION
## Summary
- add unit tests for CourseCompletionService and related caching logic
- test UserCourseService behaviours
- cover token and JWT services
- compute user progress with new service tests
- reference new test files in phpunit.xml.dist

## Testing
- `vendor/bin/phpunit -c phpunit.xml.dist --testsuite unit` *(fails: Cannot declare interface UuidGeneratorInterface)*

------
https://chatgpt.com/codex/tasks/task_e_684c88962f988324b0f15f12a77a4692