### PR TITLE
Add lesson service unit tests

### DIFF
--- a/equed-lms/Tests/Unit/Service/LessonAttemptServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/LessonAttemptServiceTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Tests\Unit\Service;
+
+use Equed\EquedLms\Domain\Repository\LessonAttemptRepositoryInterface;
+use Equed\EquedLms\Domain\Model\LessonAttempt;
+use Equed\EquedLms\Service\LessonAttemptService;
+use Equed\EquedLms\Tests\Traits\ProphecyTrait;
+use PHPUnit\Framework\TestCase;
+
+final class LessonAttemptServiceTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private LessonAttemptService $subject;
+    private $repo;
+
+    protected function setUp(): void
+    {
+        $this->repo = $this->prophesize(LessonAttemptRepositoryInterface::class);
+        $this->subject = new LessonAttemptService(
+            $this->repo->reveal()
+        );
+    }
+
+    public function testGetLatestAttemptForLessonReturnsRepositoryResult(): void
+    {
+        $attempt = $this->prophesize(LessonAttempt::class);
+        $this->repo->findLatestByUserAndLesson(5, 7)->willReturn($attempt->reveal());
+
+        $result = $this->subject->getLatestAttemptForLesson(5, 7);
+        $this->assertSame($attempt->reveal(), $result);
+    }
+
+    public function testHasUnfinishedAttemptReturnsTrue(): void
+    {
+        $attempt = $this->prophesize(LessonAttempt::class);
+        $attempt->getStatus()->willReturn('incomplete');
+        $this->repo->findLatestByUserAndLesson(3, 9)->willReturn($attempt->reveal());
+
+        $this->assertTrue($this->subject->hasUnfinishedAttempt(3, 9));
+    }
+
+    public function testHasUnfinishedAttemptReturnsFalseWhenCompleted(): void
+    {
+        $attempt = $this->prophesize(LessonAttempt::class);
+        $attempt->getStatus()->willReturn('completed');
+        $this->repo->findLatestByUserAndLesson(2, 4)->willReturn($attempt->reveal());
+
+        $this->assertFalse($this->subject->hasUnfinishedAttempt(2, 4));
+    }
+
+    public function testHasUnfinishedAttemptReturnsFalseWhenNoAttempts(): void
+    {
+        $this->repo->findLatestByUserAndLesson(1, 8)->willReturn(null);
+
+        $this->assertFalse($this->subject->hasUnfinishedAttempt(1, 8));
+    }
+}

--- a/equed-lms/Tests/Unit/Service/LessonContentServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/LessonContentServiceTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Tests\Unit\Service;
+
+use Equed\EquedLms\Domain\Repository\LessonRepositoryInterface;
+use Equed\EquedLms\Domain\Model\Lesson;
+use Equed\EquedLms\Service\LessonContentService;
+use Equed\EquedLms\Tests\Traits\ProphecyTrait;
+use PHPUnit\Framework\TestCase;
+
+final class LessonContentServiceTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private LessonContentService $subject;
+    private $repo;
+
+    protected function setUp(): void
+    {
+        $this->repo = $this->prophesize(LessonRepositoryInterface::class);
+        $this->subject = new LessonContentService(
+            $this->repo->reveal()
+        );
+    }
+
+    public function testReturnsOnlyVisibleLessonsForProgram(): void
+    {
+        $visible = $this->prophesize(Lesson::class);
+        $visible->getHidden()->willReturn(false);
+        $hidden = $this->prophesize(Lesson::class);
+        $hidden->getHidden()->willReturn(true);
+
+        $this->repo->findByCourseProgram(11)->willReturn([
+            $visible->reveal(),
+            $hidden->reveal(),
+        ]);
+
+        $result = $this->subject->getVisibleLessonsForCourseProgram(11);
+        $this->assertSame([$visible->reveal()], $result);
+    }
+}

--- a/equed-lms/phpunit.xml.dist
+++ b/equed-lms/phpunit.xml.dist
@@ -33,6 +33,8 @@
         <file>./Tests/Unit/Service/TokenServiceTest.php</file>
         <file>./Tests/Unit/Service/JwtServiceTest.php</file>
         <file>./Tests/Unit/Service/UserProgressServiceTest.php</file>
+        <file>./Tests/Unit/Service/LessonAttemptServiceTest.php</file>
+        <file>./Tests/Unit/Service/LessonContentServiceTest.php</file>
         </testsuite>
         <testsuite name="functional">
             <directory>./Tests/Functional/</directory>


### PR DESCRIPTION
## Summary
- add unit tests for `LessonAttemptService` and `LessonContentService`
- register new tests in `phpunit.xml.dist`

## Testing
- `./vendor/bin/phpunit --configuration phpunit.xml.dist` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c9c65e288832486ed5bc8b8309f6a