### PR TITLE
Change maxParticipants to int

### DIFF
--- a/equed-lms/Classes/Domain/Model/EventSchedule.php
+++ b/equed-lms/Classes/Domain/Model/EventSchedule.php
@@ -34,7 +34,7 @@ final class EventSchedule extends AbstractEntity
 
     protected string $location = '';
 
-    protected string $maxParticipants = '';
+    protected int $maxParticipants = 0;
 
     protected string $notes = '';
 
@@ -139,12 +139,12 @@ final class EventSchedule extends AbstractEntity
         $this->location = $location;
     }
 
-    public function getMaxParticipants(): string
+    public function getMaxParticipants(): int
     {
         return $this->maxParticipants;
     }
 
-    public function setMaxParticipants(string $maxParticipants): void
+    public function setMaxParticipants(int $maxParticipants): void
     {
         $this->maxParticipants = $maxParticipants;
     }

--- a/equed-lms/Configuration/Schema/Domain/Model/Eventschedule.yaml
+++ b/equed-lms/Configuration/Schema/Domain/Model/Eventschedule.yaml
@@ -19,7 +19,7 @@ columns:
   location:
     type: string
   max_participants:
-    type: string
+    type: integer
   notes:
     type: text
   is_active:

--- a/equed-lms/Configuration/TCA/tx_equedlms_domain_model_eventschedule.php
+++ b/equed-lms/Configuration/TCA/tx_equedlms_domain_model_eventschedule.php
@@ -16,7 +16,7 @@ return [
             'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_eventschedule.title',
             'config' => [
                 'type' => 'input',
-                'eval' => 'trim'
+                'eval' => 'int'
             ]
         ],
         'description' => [
@@ -63,7 +63,7 @@ return [
             'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_eventschedule.location',
             'config' => [
                 'type' => 'input',
-                'eval' => 'trim'
+                'eval' => 'int'
             ]
         ],
         'max_participants' => [
@@ -71,7 +71,7 @@ return [
             'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_eventschedule.max_participants',
             'config' => [
                 'type' => 'input',
-                'eval' => 'trim'
+                'eval' => 'int'
             ]
         ],
         'notes' => [


### PR DESCRIPTION
## Summary
- use `int` for `EventSchedule::$maxParticipants`
- update getter/setter and default value
- mark the DB schema and TCA config as integers

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d792047bc83249bf2b5a27f0325ea