### PR TITLE
Update SyncController to use UserProfile

### DIFF
--- a/equed-lms/Classes/Service/SyncService.php
+++ b/equed-lms/Classes/Service/SyncService.php
@@ -34,7 +34,11 @@ final class SyncService
     public function pullFromApp(array $data): UserProfile
     {
         $userId = isset($data['userId']) ? (int) $data['userId'] : 0;
-        $profile = $this->profileRepository->findByUserId($userId) ?? new UserProfile();
+        $profile = $this->profileRepository->findByUserId($userId);
+        if ($profile === null) {
+            $profile = new UserProfile();
+            $profile->setUpdatedAt($this->clock->now());
+        }
 
         // Set user reference
         $profile->setFeUser($userId);

--- a/equed-lms/Tests/Unit/Controller/SyncControllerTest.php
+++ b/equed-lms/Tests/Unit/Controller/SyncControllerTest.php
@@ -1,0 +1,100 @@
+<?php
+declare(strict_types=1);
+
+namespace Equed\Core\Service;
+if (!interface_exists(ClockInterface::class)) {
+    interface ClockInterface { public function now(): \DateTimeImmutable; }
+}
+if (!interface_exists(UuidGeneratorInterface::class)) {
+    interface UuidGeneratorInterface { public function generate(): string; }
+}
+
+namespace TYPO3\CMS\Extbase\Domain\Model;
+if (!class_exists(FrontendUser::class)) {
+    class FrontendUser
+    {
+        private array $properties = [];
+
+        public function _setProperty(string $name, mixed $value): void
+        {
+            $this->properties[$name] = $value;
+        }
+
+        public function _getProperty(string $name): mixed
+        {
+            return $this->properties[$name] ?? null;
+        }
+    }
+}
+
+namespace Equed\EquedLms\Tests\Unit\Controller;
+
+use Equed\EquedLms\Controller\Api\SyncController;
+use Equed\EquedLms\Service\SyncService;
+use Equed\EquedLms\Service\GptTranslationServiceInterface;
+use Equed\EquedLms\Domain\Repository\UserProfileRepositoryInterface;
+use Equed\EquedLms\Domain\Model\UserProfile;
+use TYPO3\CMS\Core\Context\Context;
+use Psr\Http\Message\ServerRequestInterface;
+use PHPUnit\Framework\TestCase;
+use Equed\EquedLms\Tests\Traits\ProphecyTrait;
+use TYPO3\CMS\Core\Http\JsonResponse;
+use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
+use Equed\Core\Service\ClockInterface;
+use Equed\EquedLms\Domain\Service\ClockInterface as DomainClockInterface;
+
+class SyncControllerTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private SyncController $subject;
+    private $service;
+    private $repo;
+    private $translator;
+    private $context;
+
+    protected function setUp(): void
+    {
+        $this->repo = $this->prophesize(UserProfileRepositoryInterface::class);
+        $pm = $this->prophesize(PersistenceManagerInterface::class);
+        $clock = $this->prophesize(DomainClockInterface::class);
+        $this->service = new SyncService($this->repo->reveal(), $pm->reveal(), $clock->reveal());
+        $this->translator = $this->prophesize(GptTranslationServiceInterface::class);
+        $this->context = $this->prophesize(Context::class);
+
+        $ref = new \ReflectionClass(SyncController::class);
+        $this->subject = $ref->newInstanceWithoutConstructor();
+
+        foreach (['syncService' => $this->service, 'profileRepository' => $this->repo->reveal(), 'translationService' => $this->translator->reveal(), 'context' => $this->context->reveal()] as $prop => $value) {
+            $p = new \ReflectionProperty($this->subject, $prop);
+            $p->setAccessible(true);
+            $p->setValue($this->subject, $value);
+        }
+    }
+
+    public function testPushActionLoadsProfileAndDelegates(): void
+    {
+        $req = $this->prophesize(ServerRequestInterface::class);
+        $req->getQueryParams()->willReturn(['userId' => 5]);
+
+        $profile = new UserProfile();
+        $prop = new \ReflectionProperty($profile, 'clock');
+        $prop->setAccessible(true);
+        $prop->setValue($profile, new class implements ClockInterface {
+            public function now(): \DateTimeImmutable { return new \DateTimeImmutable('2024-01-01T00:00:00+00:00'); }
+        });
+        $prop = new \ReflectionProperty($profile, 'uuidGenerator');
+        $prop->setAccessible(true);
+        $prop->setValue($profile, new class implements \Equed\Core\Service\UuidGeneratorInterface { public function generate(): string { return 'u1'; } });
+        $profile->initializeObject();
+        $profile->setFeUser(5);
+        $profile->setDisplayName('John');
+        $profile->setLanguage('en');
+        $profile->setCountry('US');
+
+        $this->repo->findByUserId(5)->willReturn($profile)->shouldBeCalled();
+
+        $res = $this->subject->pushAction($req->reveal());
+        $this->assertInstanceOf(JsonResponse::class, $res);
+    }
+}

--- a/equed-lms/Tests/Unit/Service/SyncServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/SyncServiceTest.php
@@ -2,18 +2,71 @@
 
 declare(strict_types=1);
 
-namespace Ramsey\Uuid { if (!class_exists(Uuid::class)) { class Uuid { public static function uuid4(){ return new class { public function toString(){ return 'generated'; } }; } } } }
+namespace Ramsey\Uuid;
+
+if (!class_exists(Uuid::class)) {
+    class Uuid
+    {
+        public static function uuid4()
+        {
+            return new class {
+                public function toString()
+                {
+                    return 'generated';
+                }
+            };
+        }
+    }
+}
+
+namespace Equed\Core\Service;
+
+interface UuidGeneratorInterface { public function generate(): string; }
+interface ClockInterface { public function now(): \DateTimeImmutable; }
+
+namespace TYPO3\CMS\Extbase\Domain\Model;
+
+if (!class_exists(FrontendUser::class)) {
+    class FrontendUser
+    {
+        private array $properties = [];
+
+        public function _setProperty(string $name, mixed $value): void
+        {
+            $this->properties[$name] = $value;
+        }
+
+        public function _getProperty(string $name): mixed
+        {
+            return $this->properties[$name] ?? null;
+        }
+    }
+}
 
 namespace Equed\EquedLms\Tests\Unit\Service;
 
 use Equed\EquedLms\Domain\Model\UserProfile;
 use Equed\EquedLms\Domain\Repository\UserProfileRepositoryInterface;
 use Equed\EquedLms\Service\SyncService;
-use Equed\EquedLms\Domain\Service\ClockInterface;
+use Equed\Core\Service\ClockInterface;
+use Equed\EquedLms\Domain\Service\ClockInterface as DomainClockInterface;
+use Equed\Core\Service\UuidGeneratorInterface;
 use PHPUnit\Framework\TestCase;
 use Equed\EquedLms\Tests\Traits\ProphecyTrait;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 use Prophecy\Argument;
+
+class FakeClock implements ClockInterface, DomainClockInterface
+{
+    public function __construct(private \DateTimeImmutable $now) {}
+    public function now(): \DateTimeImmutable { return $this->now; }
+}
+
+class FakeUuidGenerator implements UuidGeneratorInterface
+{
+    public function __construct(private string $uuid) {}
+    public function generate(): string { return $this->uuid; }
+}
 
 class SyncServiceTest extends TestCase
 {
@@ -22,7 +75,13 @@ class SyncServiceTest extends TestCase
     public function testPushToAppMapsFields(): void
     {
         $profile = new UserProfile();
-        $profile->setUuid('abc');
+        $prop = new \ReflectionProperty($profile, 'clock');
+        $prop->setAccessible(true);
+        $prop->setValue($profile, new FakeClock(new \DateTimeImmutable('2024-01-01T00:00:00+00:00')));
+        $prop = new \ReflectionProperty($profile, 'uuidGenerator');
+        $prop->setAccessible(true);
+        $prop->setValue($profile, new FakeUuidGenerator('abc'));
+        $profile->initializeObject();
         $profile->setFeUser(5);
         $profile->setDisplayName('John');
         $profile->setLanguage('de');
@@ -31,7 +90,7 @@ class SyncServiceTest extends TestCase
 
         $repo = $this->prophesize(UserProfileRepositoryInterface::class);
         $pm = $this->prophesize(PersistenceManagerInterface::class);
-        $clock = $this->prophesize(ClockInterface::class);
+        $clock = $this->prophesize(DomainClockInterface::class);
         $service = new SyncService($repo->reveal(), $pm->reveal(), $clock->reveal());
 
         $data = $service->pushToApp($profile);
@@ -47,7 +106,8 @@ class SyncServiceTest extends TestCase
 
         $pm = $this->prophesize(PersistenceManagerInterface::class);
         $pm->persistAll()->shouldBeCalled();
-        $clock = $this->prophesize(ClockInterface::class);
+        $clock = $this->prophesize(DomainClockInterface::class);
+        $clock->now()->willReturn(new \DateTimeImmutable('2024-01-02T00:00:00+00:00'));
 
         $service = new SyncService($repo->reveal(), $pm->reveal(), $clock->reveal());
         $result = $service->pullFromApp([


### PR DESCRIPTION
## Summary
- inject UserProfileRepository into SyncController
- load profile before pushing data to app
- ensure new profiles have `updatedAt` set in SyncService
- fix SyncServiceTest namespace stubs
- add SyncControllerTest covering push action

## Testing
- `vendor/bin/phpunit Tests/Unit/Service/SyncServiceTest.php Tests/Unit/Controller/SyncControllerTest.php`

------
https://chatgpt.com/codex/tasks/task_e_684cba02a2c4832499c4eda7b3eaff13