### PR TITLE
Add methods to fetch user course records

### DIFF
--- a/equed-lms/Classes/Domain/Repository/UserCourseRecordRepositoryInterface.php
+++ b/equed-lms/Classes/Domain/Repository/UserCourseRecordRepositoryInterface.php
@@ -28,4 +28,11 @@ use Equed\EquedLms\Domain\Model\UserCourseRecord;
 interface UserCourseRecordRepositoryInterface
 {
     public function findByUuid(string $uuid): ?UserCourseRecord;
+
+    /**
+     * @return UserCourseRecord[]
+     */
+    public function findCompletedWithoutBadge(): array;
+
+    public function findOneByUserAndCourse(int $userId, int $courseUid): ?UserCourseRecord;
 }


### PR DESCRIPTION
## Summary
- support finding completed records without badge
- add ability to look up a record by user and course
- expose methods via `UserCourseRecordRepositoryInterface`

## Testing
- `php` and `composer` commands were not available, so tests could not be run

------
https://chatgpt.com/codex/tasks/task_e_684d8c2854008324874aa2f9d76d925a