### PR TITLE
Switch Course startDate to DateTimeImmutable

### DIFF
--- a/equed-lms/Classes/Domain/Model/Course.php
+++ b/equed-lms/Classes/Domain/Model/Course.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Equed\EquedLms\Domain\Model;
 
+use DateTimeImmutable;
 use TYPO3\CMS\Extbase\Annotation as Extbase;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 use Equed\EquedLms\Domain\Model\LearningPath;
@@ -28,7 +29,7 @@ final class Course extends AbstractEntity
     #[Extbase\ORM\Lazy]
     protected ?CourseProgram $courseProgram = null;
 
-    protected int $startDate = 0;
+    protected ?DateTimeImmutable $startDate = null;
 
     protected string $location = '';
 
@@ -72,12 +73,12 @@ final class Course extends AbstractEntity
         $this->courseProgram = $courseProgram;
     }
 
-    public function getStartDate(): int
+    public function getStartDate(): ?DateTimeImmutable
     {
         return $this->startDate;
     }
 
-    public function setStartDate(int $startDate): void
+    public function setStartDate(?DateTimeImmutable $startDate): void
     {
         $this->startDate = $startDate;
     }

--- a/equed-lms/Configuration/Schema/Domain/Model/Course.yaml
+++ b/equed-lms/Configuration/Schema/Domain/Model/Course.yaml
@@ -13,6 +13,7 @@ columns:
   courseprogram:
     type: integer
   start_date:
+    # stored as UNIX timestamp
     type: integer
   location:
     type: string

--- a/equed-lms/Configuration/TCA/tx_equedlms_domain_model_course.php
+++ b/equed-lms/Configuration/TCA/tx_equedlms_domain_model_course.php
@@ -47,7 +47,7 @@ return [
             'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_course.start_date',
             'config' => [
                 'type' => 'input',
-                'eval' => 'int'
+                'eval' => 'date'
             ]
         ],
         'location' => [


### PR DESCRIPTION
## Summary
- use `DateTimeImmutable` for `Course::$startDate`
- align TCA configuration to accept dates
- document timestamp type in schema

## Testing
- `composer phpstan` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d3807326c83249037261e87a45789