### PR TITLE
Add unique constraint on user and course instance

### DIFF
--- a/equed-lms/Classes/Domain/Model/UserCourseRecord.php
+++ b/equed-lms/Classes/Domain/Model/UserCourseRecord.php
@@ -14,10 +14,12 @@ use TYPO3\CMS\Extbase\Annotation\ORM\Lazy;
 use TYPO3\CMS\Extbase\Annotation\ORM\ManyToOne;
 use Equed\EquedLms\Domain\Model\FrontendUser;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
+use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
 /**
  * Domain model for user course records.
  */
+#[UniqueEntity(fields: ['courseInstance', 'user'])]
 final class UserCourseRecord extends AbstractEntity
 {
     protected string $uuid = '';


### PR DESCRIPTION
## Summary
- enforce unique user/course instance combination via UniqueEntity annotation

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d7cad5800832496e9d2a3afe18bd8