### PR TITLE
Add custom extensions injection

### DIFF
--- a/equed-lms/Classes/Service/DocumentService.php
+++ b/equed-lms/Classes/Service/DocumentService.php
@@ -18,7 +18,8 @@ final class DocumentService implements DocumentServiceInterface
     public function __construct(
         private readonly string $documentsBaseUri,
         private readonly string $templatesBaseUri,
-        private readonly ?SettingsService $settingsService = null
+        private readonly ?SettingsService $settingsService = null,
+        private readonly array $allowedExtensions = self::ALLOWED_EXTENSIONS
     ) {
     }
 
@@ -61,6 +62,10 @@ final class DocumentService implements DocumentServiceInterface
      */
     private function getAllowedExtensions(): array
     {
+        if ($this->allowedExtensions !== self::ALLOWED_EXTENSIONS) {
+            return array_map('strtolower', $this->allowedExtensions);
+        }
+
         $custom = $this->settingsService?->get('allowedDocumentExtensions');
         if (is_string($custom)) {
             $custom = array_filter(array_map('trim', explode(',', $custom)));

--- a/equed-lms/Tests/Unit/Service/DocumentServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/DocumentServiceTest.php
@@ -31,4 +31,17 @@ final class DocumentServiceTest extends TestCase
         $this->assertSame('https://tpl.example.com/Danger123.pdf', $result);
     }
 
+    public function testCustomAllowedExtensionsOverrideDefaults(): void
+    {
+        $service = new DocumentService(
+            'https://files.example.com',
+            'https://tpl.example.com',
+            null,
+            ['txt']
+        );
+
+        $result = $service->generateDownloadLink('note.txt');
+        $this->assertSame('https://files.example.com/note.txt', $result);
+    }
+
 }


### PR DESCRIPTION
## Summary
- allow customizing allowed document extensions via constructor
- test custom extension injection

## Testing
- `php -v` *(fails: command not found)*
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c92dbd2248324b1d56259a7e09e03