### PR TITLE
Fix default ordering key

### DIFF
--- a/equed-lms/Classes/Domain/Repository/TrainingCenterFeedbackRepository.php
+++ b/equed-lms/Classes/Domain/Repository/TrainingCenterFeedbackRepository.php
@@ -71,7 +71,7 @@ final class TrainingCenterFeedbackRepository extends Repository
         $query->matching(
             $query->equals('trainingCenter', $trainingCenter)
         );
-        $query->setOrderings(['crdate' => QueryInterface::ORDER_DESCENDING]);
+        $query->setOrderings(['createdAt' => QueryInterface::ORDER_DESCENDING]);
         $query->setLimit(1);
 
         return $query->execute()->getFirst();

--- a/equed-lms/Classes/Domain/Repository/UserCourseRecordRepository.php
+++ b/equed-lms/Classes/Domain/Repository/UserCourseRecordRepository.php
@@ -26,7 +26,7 @@ final class UserCourseRecordRepository extends Repository implements UserCourseR
      * @var array<string,int>
      */
     protected array $defaultOrderings = [
-        'crdate' => QueryInterface::ORDER_DESCENDING,
+        'createdAt' => QueryInterface::ORDER_DESCENDING,
     ];
 
     /**


### PR DESCRIPTION
## Summary
- replace `crdate` key with `createdAt` in `UserCourseRecordRepository`
- update `TrainingCenterFeedbackRepository` to use `createdAt` ordering

## Testing
- `composer install` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684dba8bcbf483248807db7483d9bad0