### PR TITLE
Update LessonAttemptRepository ordering

### DIFF
--- a/equed-lms/Classes/Domain/Repository/LessonAttemptRepository.php
+++ b/equed-lms/Classes/Domain/Repository/LessonAttemptRepository.php
@@ -35,7 +35,7 @@ final class LessonAttemptRepository extends Repository implements LessonAttemptR
                 $query->equals('lesson', $lesson),
             ])
         );
-        $query->setOrderings(['crdate' => QueryInterface::ORDER_DESCENDING]);
+        $query->setOrderings(['createdAt' => QueryInterface::ORDER_DESCENDING]);
         $query->setLimit(1);
 
         return $query->execute()->getFirst();


### PR DESCRIPTION
## Summary
- update `findLatestByUserAndLesson()` to order by `createdAt`

## Testing
- `composer lint` *(fails: command not found)*
- `php -l Classes/Domain/Repository/LessonAttemptRepository.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684db9c83d2c8324bb10be6bf2c2b5cb