### PR TITLE
Fix AccessLog imports

### DIFF
--- a/equed-lms/Classes/Domain/Model/AccessLog.php
+++ b/equed-lms/Classes/Domain/Model/AccessLog.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Equed\EquedLms\Domain\Model;
 
 use Equed\EquedLms\Domain\Model\Traits\PersistenceTrait;
-use TYPO3\CMS\Extbase\Annotation\Inject;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 
 /**


### PR DESCRIPTION
## Summary
- remove unused `Inject` import from AccessLog model

## Testing
- `composer phpstan` *(fails: Error while loading phpstan-baseline.neon)*

------
https://chatgpt.com/codex/tasks/task_e_684d693a7c8c8324a30bb34dacace718