### PR TITLE
Add repository interfaces and update service dependencies

### DIFF
--- a/equed-lms/Classes/Domain/Repository/BadgeAwardRepositoryInterface.php
+++ b/equed-lms/Classes/Domain/Repository/BadgeAwardRepositoryInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Domain\Repository;
+
+use Equed\EquedLms\Domain\Model\BadgeAward;
+
+interface BadgeAwardRepositoryInterface
+{
+    /**
+     * @param int $feUserId
+     * @return BadgeAward[]
+     */
+    public function findByFeUser(int $feUserId): array;
+
+    public function addForCourse(int $userId, int $courseId, string $label): void;
+
+    public function addForLearningPath(int $userId, int $pathId, string $label): void;
+}

--- a/equed-lms/Classes/Domain/Repository/CourseGoalRepository.php
+++ b/equed-lms/Classes/Domain/Repository/CourseGoalRepository.php
@@ -6,13 +6,14 @@ namespace Equed\EquedLms\Domain\Repository;
 
 use TYPO3\CMS\Extbase\Persistence\Repository;
 use Equed\EquedLms\Domain\Model\CourseGoal;
+use Equed\EquedLms\Domain\Repository\CourseGoalRepositoryInterface;
 
 /**
  * Repository for CourseGoal entities.
  *
  * @extends Repository<CourseGoal>
  */
-final class CourseGoalRepository extends Repository
+final class CourseGoalRepository extends Repository implements CourseGoalRepositoryInterface
 {
     /**
      * Find goals for a specific course program.

--- a/equed-lms/Classes/Domain/Repository/CourseGoalRepositoryInterface.php
+++ b/equed-lms/Classes/Domain/Repository/CourseGoalRepositoryInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Domain\Repository;
+
+use Equed\EquedLms\Domain\Model\CourseGoal;
+use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
+
+interface CourseGoalRepositoryInterface
+{
+    /**
+     * @return CourseGoal[]|QueryResultInterface
+     */
+    public function findAll();
+
+    /**
+     * @param int $courseProgramId
+     * @return CourseGoal[]
+     */
+    public function findByCourseProgram(int $courseProgramId): array;
+}

--- a/equed-lms/Classes/Domain/Repository/LessonAttemptRepository.php
+++ b/equed-lms/Classes/Domain/Repository/LessonAttemptRepository.php
@@ -9,6 +9,7 @@ use Equed\EquedLms\Domain\Model\LessonAttempt;
 use Equed\EquedLms\Domain\Model\FrontendUser;
 use TYPO3\CMS\Extbase\Persistence\QueryInterface;
 use TYPO3\CMS\Extbase\Persistence\Repository;
+use Equed\EquedLms\Domain\Repository\LessonAttemptRepositoryInterface;
 
 /**
  * Repository for LessonAttempt entities.
@@ -16,7 +17,7 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
  *
  * @extends Repository<LessonAttempt>
  */
-final class LessonAttemptRepository extends Repository
+final class LessonAttemptRepository extends Repository implements LessonAttemptRepositoryInterface
 {
     /**
      * Finds the latest attempt by a specific instructor for a given lesson.

--- a/equed-lms/Classes/Domain/Repository/LessonAttemptRepositoryInterface.php
+++ b/equed-lms/Classes/Domain/Repository/LessonAttemptRepositoryInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Domain\Repository;
+
+use Equed\EquedLms\Domain\Model\FrontendUser;
+use Equed\EquedLms\Domain\Model\Lesson;
+use Equed\EquedLms\Domain\Model\LessonAttempt;
+
+interface LessonAttemptRepositoryInterface
+{
+    public function findLatestByUserAndLesson(FrontendUser $user, Lesson $lesson): ?LessonAttempt;
+
+    /**
+     * @return LessonAttempt[]
+     */
+    public function findAllUnfinished(): array;
+
+    /**
+     * @param FrontendUser $user
+     * @return LessonAttempt[]
+     */
+    public function findByFeUser(FrontendUser $user): array;
+}

--- a/equed-lms/Classes/Domain/Repository/LessonRepository.php
+++ b/equed-lms/Classes/Domain/Repository/LessonRepository.php
@@ -9,6 +9,7 @@ use Equed\EquedLms\Domain\Model\Lesson;
 use Equed\EquedLms\Domain\Model\Module;
 use TYPO3\CMS\Extbase\Persistence\QueryInterface;
 use TYPO3\CMS\Extbase\Persistence\Repository;
+use Equed\EquedLms\Domain\Repository\LessonRepositoryInterface;
 
 /**
  * Repository for Lesson entities.
@@ -16,7 +17,7 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
  *
  * @extends Repository<Lesson>
  */
-final class LessonRepository extends Repository
+final class LessonRepository extends Repository implements LessonRepositoryInterface
 {
     /**
      * Finds all lessons for a given course program via the module relation.

--- a/equed-lms/Classes/Domain/Repository/LessonRepositoryInterface.php
+++ b/equed-lms/Classes/Domain/Repository/LessonRepositoryInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Domain\Repository;
+
+use Equed\EquedLms\Domain\Model\CourseProgram;
+use Equed\EquedLms\Domain\Model\Lesson;
+use Equed\EquedLms\Domain\Model\Module;
+
+interface LessonRepositoryInterface
+{
+    /**
+     * @param CourseProgram $courseProgram
+     * @return Lesson[]
+     */
+    public function findByCourseProgram(CourseProgram $courseProgram): array;
+
+    /**
+     * @return Lesson[]
+     */
+    public function findVisible(): array;
+
+    /**
+     * @return Lesson[]
+     */
+    public function findWithQuiz(): array;
+
+    /**
+     * @param Module $module
+     * @return Lesson[]
+     */
+    public function findByModule(Module $module): array;
+
+    public function findByUuid(string $uuid): ?Lesson;
+}

--- a/equed-lms/Classes/Service/BadgeAwardService.php
+++ b/equed-lms/Classes/Service/BadgeAwardService.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Equed\EquedLms\Service;
 
-use Equed\EquedLms\Domain\Repository\BadgeAwardRepository;
+use Equed\EquedLms\Domain\Repository\BadgeAwardRepositoryInterface;
 use Equed\EquedLms\Domain\Repository\UserCourseRecordRepository;
 use Equed\EquedLms\Domain\Repository\LearningPathRepository;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
@@ -12,7 +12,7 @@ use Equed\EquedLms\Service\GptTranslationServiceInterface;
 final class BadgeAwardService
 {
     public function __construct(
-        private readonly BadgeAwardRepository       $awardRepo,
+        private readonly BadgeAwardRepositoryInterface       $awardRepo,
         private readonly UserCourseRecordRepository $courseRecordRepo,
         private readonly LearningPathRepository     $learningPathRepo,
         private readonly GptTranslationServiceInterface      $translationService

--- a/equed-lms/Classes/Service/CourseGoalService.php
+++ b/equed-lms/Classes/Service/CourseGoalService.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Equed\EquedLms\Service;
 
 use Equed\EquedLms\Domain\Model\CourseGoal;
-use Equed\EquedLms\Domain\Repository\CourseGoalRepository;
+use Equed\EquedLms\Domain\Repository\CourseGoalRepositoryInterface;
 use Equed\EquedLms\Domain\Service\CourseGoalServiceInterface;
 
 /**
@@ -21,7 +21,7 @@ final class CourseGoalService implements CourseGoalServiceInterface
     private array $goalsCache = [];
 
     public function __construct(
-        private readonly CourseGoalRepository $courseGoalRepository
+        private readonly CourseGoalRepositoryInterface $courseGoalRepository
     ) {
     }
 

--- a/equed-lms/Classes/Service/LessonAttemptService.php
+++ b/equed-lms/Classes/Service/LessonAttemptService.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Equed\EquedLms\Service;
 
 use Equed\EquedLms\Domain\Model\LessonAttempt;
-use Equed\EquedLms\Domain\Repository\LessonAttemptRepository;
+use Equed\EquedLms\Domain\Repository\LessonAttemptRepositoryInterface;
 
 /**
  * Service for handling lesson attempts.
@@ -13,7 +13,7 @@ use Equed\EquedLms\Domain\Repository\LessonAttemptRepository;
 final class LessonAttemptService
 {
     public function __construct(
-        private readonly LessonAttemptRepository $lessonAttemptRepository
+        private readonly LessonAttemptRepositoryInterface $lessonAttemptRepository
     ) {
     }
 

--- a/equed-lms/Classes/Service/LessonContentService.php
+++ b/equed-lms/Classes/Service/LessonContentService.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Equed\EquedLms\Service;
 
 use Equed\EquedLms\Domain\Model\Lesson;
-use Equed\EquedLms\Domain\Repository\LessonRepository;
+use Equed\EquedLms\Domain\Repository\LessonRepositoryInterface;
 
 /**
  * Service for retrieving lesson content.
@@ -13,7 +13,7 @@ use Equed\EquedLms\Domain\Repository\LessonRepository;
 final class LessonContentService
 {
     public function __construct(
-        private readonly LessonRepository $lessonRepository
+        private readonly LessonRepositoryInterface $lessonRepository
     ) {
     }
 

--- a/equed-lms/Classes/Service/LessonService.php
+++ b/equed-lms/Classes/Service/LessonService.php
@@ -7,7 +7,7 @@ namespace Equed\EquedLms\Service;
 use Equed\EquedLms\Domain\Model\Lesson;
 use Equed\EquedLms\Domain\Model\Asset;
 use Equed\EquedLms\Domain\Model\Page;
-use Equed\EquedLms\Domain\Repository\LessonRepository;
+use Equed\EquedLms\Domain\Repository\LessonRepositoryInterface;
 use Psr\Cache\CacheItemPoolInterface;
 
 /**
@@ -19,7 +19,7 @@ final class LessonService
 {
     private const CACHE_TTL_SECONDS = 86400;
     public function __construct(
-        private readonly LessonRepository $lessonRepository,
+        private readonly LessonRepositoryInterface $lessonRepository,
         private readonly CacheItemPoolInterface $cachePool
     ) {
     }

--- a/equed-lms/Configuration/Services/Services.yaml
+++ b/equed-lms/Configuration/Services/Services.yaml
@@ -49,6 +49,18 @@ services:
   Equed\EquedLms\Domain\Repository\UserBadgeRepositoryInterface:
     class: Equed\EquedLms\Domain\Repository\UserBadgeRepository
 
+  Equed\EquedLms\Domain\Repository\BadgeAwardRepositoryInterface:
+    class: Equed\EquedLms\Domain\Repository\BadgeAwardRepository
+
+  Equed\EquedLms\Domain\Repository\CourseGoalRepositoryInterface:
+    class: Equed\EquedLms\Domain\Repository\CourseGoalRepository
+
+  Equed\EquedLms\Domain\Repository\LessonAttemptRepositoryInterface:
+    class: Equed\EquedLms\Domain\Repository\LessonAttemptRepository
+
+  Equed\EquedLms\Domain\Repository\LessonRepositoryInterface:
+    class: Equed\EquedLms\Domain\Repository\LessonRepository
+
   Equed\EquedLms\Domain\Service\DashboardServiceInterface:
     class: Equed\EquedLms\Service\DashboardService
 

--- a/equed-lms/Tests/Unit/Service/BadgeAwardServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/BadgeAwardServiceTest.php
@@ -3,10 +3,11 @@
 declare(strict_types=1);
 
 namespace Equed\EquedLms\Domain\Repository {
-    if (!class_exists(BadgeAwardRepository::class)) {
-        class BadgeAwardRepository {
-            public function addForCourse(int $userId, int $courseId, string $label): void {}
-            public function addForLearningPath(int $userId, int $pathId, string $label): void {}
+    if (!interface_exists(BadgeAwardRepositoryInterface::class)) {
+        interface BadgeAwardRepositoryInterface {
+            public function addForCourse(int $userId, int $courseId, string $label): void;
+            public function addForLearningPath(int $userId, int $pathId, string $label): void;
+            public function findByFeUser(int $feUserId): array;
         }
     }
 }
@@ -14,7 +15,7 @@ namespace Equed\EquedLms\Domain\Repository {
 namespace Equed\EquedLms\Tests\Unit\Service;
 
 use Equed\EquedLms\Service\BadgeAwardService;
-use Equed\EquedLms\Domain\Repository\BadgeAwardRepository;
+use Equed\EquedLms\Domain\Repository\BadgeAwardRepositoryInterface;
 use Equed\EquedLms\Domain\Repository\UserCourseRecordRepository;
 use Equed\EquedLms\Domain\Repository\LearningPathRepository;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
@@ -40,7 +41,7 @@ class BadgeAwardServiceTest extends TestCase
             public function getTitle(){ return 'Path'; }
         };
 
-        $awardRepo = $this->prophesize(BadgeAwardRepository::class);
+        $awardRepo = $this->prophesize(BadgeAwardRepositoryInterface::class);
         $awardRepo->addForCourse(1, 2, 'c')->shouldBeCalled();
         $awardRepo->addForLearningPath(1, 3, 'p')->shouldBeCalled();
 

--- a/equed-lms/Tests/Unit/Service/CourseGoalServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/CourseGoalServiceTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Equed\EquedLms\Tests\Unit\Service;
 
 use Equed\EquedLms\Service\CourseGoalService;
-use Equed\EquedLms\Domain\Repository\CourseGoalRepository;
+use Equed\EquedLms\Domain\Repository\CourseGoalRepositoryInterface;
 use Equed\EquedLms\Domain\Model\CourseGoal;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
@@ -20,7 +20,7 @@ final class CourseGoalServiceTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->repo = $this->prophesize(CourseGoalRepository::class);
+        $this->repo = $this->prophesize(CourseGoalRepositoryInterface::class);
         $this->subject = new CourseGoalService(
             $this->repo->reveal()
         );

--- a/equed-lms/Tests/Unit/Service/LessonServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/LessonServiceTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Equed\EquedLms\Tests\Unit\Service;
 
 use Equed\EquedLms\Service\LessonService;
-use Equed\EquedLms\Domain\Repository\LessonRepository;
+use Equed\EquedLms\Domain\Repository\LessonRepositoryInterface;
 use Equed\EquedLms\Domain\Model\Lesson;
 use Equed\EquedLms\Tests\Traits\ProphecyTrait;
 use PHPUnit\Framework\TestCase;
@@ -23,7 +23,7 @@ final class LessonServiceTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->repo = $this->prophesize(LessonRepository::class);
+        $this->repo = $this->prophesize(LessonRepositoryInterface::class);
         $this->cache = $this->prophesize(CacheItemPoolInterface::class);
 
         $this->subject = new LessonService(


### PR DESCRIPTION
## Summary
- introduce repository interfaces for badges, course goals, lesson attempts and lessons
- implement the new interfaces in existing repositories
- update services to depend on repository interfaces
- map interfaces to repositories in DI configuration
- adjust unit tests for new constructor signatures

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c8bf9b94083249079e2ce752f2b70