### PR TITLE
Add LearningPathRepositoryInterface and update BadgeAwardService DI

### DIFF
--- a/equed-lms/Classes/Domain/Repository/LearningPathRepositoryInterface.php
+++ b/equed-lms/Classes/Domain/Repository/LearningPathRepositoryInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Domain\Repository;
+
+use Equed\EquedLms\Domain\Model\LearningPath;
+
+interface LearningPathRepositoryInterface
+{
+    /**
+     * @return LearningPath[]
+     */
+    public function findCompletedWithoutBadge(): array;
+}

--- a/equed-lms/Classes/Service/BadgeAwardService.php
+++ b/equed-lms/Classes/Service/BadgeAwardService.php
@@ -5,16 +5,16 @@ declare(strict_types=1);
 namespace Equed\EquedLms\Service;
 
 use Equed\EquedLms\Domain\Repository\BadgeAwardRepositoryInterface;
-use Equed\EquedLms\Domain\Repository\UserCourseRecordRepository;
-use Equed\EquedLms\Domain\Repository\LearningPathRepository;
+use Equed\EquedLms\Domain\Repository\UserCourseRecordRepositoryInterface;
+use Equed\EquedLms\Domain\Repository\LearningPathRepositoryInterface;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 
 final class BadgeAwardService
 {
     public function __construct(
         private readonly BadgeAwardRepositoryInterface       $awardRepo,
-        private readonly UserCourseRecordRepository $courseRecordRepo,
-        private readonly LearningPathRepository     $learningPathRepo,
+        private readonly UserCourseRecordRepositoryInterface $courseRecordRepo,
+        private readonly LearningPathRepositoryInterface     $learningPathRepo,
         private readonly GptTranslationServiceInterface      $translationService
     ) {
     }

--- a/equed-lms/Configuration/Services/Services.yaml
+++ b/equed-lms/Configuration/Services/Services.yaml
@@ -67,6 +67,9 @@ services:
   Equed\EquedLms\Domain\Repository\LessonRepositoryInterface:
     class: Equed\EquedLms\Domain\Repository\LessonRepository
 
+  Equed\EquedLms\Domain\Repository\LearningPathRepositoryInterface:
+    class: Equed\EquedLms\Domain\Repository\LearningPathRepository
+
   Equed\EquedLms\Domain\Service\DashboardServiceInterface:
     class: Equed\EquedLms\Service\DashboardService
 

--- a/equed-lms/Tests/Unit/Service/BadgeAwardServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/BadgeAwardServiceTest.php
@@ -16,8 +16,8 @@ namespace Equed\EquedLms\Tests\Unit\Service;
 
 use Equed\EquedLms\Service\BadgeAwardService;
 use Equed\EquedLms\Domain\Repository\BadgeAwardRepositoryInterface;
-use Equed\EquedLms\Domain\Repository\UserCourseRecordRepository;
-use Equed\EquedLms\Domain\Repository\LearningPathRepository;
+use Equed\EquedLms\Domain\Repository\UserCourseRecordRepositoryInterface;
+use Equed\EquedLms\Domain\Repository\LearningPathRepositoryInterface;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
@@ -45,9 +45,9 @@ class BadgeAwardServiceTest extends TestCase
         $awardRepo->addForCourse(1, 2, 'c')->shouldBeCalled();
         $awardRepo->addForLearningPath(1, 3, 'p')->shouldBeCalled();
 
-        $courseRepo = $this->prophesize(UserCourseRecordRepository::class);
+        $courseRepo = $this->prophesize(UserCourseRecordRepositoryInterface::class);
         $courseRepo->findCompletedWithoutBadge()->willReturn([$record]);
-        $lpRepo = $this->prophesize(LearningPathRepository::class);
+        $lpRepo = $this->prophesize(LearningPathRepositoryInterface::class);
         $lpRepo->findCompletedWithoutBadge()->willReturn([$path]);
 
         $translator = $this->prophesize(GptTranslationServiceInterface::class);


### PR DESCRIPTION
## Summary
- add `LearningPathRepositoryInterface`
- inject interfaces into `BadgeAwardService`
- wire `LearningPathRepositoryInterface` in DI configuration
- update unit test to use repository interfaces

## Testing
- `composer install` *(fails: composer not found)*
- `vendor/bin/phpunit --version` *(fails: vendor not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cadcd13648324a5a477a85afb2a1c