### PR TITLE
Introduce LanguageCode enum

### DIFF
--- a/equed-lms/Classes/Domain/Model/BadgeAward.php
+++ b/equed-lms/Classes/Domain/Model/BadgeAward.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 namespace Equed\EquedLms\Domain\Model;
+use Equed\EquedLms\Enum\LanguageCode;
 
 use DateTimeImmutable;
 use Equed\Core\Service\ClockInterface;
@@ -72,7 +73,7 @@ final class BadgeAward extends AbstractEntity
      *
      * @var string
      */
-    protected string $lang = 'en';
+    protected LanguageCode $lang = LanguageCode::EN;
 
     /**
      * Flag if system automatically awarded the badge
@@ -190,12 +191,12 @@ final class BadgeAward extends AbstractEntity
         $this->descriptionKey = $descriptionKey;
     }
 
-    public function getLang(): string
+    public function getLang(): LanguageCode
     {
         return $this->lang;
     }
 
-    public function setLang(string $lang): void
+    public function setLang(LanguageCode $lang): void
     {
         $this->lang = $lang;
     }

--- a/equed-lms/Classes/Domain/Model/CourseMaterial.php
+++ b/equed-lms/Classes/Domain/Model/CourseMaterial.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 namespace Equed\EquedLms\Domain\Model;
+use Equed\EquedLms\Enum\LanguageCode;
 
 use DateTimeImmutable;
 use Equed\Core\Service\ClockInterface;
@@ -47,7 +48,7 @@ final class CourseMaterial extends AbstractEntity
     #[Lazy]
     protected ?FrontendUser $uploadedBy = null;
 
-    protected string $lang = 'en';
+    protected LanguageCode $lang = LanguageCode::EN;
 
     protected string $requiredDocuLevel = 'none';
 
@@ -157,12 +158,12 @@ final class CourseMaterial extends AbstractEntity
         $this->uploadedBy = $uploadedBy;
     }
 
-    public function getLang(): string
+    public function getLang(): LanguageCode
     {
         return $this->lang;
     }
 
-    public function setLang(string $lang): void
+    public function setLang(LanguageCode $lang): void
     {
         $this->lang = $lang;
     }

--- a/equed-lms/Classes/Domain/Model/ExternalSystemSync.php
+++ b/equed-lms/Classes/Domain/Model/ExternalSystemSync.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 namespace Equed\EquedLms\Domain\Model;
+use Equed\EquedLms\Enum\LanguageCode;
 
 use DateTimeImmutable;
 use Ramsey\Uuid\Uuid;
@@ -67,7 +68,7 @@ final class ExternalSystemSync extends AbstractEntity
      *
      * @var string
      */
-    protected string $lang = 'en';
+    protected LanguageCode $lang = LanguageCode::EN;
 
     /**
      * Soft-delete flag
@@ -163,12 +164,12 @@ final class ExternalSystemSync extends AbstractEntity
         $this->errorMessage = $errorMessage;
     }
 
-    public function getLang(): string
+    public function getLang(): LanguageCode
     {
         return $this->lang;
     }
 
-    public function setLang(string $lang): void
+    public function setLang(LanguageCode $lang): void
     {
         $this->lang = $lang;
     }

--- a/equed-lms/Classes/Domain/Model/GlossaryTerm.php
+++ b/equed-lms/Classes/Domain/Model/GlossaryTerm.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 namespace Equed\EquedLms\Domain\Model;
+use Equed\EquedLms\Enum\LanguageCode;
 
 use DateTimeImmutable;
 use Ramsey\Uuid\Uuid;
@@ -57,7 +58,7 @@ final class GlossaryTerm extends AbstractEntity
      *
      * @var string
      */
-    protected string $lang = 'en';
+    protected LanguageCode $lang = LanguageCode::EN;
 
     /**
      * Optional icon reference
@@ -148,12 +149,12 @@ final class GlossaryTerm extends AbstractEntity
         $this->expertExplanation = $expertExplanation;
     }
 
-    public function getLang(): string
+    public function getLang(): LanguageCode
     {
         return $this->lang;
     }
 
-    public function setLang(string $lang): void
+    public function setLang(LanguageCode $lang): void
     {
         $this->lang = $lang;
     }

--- a/equed-lms/Classes/Domain/Model/LessonFeedback.php
+++ b/equed-lms/Classes/Domain/Model/LessonFeedback.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Equed\EquedLms\Domain\Model;
 
+use Equed\EquedLms\Enum\LanguageCode;
 use DateTimeImmutable;
 use Ramsey\Uuid\Uuid;
 use TYPO3\CMS\Extbase\Annotation\ORM\Lazy;
@@ -29,7 +30,7 @@ final class LessonFeedback extends AbstractEntity
     protected ?string $courseWish = null;
     protected ?string $textFeedback = null;
     protected bool $releaseToInstructor = false;
-    protected string $lang = 'en';
+    protected LanguageCode $lang = LanguageCode::EN;
 
     protected DateTimeImmutable $createdAt;
     protected DateTimeImmutable $updatedAt;
@@ -137,12 +138,12 @@ final class LessonFeedback extends AbstractEntity
         $this->releaseToInstructor = $releaseToInstructor;
     }
 
-    public function getLang(): string
+    public function getLang(): LanguageCode
     {
         return $this->lang;
     }
 
-    public function setLang(string $lang): void
+    public function setLang(LanguageCode $lang): void
     {
         $this->lang = $lang;
     }

--- a/equed-lms/Classes/Domain/Model/PracticeAnswerOption.php
+++ b/equed-lms/Classes/Domain/Model/PracticeAnswerOption.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 namespace Equed\EquedLms\Domain\Model;
+use Equed\EquedLms\Enum\LanguageCode;
 
 use DateTimeImmutable;
 use Equed\Core\Service\UuidGeneratorInterface;
@@ -53,7 +54,7 @@ final class PracticeAnswerOption extends AbstractEntity
     /**
      * Language code for text.
      */
-    protected string $lang = 'en';
+    protected LanguageCode $lang = LanguageCode::EN;
 
     /**
      * Who generated this option (e.g. 'human', 'gpt').
@@ -166,7 +167,7 @@ final class PracticeAnswerOption extends AbstractEntity
     /**
      * Gets the language code.
      */
-    public function getLang(): string
+    public function getLang(): LanguageCode
     {
         return $this->lang;
     }
@@ -174,7 +175,7 @@ final class PracticeAnswerOption extends AbstractEntity
     /**
      * Sets the language code.
      */
-    public function setLang(string $lang): void
+    public function setLang(LanguageCode $lang): void
     {
         $this->lang = $lang;
     }

--- a/equed-lms/Classes/Domain/Model/PracticeQuestion.php
+++ b/equed-lms/Classes/Domain/Model/PracticeQuestion.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 namespace Equed\EquedLms\Domain\Model;
+use Equed\EquedLms\Enum\LanguageCode;
 
 use DateTimeImmutable;
 use Equed\Core\Service\ClockInterface;
@@ -59,7 +60,7 @@ final class PracticeQuestion extends AbstractEntity
     /**
      * Language code: en, de, fr, es, sw.
      */
-    protected string $lang = 'en';
+    protected LanguageCode $lang = LanguageCode::EN;
 
     /**
      * Optional difficulty or weight.
@@ -210,7 +211,7 @@ final class PracticeQuestion extends AbstractEntity
     /**
      * Gets the language code.
      */
-    public function getLang(): string
+    public function getLang(): LanguageCode
     {
         return $this->lang;
     }
@@ -218,7 +219,7 @@ final class PracticeQuestion extends AbstractEntity
     /**
      * Sets the language code.
      */
-    public function setLang(string $lang): void
+    public function setLang(LanguageCode $lang): void
     {
         $this->lang = $lang;
     }

--- a/equed-lms/Classes/Domain/Model/QuizResult.php
+++ b/equed-lms/Classes/Domain/Model/QuizResult.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 namespace Equed\EquedLms\Domain\Model;
+use Equed\EquedLms\Enum\LanguageCode;
 
 use DateTimeImmutable;
 use Equed\Core\Service\ClockInterface;
@@ -43,7 +44,7 @@ final class QuizResult extends AbstractEntity
 
     protected DateTimeImmutable $submittedAt;
 
-    protected string $lang = 'en';
+    protected LanguageCode $lang = LanguageCode::EN;
 
     protected DateTimeImmutable $createdAt;
 
@@ -200,7 +201,7 @@ final class QuizResult extends AbstractEntity
     /**
      * Gets the language code.
      */
-    public function getLang(): string
+    public function getLang(): LanguageCode
     {
         return $this->lang;
     }
@@ -208,7 +209,7 @@ final class QuizResult extends AbstractEntity
     /**
      * Sets the language code.
      */
-    public function setLang(string $lang): void
+    public function setLang(LanguageCode $lang): void
     {
         $this->lang = $lang;
     }

--- a/equed-lms/Classes/Domain/Model/SearchLog.php
+++ b/equed-lms/Classes/Domain/Model/SearchLog.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 namespace Equed\EquedLms\Domain\Model;
+use Equed\EquedLms\Enum\LanguageCode;
 
 use DateTimeImmutable;
 use Equed\Core\Service\ClockInterface;
@@ -32,7 +33,7 @@ final class SearchLog extends AbstractEntity
     protected string $termHash = '';
 
     /** Language used for the search */
-    protected string $lang = 'en';
+    protected LanguageCode $lang = LanguageCode::EN;
 
     protected DateTimeImmutable $createdAt;
 
@@ -85,12 +86,12 @@ final class SearchLog extends AbstractEntity
         $this->termHash = sha1($term);
     }
 
-    public function getLang(): string
+    public function getLang(): LanguageCode
     {
         return $this->lang;
     }
 
-    public function setLang(string $lang): void
+    public function setLang(LanguageCode $lang): void
     {
         $this->lang = $lang;
     }

--- a/equed-lms/Classes/Domain/Model/SubmissionAttachment.php
+++ b/equed-lms/Classes/Domain/Model/SubmissionAttachment.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 namespace Equed\EquedLms\Domain\Model;
+use Equed\EquedLms\Enum\LanguageCode;
 
 use DateTimeImmutable;
 use Equed\Core\Service\ClockInterface;
@@ -43,7 +44,7 @@ final class SubmissionAttachment extends AbstractEntity
 
     protected string $status = 'active';
 
-    protected string $lang = 'en';
+    protected LanguageCode $lang = LanguageCode::EN;
 
     protected bool $isActive = true;
 
@@ -201,7 +202,7 @@ final class SubmissionAttachment extends AbstractEntity
      *
      * @return string
      */
-    public function getLang(): string
+    public function getLang(): LanguageCode
     {
         return $this->lang;
     }
@@ -209,9 +210,9 @@ final class SubmissionAttachment extends AbstractEntity
     /**
      * Sets the language code.
      *
-     * @param string $lang
+     * @param LanguageCode $lang
      */
-    public function setLang(string $lang): void
+    public function setLang(LanguageCode $lang): void
     {
         $this->lang = $lang;
     }

--- a/equed-lms/Classes/Domain/Model/SubmissionComment.php
+++ b/equed-lms/Classes/Domain/Model/SubmissionComment.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 namespace Equed\EquedLms\Domain\Model;
+use Equed\EquedLms\Enum\LanguageCode;
 
 use DateTimeImmutable;
 use Equed\Core\Service\ClockInterface;
@@ -36,7 +37,7 @@ final class SubmissionComment extends AbstractEntity
 
     protected string $comment = '';
 
-    protected string $lang = 'en';
+    protected LanguageCode $lang = LanguageCode::EN;
 
     protected bool $visibleForUser = true;
 
@@ -127,7 +128,7 @@ final class SubmissionComment extends AbstractEntity
     /**
      * Gets the language code.
      */
-    public function getLang(): string
+    public function getLang(): LanguageCode
     {
         return $this->lang;
     }
@@ -135,7 +136,7 @@ final class SubmissionComment extends AbstractEntity
     /**
      * Sets the language code.
      */
-    public function setLang(string $lang): void
+    public function setLang(LanguageCode $lang): void
     {
         $this->lang = $lang;
     }

--- a/equed-lms/Classes/Domain/Model/SubmissionReview.php
+++ b/equed-lms/Classes/Domain/Model/SubmissionReview.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Equed\EquedLms\Domain\Model;
 
+use Equed\EquedLms\Enum\LanguageCode;
+
 use DateTimeImmutable;
 use Equed\Core\Service\ClockInterface;
 use Equed\Core\Service\UuidGeneratorInterface;
@@ -50,7 +52,7 @@ final class SubmissionReview extends AbstractEntity
 
     protected bool $wasGeneratedByGpt = false;
 
-    protected string $lang = 'en';
+    protected LanguageCode $lang = LanguageCode::EN;
 
     protected DateTimeImmutable $createdAt;
 
@@ -216,7 +218,7 @@ final class SubmissionReview extends AbstractEntity
     /**
      * Gets the language code.
      */
-    public function getLang(): string
+    public function getLang(): LanguageCode
     {
         return $this->lang;
     }
@@ -224,9 +226,9 @@ final class SubmissionReview extends AbstractEntity
     /**
      * Sets the language code.
      *
-     * @param string $lang
+     * @param LanguageCode $lang
      */
-    public function setLang(string $lang): void
+    public function setLang(LanguageCode $lang): void
     {
         $this->lang = $lang;
     }

--- a/equed-lms/Classes/Domain/Model/TrainingCenter.php
+++ b/equed-lms/Classes/Domain/Model/TrainingCenter.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 namespace Equed\EquedLms\Domain\Model;
+use Equed\EquedLms\Enum\LanguageCode;
 
 use DateTimeImmutable;
 use Equed\Core\Service\ClockInterface;
@@ -85,7 +86,7 @@ final class TrainingCenter extends AbstractEntity
     #[Cascade('remove')]
     protected ?FileReference $logo = null;
 
-    protected string $lang = 'en';
+    protected LanguageCode $lang = LanguageCode::EN;
 
     protected bool $isArchived = false;
 
@@ -503,7 +504,7 @@ final class TrainingCenter extends AbstractEntity
     /**
      * Gets the language code.
      */
-    public function getLang(): string
+    public function getLang(): LanguageCode
     {
         return $this->lang;
     }
@@ -511,9 +512,9 @@ final class TrainingCenter extends AbstractEntity
     /**
      * Sets the language code.
      *
-     * @param string $lang
+     * @param LanguageCode $lang
      */
-    public function setLang(string $lang): void
+    public function setLang(LanguageCode $lang): void
     {
         $this->lang = $lang;
     }

--- a/equed-lms/Classes/Domain/Model/TrainingRecord.php
+++ b/equed-lms/Classes/Domain/Model/TrainingRecord.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Equed\EquedLms\Domain\Model;
 
+use Equed\EquedLms\Enum\LanguageCode;
+
 use DateTimeImmutable;
 use Equed\Core\Service\ClockInterface;
 use Equed\Core\Service\UuidGeneratorInterface;
@@ -52,7 +54,7 @@ final class TrainingRecord extends AbstractEntity
     protected bool $isValidated = false;
     protected ?string $validatedBy = null;
 
-    protected string $lang = 'en';
+    protected LanguageCode $lang = LanguageCode::EN;
 
     protected bool $isArchived = false;
 
@@ -298,7 +300,7 @@ final class TrainingRecord extends AbstractEntity
     /**
      * Gets the language code.
      */
-    public function getLang(): string
+    public function getLang(): LanguageCode
     {
         return $this->lang;
     }
@@ -306,7 +308,7 @@ final class TrainingRecord extends AbstractEntity
     /**
      * Sets the language code.
      */
-    public function setLang(string $lang): void
+    public function setLang(LanguageCode $lang): void
     {
         $this->lang = $lang;
     }

--- a/equed-lms/Classes/Enum/LanguageCode.php
+++ b/equed-lms/Classes/Enum/LanguageCode.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Enum;
+
+/**
+ * Supported language codes for multilingual content.
+ */
+enum LanguageCode: string
+{
+    case EN = 'en';
+    case DE = 'de';
+    case FR = 'fr';
+    case ES = 'es';
+    case SW = 'sw';
+    case EASY = 'easy';
+}
+

--- a/equed-lms/Classes/Helper/LanguageHelper.php
+++ b/equed-lms/Classes/Helper/LanguageHelper.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Equed\EquedLms\Helper;
 
+use Equed\EquedLms\Enum\LanguageCode;
+
 /**
  * Provides language detection and simple translation messages
  * in accordance with project’s hybrid GPT‐translation requirements.
@@ -27,10 +29,10 @@ final class LanguageHelper
      * Returns a localized message for a given key and language.
      * Falls back to English if the language or key is missing.
      *
-     * @param string $key  Message identifier
-     * @param string $lang ISO 639-1 code, e.g. 'en', 'de', 'fr', 'es', 'sw'
+     * @param string       $key  Message identifier
+     * @param LanguageCode $lang Target language
      */
-    public static function translate(string $key, string $lang): string
+    public static function translate(string $key, LanguageCode $lang): string
     {
         static $messages = [
             'unauthorized' => [
@@ -60,8 +62,8 @@ final class LanguageHelper
             return 'Unknown error';
         }
 
-        return $messages[$key][$lang]
-            ?? $messages[$key]['en'];
+        return $messages[$key][$lang->value]
+            ?? $messages[$key][LanguageCode::EN->value];
     }
 }
 // EOF

--- a/equed-lms/Classes/Middleware/ApiTokenMiddleware.php
+++ b/equed-lms/Classes/Middleware/ApiTokenMiddleware.php
@@ -10,6 +10,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Equed\EquedLms\Service\ApiTokenService;
 use Equed\EquedLms\Helper\LanguageHelper;
+use Equed\EquedLms\Enum\LanguageCode;
 use Laminas\Diactoros\Response\JsonResponse;
 
 /**
@@ -30,7 +31,7 @@ final class ApiTokenMiddleware implements MiddlewareInterface
         $token = $this->extractBearerToken($request);
         if ($token === null || !$this->tokenService->isValidToken($token)) {
             $lang    = LanguageHelper::detectLanguage($request->getServerParams());
-            $message = LanguageHelper::translate('unauthorized', $lang);
+            $message = LanguageHelper::translate('unauthorized', LanguageCode::from($lang));
 
             return new JsonResponse(
                 ['error' => $message],


### PR DESCRIPTION
## Summary
- add new `LanguageCode` enum with supported language constants
- migrate `$lang` properties in domain models to use the enum
- update getters and setters accordingly
- adjust `LanguageHelper` and `ApiTokenMiddleware` to work with the enum

## Testing
- `composer test` *(fails: `composer: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684d4571aafc8324975e960fb3fe43ba