### PR TITLE
Use enum objects for QMS and submission reviews

### DIFF
--- a/equed-lms/Classes/Domain/Model/QmsCase.php
+++ b/equed-lms/Classes/Domain/Model/QmsCase.php
@@ -7,6 +7,8 @@ namespace Equed\EquedLms\Domain\Model;
 use DateTimeImmutable;
 use Equed\Core\Service\ClockInterface;
 use Equed\Core\Service\UuidGeneratorInterface;
+use Equed\EquedLms\Enum\QmsCaseStatus;
+use Equed\EquedLms\Enum\QmsCaseType;
 use TYPO3\CMS\Extbase\Annotation\Inject;
 use TYPO3\CMS\Extbase\Annotation\ORM\Cascade;
 use TYPO3\CMS\Extbase\Annotation\ORM\Lazy;
@@ -52,9 +54,9 @@ final class QmsCase extends AbstractEntity
 
     protected ?string $titleKey = null;
 
-    protected string $caseType = 'violation';
+    protected QmsCaseType $caseType = QmsCaseType::Violation;
 
-    protected string $status = 'open';
+    protected QmsCaseStatus $status = QmsCaseStatus::Open;
 
     protected string $priority = 'normal';
 
@@ -221,7 +223,7 @@ final class QmsCase extends AbstractEntity
     /**
      * Gets the case type.
      */
-    public function getCaseType(): string
+    public function getCaseType(): QmsCaseType
     {
         return $this->caseType;
     }
@@ -229,15 +231,18 @@ final class QmsCase extends AbstractEntity
     /**
      * Sets the case type.
      */
-    public function setCaseType(string $caseType): void
+    public function setCaseType(QmsCaseType|string $caseType): void
     {
+        if (is_string($caseType)) {
+            $caseType = QmsCaseType::from($caseType);
+        }
         $this->caseType = $caseType;
     }
 
     /**
      * Gets the case status.
      */
-    public function getStatus(): string
+    public function getStatus(): QmsCaseStatus
     {
         return $this->status;
     }
@@ -245,8 +250,11 @@ final class QmsCase extends AbstractEntity
     /**
      * Sets the case status.
      */
-    public function setStatus(string $status): void
+    public function setStatus(QmsCaseStatus|string $status): void
     {
+        if (is_string($status)) {
+            $status = QmsCaseStatus::from($status);
+        }
         $this->status = $status;
     }
 

--- a/equed-lms/Classes/Domain/Model/SubmissionReview.php
+++ b/equed-lms/Classes/Domain/Model/SubmissionReview.php
@@ -7,6 +7,7 @@ namespace Equed\EquedLms\Domain\Model;
 use DateTimeImmutable;
 use Equed\Core\Service\ClockInterface;
 use Equed\Core\Service\UuidGeneratorInterface;
+use Equed\EquedLms\Enum\SubmissionReviewStatus;
 use TYPO3\CMS\Extbase\Annotation\Inject;
 use TYPO3\CMS\Extbase\Annotation\ORM\Cascade;
 use TYPO3\CMS\Extbase\Annotation\ORM\Lazy;
@@ -36,7 +37,7 @@ final class SubmissionReview extends AbstractEntity
     #[Lazy]
     protected ?FrontendUser $reviewedBy = null;
 
-    protected string $status = 'open';
+    protected SubmissionReviewStatus $status = SubmissionReviewStatus::Open;
 
     protected ?string $comment = null;
 
@@ -122,7 +123,7 @@ final class SubmissionReview extends AbstractEntity
     /**
      * Gets the review status.
      */
-    public function getStatus(): string
+    public function getStatus(): SubmissionReviewStatus
     {
         return $this->status;
     }
@@ -132,8 +133,11 @@ final class SubmissionReview extends AbstractEntity
      *
      * @param string $status
      */
-    public function setStatus(string $status): void
+    public function setStatus(SubmissionReviewStatus|string $status): void
     {
+        if (is_string($status)) {
+            $status = SubmissionReviewStatus::from($status);
+        }
         $this->status = $status;
     }
 

--- a/equed-lms/Classes/Domain/Repository/QmsCaseRepository.php
+++ b/equed-lms/Classes/Domain/Repository/QmsCaseRepository.php
@@ -6,6 +6,7 @@ namespace Equed\EquedLms\Domain\Repository;
 
 use Equed\EquedLms\Domain\Model\QmsCase;
 use Equed\EquedLms\Domain\Model\FrontendUser;
+use Equed\EquedLms\Enum\QmsCaseStatus;
 use TYPO3\CMS\Extbase\Persistence\QueryInterface;
 use TYPO3\CMS\Extbase\Persistence\Repository;
 
@@ -29,7 +30,7 @@ final class QmsCaseRepository extends Repository
     {
         $query = $this->createQuery();
         $query->matching(
-            $query->equals('status', 'open')
+            $query->equals('status', QmsCaseStatus::Open->value)
         );
 
         return $query->execute()->toArray();

--- a/equed-lms/Classes/Enum/QmsCaseStatus.php
+++ b/equed-lms/Classes/Enum/QmsCaseStatus.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Enum;
+
+/**
+ * Status values for QmsCase entities.
+ */
+enum QmsCaseStatus: string
+{
+    case Open = 'open';
+    case InProgress = 'in_progress';
+    case Closed = 'closed';
+}

--- a/equed-lms/Classes/Enum/QmsCaseType.php
+++ b/equed-lms/Classes/Enum/QmsCaseType.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Enum;
+
+/**
+ * Types of QmsCase.
+ */
+enum QmsCaseType: string
+{
+    case Violation = 'violation';
+    case Complaint = 'complaint';
+    case Audit = 'audit';
+}

--- a/equed-lms/Classes/Enum/SubmissionReviewStatus.php
+++ b/equed-lms/Classes/Enum/SubmissionReviewStatus.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Enum;
+
+/**
+ * Possible status values for SubmissionReview entities.
+ */
+enum SubmissionReviewStatus: string
+{
+    case Open = 'open';
+    case Approved = 'approved';
+    case Rejected = 'rejected';
+}

--- a/equed-lms/Configuration/Schema/Domain/Model/Submissionreview.yaml
+++ b/equed-lms/Configuration/Schema/Domain/Model/Submissionreview.yaml
@@ -9,7 +9,7 @@ columns:
   reviewed_by:
     type: integer
   status:
-    type: integer
+    type: string
   comment:
     type: text
   evaluation_document:

--- a/equed-lms/Configuration/TCA/Overrides/tx_equedlms_domain_model_qmscase.php
+++ b/equed-lms/Configuration/TCA/Overrides/tx_equedlms_domain_model_qmscase.php
@@ -74,15 +74,27 @@ use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
         'case_type' => [
             'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:qmscase.case_type',
             'config' => [
-                'type' => 'input',
-                'eval' => 'trim',
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'items' => [
+                    ['Violation', \Equed\EquedLms\Enum\QmsCaseType::Violation->value],
+                    ['Complaint', \Equed\EquedLms\Enum\QmsCaseType::Complaint->value],
+                    ['Audit', \Equed\EquedLms\Enum\QmsCaseType::Audit->value],
+                ],
+                'default' => \Equed\EquedLms\Enum\QmsCaseType::Violation->value,
             ],
         ],
         'status' => [
             'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:qmscase.status',
             'config' => [
-                'type' => 'input',
-                'eval' => 'trim',
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'items' => [
+                    ['Open', \Equed\EquedLms\Enum\QmsCaseStatus::Open->value],
+                    ['In Progress', \Equed\EquedLms\Enum\QmsCaseStatus::InProgress->value],
+                    ['Closed', \Equed\EquedLms\Enum\QmsCaseStatus::Closed->value],
+                ],
+                'default' => \Equed\EquedLms\Enum\QmsCaseStatus::Open->value,
             ],
         ],
         'priority' => [

--- a/equed-lms/Configuration/TCA/Overrides/tx_equedlms_domain_model_submissionreview.php
+++ b/equed-lms/Configuration/TCA/Overrides/tx_equedlms_domain_model_submissionreview.php
@@ -38,12 +38,11 @@ return [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
                 'items' => [
-                    ['Open', 'open'],
-                    ['Passed', 'passed'],
-                    ['Failed', 'failed'],
-                    ['Revision required', 'revision_required']
+                    ['Open', \Equed\EquedLms\Enum\SubmissionReviewStatus::Open->value],
+                    ['Approved', \Equed\EquedLms\Enum\SubmissionReviewStatus::Approved->value],
+                    ['Rejected', \Equed\EquedLms\Enum\SubmissionReviewStatus::Rejected->value],
                 ],
-                'default' => 'open'
+                'default' => \Equed\EquedLms\Enum\SubmissionReviewStatus::Open->value
             ]
         ],
         'comment' => [

--- a/equed-lms/Configuration/TCA/tx_equedlms_domain_model_qmscase.php
+++ b/equed-lms/Configuration/TCA/tx_equedlms_domain_model_qmscase.php
@@ -79,16 +79,28 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_qmscase.case_type',
             'config' => [
-                'type' => 'input',
-                'eval' => 'trim'
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'items' => [
+                    ['Violation', \Equed\EquedLms\Enum\QmsCaseType::Violation->value],
+                    ['Complaint', \Equed\EquedLms\Enum\QmsCaseType::Complaint->value],
+                    ['Audit', \Equed\EquedLms\Enum\QmsCaseType::Audit->value],
+                ],
+                'default' => \Equed\EquedLms\Enum\QmsCaseType::Violation->value,
             ]
         ],
         'status' => [
             'exclude' => true,
             'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_qmscase.status',
             'config' => [
-                'type' => 'input',
-                'eval' => 'trim'
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'items' => [
+                    ['Open', \Equed\EquedLms\Enum\QmsCaseStatus::Open->value],
+                    ['In Progress', \Equed\EquedLms\Enum\QmsCaseStatus::InProgress->value],
+                    ['Closed', \Equed\EquedLms\Enum\QmsCaseStatus::Closed->value],
+                ],
+                'default' => \Equed\EquedLms\Enum\QmsCaseStatus::Open->value,
             ]
         ],
         'priority' => [

--- a/equed-lms/Configuration/TCA/tx_equedlms_domain_model_submissionreview.php
+++ b/equed-lms/Configuration/TCA/tx_equedlms_domain_model_submissionreview.php
@@ -31,8 +31,14 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_submissionreview.status',
             'config' => [
-                'type' => 'input',
-                'eval' => 'int'
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'items' => [
+                    ['Open', \Equed\EquedLms\Enum\SubmissionReviewStatus::Open->value],
+                    ['Approved', \Equed\EquedLms\Enum\SubmissionReviewStatus::Approved->value],
+                    ['Rejected', \Equed\EquedLms\Enum\SubmissionReviewStatus::Rejected->value],
+                ],
+                'default' => \Equed\EquedLms\Enum\SubmissionReviewStatus::Open->value,
             ]
         ],
         'comment' => [

--- a/equed-lms/Tests/Unit/Service/QmsEscalationServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/QmsEscalationServiceTest.php
@@ -9,6 +9,7 @@ use Equed\EquedLms\Domain\Service\LanguageServiceInterface;
 use Equed\EquedLms\Service\LogService;
 use Equed\EquedLms\Service\MailServiceInterface;
 use Equed\EquedLms\Service\QmsEscalationService;
+use Equed\EquedLms\Enum\QmsCaseStatus;
 use Equed\EquedLms\Tests\Traits\ProphecyTrait;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -43,14 +44,14 @@ class QmsEscalationServiceTest extends TestCase
         $case = $this->prophesize(QmsCase::class);
         $case->getUid()->willReturn(5);
         $case->getIssue()->willReturn('issue');
-        $case->getStatus()->willReturn('open');
+        $case->getStatus()->willReturn(QmsCaseStatus::Open);
         $case->getFeUser()->willReturn(42);
 
         $this->language->translate('qms.escalation.subject', ['caseId' => 5], 'equed_lms')->willReturn('Subj');
         $this->language->translate('qms.escalation.body', [
             'caseId' => 5,
             'issue' => 'issue',
-            'status' => 'open',
+            'status' => QmsCaseStatus::Open->value,
             'userId' => 42,
         ], 'equed_lms')->willReturn('Body');
 


### PR DESCRIPTION
## Summary
- introduce `QmsCaseStatus`, `QmsCaseType` and `SubmissionReviewStatus` enums
- migrate `QmsCase` and `SubmissionReview` models to use enums
- update TCA configuration to expose enums in backend select fields
- adjust repository, schema, and unit tests for new enums

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d424de9f88324b09855cf119d9b3d