### PR TITLE
Use LanguageCode for Event booking & schedule

### DIFF
--- a/equed-lms/Classes/Domain/Model/EventBooking.php
+++ b/equed-lms/Classes/Domain/Model/EventBooking.php
@@ -6,6 +6,7 @@ namespace Equed\EquedLms\Domain\Model;
 
 use DateTimeImmutable;
 use Equed\Core\Service\ClockInterface;
+use Equed\EquedLms\Enum\LanguageCode;
 use TYPO3\CMS\Extbase\Annotation\Inject;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 
@@ -33,7 +34,7 @@ final class EventBooking extends AbstractEntity
 
     protected string $cancelledReason = '';
 
-    protected string $language = '';
+    protected LanguageCode $language = LanguageCode::EN;
 
     protected string $uuid = '';
 
@@ -124,12 +125,12 @@ final class EventBooking extends AbstractEntity
         $this->cancelledReason = $cancelledReason;
     }
 
-    public function getLanguage(): string
+    public function getLanguage(): LanguageCode
     {
         return $this->language;
     }
 
-    public function setLanguage(string $language): void
+    public function setLanguage(LanguageCode $language): void
     {
         $this->language = $language;
     }

--- a/equed-lms/Classes/Domain/Model/EventSchedule.php
+++ b/equed-lms/Classes/Domain/Model/EventSchedule.php
@@ -6,6 +6,7 @@ namespace Equed\EquedLms\Domain\Model;
 
 use DateTimeImmutable;
 use Equed\Core\Service\ClockInterface;
+use Equed\EquedLms\Enum\LanguageCode;
 use TYPO3\CMS\Extbase\Annotation\Inject;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 
@@ -39,7 +40,7 @@ final class EventSchedule extends AbstractEntity
 
     protected bool $isActive = false;
 
-    protected string $language = '';
+    protected LanguageCode $language = LanguageCode::EN;
 
     protected string $uuid = '';
 
@@ -168,12 +169,12 @@ final class EventSchedule extends AbstractEntity
         $this->isActive = $isActive;
     }
 
-    public function getLanguage(): string
+    public function getLanguage(): LanguageCode
     {
         return $this->language;
     }
 
-    public function setLanguage(string $language): void
+    public function setLanguage(LanguageCode $language): void
     {
         $this->language = $language;
     }


### PR DESCRIPTION
## Summary
- use `LanguageCode` enum for `EventBooking` and `EventSchedule`

## Testing
- `php -l` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684d717ce0088324ba80cf58f33516eb