### PR TITLE
Introduce translator service

### DIFF
--- a/equed-lms/Classes/Domain/Service/TranslatorInterface.php
+++ b/equed-lms/Classes/Domain/Service/TranslatorInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Domain\Service;
+
+interface TranslatorInterface
+{
+    public function translate(string $key, array $arguments = [], ?string $extension = null): ?string;
+}

--- a/equed-lms/Classes/Service/GptTranslationService.php
+++ b/equed-lms/Classes/Service/GptTranslationService.php
@@ -7,7 +7,7 @@ namespace Equed\EquedLms\Service;
 use Psr\Cache\CacheItemPoolInterface;
 use Equed\EquedLms\Service\LogService;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
-use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
+use Equed\EquedLms\Domain\Service\TranslatorInterface;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 
 final class GptTranslationService implements GptTranslationServiceInterface
@@ -18,6 +18,7 @@ final class GptTranslationService implements GptTranslationServiceInterface
         private readonly HttpClientInterface $httpClient,
         private readonly CacheItemPoolInterface $cache,
         private readonly LogService $logService,
+        private readonly TranslatorInterface $translator,
         private readonly string $apiEndpoint,
         private readonly string $apiKey,
         private readonly string $defaultLanguage = 'en'
@@ -64,7 +65,7 @@ final class GptTranslationService implements GptTranslationServiceInterface
         }
 
         // 2) static XLIFF
-        $static = LocalizationUtility::translate($key, $extension ?? 'equed_lms', $arguments, $language);
+        $static = $this->translator->translate($key, $arguments, $extension ?? 'equed_lms');
         if ($static !== null) {
             $item->set($static)->expiresAfter(self::CACHE_TTL);
             $this->cache->save($item);

--- a/equed-lms/Classes/Service/LanguageService.php
+++ b/equed-lms/Classes/Service/LanguageService.php
@@ -6,7 +6,7 @@ namespace Equed\EquedLms\Service;
 
 use Equed\EquedLms\Domain\Service\LanguageServiceInterface;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
-use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
+use Equed\EquedLms\Domain\Service\TranslatorInterface;
 
 /**
  * Service for translating labels via GPT-based translation service
@@ -15,14 +15,17 @@ use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 final class LanguageService implements LanguageServiceInterface
 {
     private GptTranslationServiceInterface $gptTranslationService;
+    private TranslatorInterface $translator;
     private string $extensionKey;
 
     public function __construct(
         GptTranslationServiceInterface $gptTranslationService,
+        TranslatorInterface $translator,
         string $extensionKey = 'equed_lms'
     ) {
         $this->gptTranslationService = $gptTranslationService;
-        $this->extensionKey         = $extensionKey;
+        $this->translator            = $translator;
+        $this->extensionKey          = $extensionKey;
     }
 
     /**
@@ -49,6 +52,6 @@ final class LanguageService implements LanguageServiceInterface
             }
         }
 
-        return LocalizationUtility::translate($key, $extension, $arguments) ?? $key;
+        return $this->translator->translate($key, $arguments, $extension) ?? $key;
     }
 }

--- a/equed-lms/Classes/Service/Translator.php
+++ b/equed-lms/Classes/Service/Translator.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Service;
+
+use Equed\EquedLms\Domain\Service\TranslatorInterface;
+use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
+
+final class Translator implements TranslatorInterface
+{
+    public function translate(string $key, array $arguments = [], ?string $extension = null): ?string
+    {
+        return LocalizationUtility::translate($key, $extension, $arguments);
+    }
+}

--- a/equed-lms/Classes/Service/ViewHelperService.php
+++ b/equed-lms/Classes/Service/ViewHelperService.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Equed\EquedLms\Service;
 
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
-use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
+use Equed\EquedLms\Domain\Service\TranslatorInterface;
 
 /**
  * Service for formatting view-related helpers.
@@ -16,6 +16,7 @@ final class ViewHelperService
 
     public function __construct(
         private readonly GptTranslationServiceInterface $translationService,
+        private readonly TranslatorInterface $translator,
         string $extensionKey = 'equed_lms'
     ) {
         $this->extensionKey = $extensionKey;
@@ -54,6 +55,6 @@ final class ViewHelperService
             }
         }
 
-        return LocalizationUtility::translate($key, $this->extensionKey) ?? $badgeIdentifier;
+        return $this->translator->translate($key, [], $this->extensionKey) ?? $badgeIdentifier;
     }
 }

--- a/equed-lms/Configuration/Services/Services.yaml
+++ b/equed-lms/Configuration/Services/Services.yaml
@@ -15,10 +15,16 @@ services:
   Equed\EquedLms\Service\GptTranslationService:
     public: true
 
+  Equed\EquedLms\Service\Translator: ~
+
+  Equed\EquedLms\Domain\Service\TranslatorInterface:
+    class: Equed\EquedLms\Service\Translator
+
   # LanguageService now injected with GptTranslationService
   Equed\EquedLms\Service\LanguageService:
     arguments:
       $gptTranslationService: '@Equed\EquedLms\Service\GptTranslationService'
+      $translator: '@Equed\EquedLms\Service\Translator'
 
   # Event listener for course completion (PSR-14)
   Equed\EquedLms\EventListener\CourseCompletedListener:

--- a/equed-lms/Tests/Unit/Service/GptTranslationServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/GptTranslationServiceTest.php
@@ -18,6 +18,7 @@ namespace Equed\EquedLms\Tests\Unit\Service;
 
 use Equed\EquedLms\Service\GptTranslationService;
 use Equed\EquedLms\Service\LogServiceInterface;
+use Equed\EquedLms\Domain\Service\TranslatorInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\HttpClient\MockHttpClient;
@@ -42,10 +43,12 @@ class GptTranslationServiceTest extends TestCase
         $logger = $this->prophesize(LogServiceInterface::class);
         $logger->logWarning(Argument::cetera())->shouldNotBeCalled();
 
+        $translator = $this->createMock(TranslatorInterface::class);
         $service = new GptTranslationService(
             $httpClient,
             $cache,
             $logger->reveal(),
+            $translator,
             'https://example.com',
             'apikey',
             'en'
@@ -68,10 +71,12 @@ class GptTranslationServiceTest extends TestCase
         $logger = $this->prophesize(LogServiceInterface::class);
         $logger->logWarning('GPT translation failed', Argument::type('array'))->shouldBeCalledTimes(2);
 
+        $translator = $this->createMock(TranslatorInterface::class);
         $service = new GptTranslationService(
             $httpClient,
             $cache,
             $logger->reveal(),
+            $translator,
             'https://example.com',
             'apikey',
             'en'

--- a/equed-lms/Tests/Unit/Service/LanguageServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/LanguageServiceTest.php
@@ -24,13 +24,21 @@ if (!interface_exists(GptTranslationServiceInterface::class)) {
     }
 }
 
+if (!interface_exists(\Equed\EquedLms\Domain\Service\TranslatorInterface::class)) {
+    interface TranslatorInterface
+    {
+        public function translate(string $key, array $arguments = [], ?string $extension = null): ?string;
+    }
+}
+
 namespace Equed\EquedLms\Tests\Unit\Service;
 
 use Equed\EquedLms\Service\LanguageService;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
+use Equed\EquedLms\Domain\Service\TranslatorInterface;
 use PHPUnit\Framework\TestCase;
 
-class DummyTranslationService implements GptTranslationServiceInterface
+class DummyGptTranslationService implements GptTranslationServiceInterface
 {
     public function __construct(private bool $enabled = false)
     {
@@ -47,11 +55,22 @@ class DummyTranslationService implements GptTranslationServiceInterface
     }
 }
 
+class DummyTranslator implements TranslatorInterface
+{
+    public function translate(string $key, array $arguments = [], ?string $extension = null): ?string
+    {
+        return null;
+    }
+}
+
 class LanguageServiceTest extends TestCase
 {
     public function testFallbackReturnsKeyWhenTranslationMissing(): void
     {
-        $service = new LanguageService(new DummyTranslationService(false));
+        $service = new LanguageService(
+            new DummyGptTranslationService(false),
+            new DummyTranslator()
+        );
         $this->assertSame('missing.key', $service->translate('missing.key'));
     }
 }


### PR DESCRIPTION
## Summary
- add a new `TranslatorInterface` with default implementation
- inject translator into the GPT, language and view helper services
- update service wiring and unit tests

## Testing
- ❌ `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c8f0e46b883249d1a873525afc22f