### PR TITLE
Switch LessonProgress status to enum

### DIFF
--- a/equed-lms/Classes/Domain/Model/LessonProgress.php
+++ b/equed-lms/Classes/Domain/Model/LessonProgress.php
@@ -10,6 +10,7 @@ use TYPO3\CMS\Extbase\Annotation\ORM\Cascade;
 use TYPO3\CMS\Extbase\Annotation\ORM\Lazy;
 use TYPO3\CMS\Extbase\Annotation\ORM\ManyToOne;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
+use Equed\EquedLms\Enum\ProgressStatus;
 
 /**
  * Represents the progress state of a user for a specific lesson.
@@ -35,9 +36,9 @@ final class LessonProgress extends AbstractEntity
     protected int $progress = 0;
 
     /**
-     * Status string (e.g. incomplete, completed)
+     * Status of the lesson progress.
      */
-    protected string $status = 'incomplete';
+    protected ProgressStatus $status = ProgressStatus::NotStarted;
 
     protected string $uuid;
 
@@ -137,13 +138,17 @@ final class LessonProgress extends AbstractEntity
         $this->progress = $progress;
     }
 
-    public function getStatus(): string
+    public function getStatus(): ProgressStatus
     {
         return $this->status;
     }
 
-    public function setStatus(string $status): void
+    public function setStatus(ProgressStatus|string $status): void
     {
+        if (is_string($status)) {
+            $status = ProgressStatus::from($status);
+        }
+
         $this->status = $status;
     }
 

--- a/equed-lms/Classes/Service/CourseGoalService.php
+++ b/equed-lms/Classes/Service/CourseGoalService.php
@@ -7,6 +7,7 @@ namespace Equed\EquedLms\Service;
 use Equed\EquedLms\Domain\Model\CourseGoal;
 use Equed\EquedLms\Domain\Repository\CourseGoalRepositoryInterface;
 use Equed\EquedLms\Domain\Service\CourseGoalServiceInterface;
+use Equed\EquedLms\Enum\ProgressStatus;
 
 /**
  * Service to manage course goals retrieval and evaluation.
@@ -80,7 +81,16 @@ final class CourseGoalService implements CourseGoalServiceInterface
             $lesson = $progress->getLesson();
             $goal = $lesson?->getCourseGoal();
 
-            if ($goal?->getUid() === $goalId && $progress->getStatus() === 'completed') {
+            if ($goal?->getUid() !== $goalId) {
+                continue;
+            }
+
+            $status = $progress->getStatus();
+            if ($status instanceof ProgressStatus) {
+                if ($status === ProgressStatus::Completed) {
+                    return true;
+                }
+            } elseif ($status === 'completed') {
                 return true;
             }
         }

--- a/equed-lms/Classes/Service/LessonProgressService.php
+++ b/equed-lms/Classes/Service/LessonProgressService.php
@@ -9,6 +9,7 @@ use Equed\EquedLms\Domain\Model\Lesson;
 use Equed\EquedLms\Domain\Model\LessonProgress;
 use Equed\EquedLms\Domain\Repository\LessonProgressRepositoryInterface;
 use Equed\EquedLms\Domain\Model\FrontendUser;
+use Equed\EquedLms\Enum\ProgressStatus;
 
 /**
  * Service to manage lesson progress for users.
@@ -53,7 +54,7 @@ final class LessonProgressService
             $progress->setLesson($lesson);
         }
 
-        $progress->setStatus('completed');
+        $progress->setStatus(ProgressStatus::Completed);
         $progress->setCompleted(true);
         $progress->setCompletedAt($this->clock->now());
 

--- a/equed-lms/Classes/Service/LessonProgressSyncService.php
+++ b/equed-lms/Classes/Service/LessonProgressSyncService.php
@@ -8,6 +8,7 @@ use Equed\EquedLms\Domain\Repository\LessonProgressRepositoryInterface;
 use Equed\EquedLms\Domain\Repository\LessonRepositoryInterface;
 use Equed\EquedLms\Domain\Model\LessonProgress;
 use Equed\EquedLms\Domain\Model\Lesson;
+use Equed\EquedLms\Enum\ProgressStatus;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 use Equed\EquedLms\Domain\Service\ClockInterface;
 
@@ -30,7 +31,7 @@ final class LessonProgressSyncService
             $result[] = [
                 'lessonId'   => $entry->getLesson()->getUid(),
                 'progress'   => $entry->getProgress(),
-                'status'     => $entry->getStatus(),
+                'status'     => $entry->getStatus()->value,
                 'completed'  => $entry->isCompleted(),
                 'updatedAt'  => $entry->getUpdatedAt()?->format(DATE_ATOM),
             ];
@@ -55,7 +56,8 @@ final class LessonProgressSyncService
                 $entry->setFeUser($userId);
                 $entry->setLesson($lesson);
                 $entry->setProgress((int) $item['progress']);
-                $entry->setStatus($item['status'] ?? 'incomplete');
+                $statusValue = $item['status'] ?? 'notStarted';
+                $entry->setStatus(ProgressStatus::from($statusValue));
                 $entry->setCompleted((bool) $item['completed']);
                 $entry->setUpdatedAt($this->clock->now());
             }

--- a/equed-lms/Configuration/TCA/tx_equedlms_domain_model_lessonprogress.php
+++ b/equed-lms/Configuration/TCA/tx_equedlms_domain_model_lessonprogress.php
@@ -137,7 +137,7 @@ return [
             'label'   => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_lessonprogress.status',
             'config'  => [
                 'type'    => 'input',
-                'default' => 'incomplete',
+                'default' => 'notStarted',
             ],
         ],
         'uuid' => [

--- a/equed-lms/Tests/Unit/Domain/Model/LessonProgressTest.php
+++ b/equed-lms/Tests/Unit/Domain/Model/LessonProgressTest.php
@@ -6,6 +6,7 @@ namespace Equed\EquedLms\Tests\Unit\Domain\Model;
 
 use PHPUnit\Framework\TestCase;
 use Equed\EquedLms\Domain\Model\LessonProgress;
+use Equed\EquedLms\Enum\ProgressStatus;
 
 class LessonProgressTest extends TestCase
 {
@@ -15,6 +16,7 @@ class LessonProgressTest extends TestCase
         $this->assertNotEmpty($progress->getUuid());
         $this->assertInstanceOf(\DateTimeImmutable::class, $progress->getCreatedAt());
         $this->assertInstanceOf(\DateTimeImmutable::class, $progress->getUpdatedAt());
+        $this->assertSame(ProgressStatus::NotStarted, $progress->getStatus());
     }
 
     public function testProgressAccessors(): void

--- a/equed-lms/Tests/Unit/Service/LessonProgressServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/LessonProgressServiceTest.php
@@ -11,6 +11,7 @@ use Equed\EquedLms\Domain\Repository\LessonProgressRepositoryInterface;
 use Equed\EquedLms\Domain\Model\LessonProgress;
 use Equed\EquedLms\Domain\Model\Lesson;
 use TYPO3\CMS\Extbase\Domain\Model\FrontendUser;
+use Equed\EquedLms\Enum\ProgressStatus;
 
 class LessonProgressServiceTest extends TestCase
 {
@@ -36,7 +37,7 @@ class LessonProgressServiceTest extends TestCase
         $this->repo->updateOrAdd(\Prophecy\Argument::type(LessonProgress::class))->shouldBeCalled();
 
         $progress = $this->subject->setProgressCompleted($user->reveal(), $lesson->reveal());
-        $this->assertSame('completed', $progress->getStatus());
+        $this->assertSame(ProgressStatus::Completed, $progress->getStatus());
         $this->assertTrue($progress->isCompleted());
     }
 }


### PR DESCRIPTION
## Summary
- use `ProgressStatus` enum in LessonProgress model
- update lesson progress services and TCA configuration
- adjust CourseGoalService to work with enum
- fix related unit tests

## Testing
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d302ffac08324a6646c58ca696a0c