### PR TITLE
Translate exam notifications

### DIFF
--- a/equed-lms/Classes/Service/ExamNotificationService.php
+++ b/equed-lms/Classes/Service/ExamNotificationService.php
@@ -8,6 +8,8 @@ use Equed\EquedLms\Domain\Repository\CourseInstanceRepositoryInterface;
 use Equed\EquedLms\Domain\Repository\FrontendUserRepositoryInterface;
 use Equed\EquedLms\Domain\Model\FrontendUser;
 use Equed\EquedLms\Domain\Service\ExamNotificationServiceInterface;
+use Equed\EquedLms\Service\MailServiceInterface;
+use Equed\EquedLms\Domain\Service\LanguageServiceInterface;
 
 /**
  * Simple implementation that notifies assigned examiners about upcoming exams.
@@ -18,6 +20,7 @@ final class ExamNotificationService implements ExamNotificationServiceInterface
         private readonly CourseInstanceRepositoryInterface $courseInstanceRepository,
         private readonly FrontendUserRepositoryInterface $frontendUserRepository,
         private readonly MailServiceInterface $mailService,
+        private readonly LanguageServiceInterface $languageService,
     ) {
     }
 
@@ -29,8 +32,11 @@ final class ExamNotificationService implements ExamNotificationServiceInterface
         foreach ($instances as $instance) {
             $examiner = $instance->getExternalExaminer();
             if ($examiner instanceof FrontendUser && $examiner->getEmail() !== '') {
-                $subject = 'Upcoming exam reminder';
-                $body = sprintf('An exam for "%s" is scheduled soon.', $instance->getTitle());
+                $subject = $this->languageService->translate('notification.exam.subject');
+                $body = $this->languageService->translate(
+                    'notification.exam.body',
+                    ['course' => $instance->getTitle()]
+                );
                 $this->mailService->sendMail($examiner->getEmail(), $subject, $body);
                 ++$count;
             }

--- a/equed-lms/Resources/Private/Language/locallang_db.de.xlf
+++ b/equed-lms/Resources/Private/Language/locallang_db.de.xlf
@@ -516,6 +516,10 @@
         <source>Created at</source><target>Erstellt am</target></trans-unit>
       <trans-unit id="tx_equedlms_domain_model_courseexamslot.updated_at">
         <source>Updated at</source><target>Aktualisiert am</target></trans-unit>
+      <trans-unit id="notification.exam.subject">
+        <source>Upcoming exam reminder</source><target>Erinnerung an anstehende Prüfung</target></trans-unit>
+      <trans-unit id="notification.exam.body">
+        <source>An exam for "{course}" is scheduled soon.</source><target>Eine Prüfung für "{course}" findet bald statt.</target></trans-unit>
     </body>
   </file>
 </xliff>

--- a/equed-lms/Resources/Private/Language/locallang_db.easy.xlf
+++ b/equed-lms/Resources/Private/Language/locallang_db.easy.xlf
@@ -473,6 +473,10 @@
         <source>Created at</source><target>Created at</target></trans-unit>
       <trans-unit id="tx_equedlms_domain_model_courseexamslot.updated_at">
         <source>Updated at</source><target>Updated at</target></trans-unit>
+      <trans-unit id="notification.exam.subject">
+        <source>Upcoming exam reminder</source><target>Upcoming exam reminder</target></trans-unit>
+      <trans-unit id="notification.exam.body">
+        <source>An exam for "{course}" is scheduled soon.</source><target>An exam for "{course}" is scheduled soon.</target></trans-unit>
     </body>
   </file>
 </xliff>

--- a/equed-lms/Resources/Private/Language/locallang_db.en.xlf
+++ b/equed-lms/Resources/Private/Language/locallang_db.en.xlf
@@ -793,6 +793,12 @@
       <trans-unit id="tx_equedlms_domain_model_courseexamslot.updated_at">
         <source>Updated at</source>
       </trans-unit>
+      <trans-unit id="notification.exam.subject">
+        <source>Upcoming exam reminder</source>
+      </trans-unit>
+      <trans-unit id="notification.exam.body">
+        <source>An exam for "{course}" is scheduled soon.</source>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/equed-lms/Resources/Private/Language/locallang_db.es.xlf
+++ b/equed-lms/Resources/Private/Language/locallang_db.es.xlf
@@ -495,6 +495,10 @@
         <source>Created at</source><target>Creado el</target></trans-unit>
       <trans-unit id="tx_equedlms_domain_model_courseexamslot.updated_at">
         <source>Updated at</source><target>Actualizado el</target></trans-unit>
+      <trans-unit id="notification.exam.subject">
+        <source>Upcoming exam reminder</source><target>Recordatorio de examen próximo</target></trans-unit>
+      <trans-unit id="notification.exam.body">
+        <source>An exam for "{course}" is scheduled soon.</source><target>Se programó pronto un examen para "{course}".</target></trans-unit>
     </body>
   </file>
 </xliff>

--- a/equed-lms/Resources/Private/Language/locallang_db.fr.xlf
+++ b/equed-lms/Resources/Private/Language/locallang_db.fr.xlf
@@ -495,6 +495,10 @@
         <source>Created at</source><target>Créé le</target></trans-unit>
       <trans-unit id="tx_equedlms_domain_model_courseexamslot.updated_at">
         <source>Updated at</source><target>Mis à jour le</target></trans-unit>
+      <trans-unit id="notification.exam.subject">
+        <source>Upcoming exam reminder</source><target>Rappel d'examen à venir</target></trans-unit>
+      <trans-unit id="notification.exam.body">
+        <source>An exam for "{course}" is scheduled soon.</source><target>Un examen pour "{course}" est prévu prochainement.</target></trans-unit>
     </body>
   </file>
 </xliff>

--- a/equed-lms/Resources/Private/Language/locallang_db.sw.xlf
+++ b/equed-lms/Resources/Private/Language/locallang_db.sw.xlf
@@ -495,6 +495,10 @@
         <source>Created at</source><target>Skapad</target></trans-unit>
       <trans-unit id="tx_equedlms_domain_model_courseexamslot.updated_at">
         <source>Updated at</source><target>Uppdaterad</target></trans-unit>
+      <trans-unit id="notification.exam.subject">
+        <source>Upcoming exam reminder</source><target>Påminnelse om kommande prov</target></trans-unit>
+      <trans-unit id="notification.exam.body">
+        <source>An exam for "{course}" is scheduled soon.</source><target>Ett prov för "{course}" är planerat snart.</target></trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
## Summary
- inject `LanguageServiceInterface` into `ExamNotificationService`
- translate subject and body via `languageService`
- add exam notification translations for all languages

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cafd0320083249d85def8af8b1fe1