### PR TITLE
chore: remove unused DateTimeImmutable imports

### DIFF
--- a/equed-lms/Classes/Service/CertificateService.php
+++ b/equed-lms/Classes/Service/CertificateService.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Equed\EquedLms\Service;
 
-use DateTimeImmutable;
 use Equed\EquedLms\Domain\Service\ClockInterface;
 use Equed\EquedLms\Domain\Model\CertificateDispatch;
 use Equed\EquedLms\Domain\Model\UserCourseRecord;

--- a/equed-lms/Classes/Service/CourseCompletionService.php
+++ b/equed-lms/Classes/Service/CourseCompletionService.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Equed\EquedLms\Service;
 
-use DateTimeImmutable;
 use Equed\EquedLms\Domain\Service\ClockInterface;
 use Equed\EquedLms\Domain\Model\UserCourseRecord;
 use Equed\EquedLms\Domain\Repository\UserCourseRecordRepositoryInterface;

--- a/equed-lms/Classes/Service/CourseStatusUpdaterService.php
+++ b/equed-lms/Classes/Service/CourseStatusUpdaterService.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Equed\EquedLms\Service;
 
-use DateTimeImmutable;
 use Equed\EquedLms\Domain\Service\ClockInterface;
 use Equed\EquedLms\Domain\Model\UserCourseRecord;
 use Equed\EquedLms\Domain\Repository\UserCourseRecordRepositoryInterface;

--- a/equed-lms/Classes/Service/ExamService.php
+++ b/equed-lms/Classes/Service/ExamService.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Equed\EquedLms\Service;
 
-use DateTimeImmutable;
 use Equed\EquedLms\Domain\Service\ClockInterface;
 use Equed\EquedLms\Domain\Model\ExamAttempt;
 use Equed\EquedLms\Domain\Repository\ExamAttemptRepositoryInterface;

--- a/equed-lms/Classes/Service/GptEvaluationService.php
+++ b/equed-lms/Classes/Service/GptEvaluationService.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Equed\EquedLms\Service;
 
-use DateTimeImmutable;
 use Equed\EquedLms\Domain\Service\ClockInterface;
 use JsonException;
 use Psr\Http\Client\ClientExceptionInterface;

--- a/equed-lms/Classes/Service/LessonProgressService.php
+++ b/equed-lms/Classes/Service/LessonProgressService.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Equed\EquedLms\Service;
 
-use DateTimeImmutable;
 use Equed\EquedLms\Domain\Service\ClockInterface;
 use Equed\EquedLms\Domain\Model\Lesson;
 use Equed\EquedLms\Domain\Model\LessonProgress;


### PR DESCRIPTION
## Summary
- remove unused `DateTimeImmutable` imports from service classes

## Testing
- `php -l equed-lms/Classes/Service/CourseCompletionService.php`
- `php -l equed-lms/Classes/Service/GptEvaluationService.php`
- `php -l equed-lms/Classes/Service/CourseStatusUpdaterService.php`
- `php -l equed-lms/Classes/Service/CertificateService.php`
- `php -l equed-lms/Classes/Service/ExamService.php`
- `php -l equed-lms/Classes/Service/LessonProgressService.php`
- `find equed-lms/Classes/Service -name '*.php' | xargs -I{} php -l {}`


------
https://chatgpt.com/codex/tasks/task_e_684ca95fbe388324a03aaf6ccd07648f