### PR TITLE
Refactor dashboard service

### DIFF
--- a/equed-lms/Classes/Service/Dashboard/FilterMetadataProvider.php
+++ b/equed-lms/Classes/Service/Dashboard/FilterMetadataProvider.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Service\Dashboard;
+
+use Equed\EquedLms\Domain\Repository\CourseInstanceRepositoryInterface;
+use Equed\EquedLms\Domain\Repository\UserCourseRecordRepositoryInterface;
+
+/**
+ * Provides filter option metadata for the dashboard.
+ */
+final class FilterMetadataProvider
+{
+    public function __construct(
+        private readonly CourseInstanceRepositoryInterface $courseInstanceRepo,
+        private readonly UserCourseRecordRepositoryInterface $userCourseRecordRepo,
+    ) {
+    }
+
+    /**
+     * Collect available filter values.
+     *
+     * @return array<string,mixed>
+     */
+    public function getMetadata(): array
+    {
+        return [
+            'theme'       => $this->courseInstanceRepo->findDistinctField('theme'),
+            'language'    => $this->courseInstanceRepo->findDistinctField('language'),
+            'badgeStatus' => $this->userCourseRecordRepo->findDistinctField('badgeStatus'),
+            'eqfLevel'    => $this->courseInstanceRepo->findDistinctField('eqfLevel'),
+        ];
+    }
+}

--- a/equed-lms/Classes/Service/Dashboard/TabsBuilder.php
+++ b/equed-lms/Classes/Service/Dashboard/TabsBuilder.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Service\Dashboard;
+
+use Equed\EquedLms\Domain\Model\FrontendUser;
+use Equed\EquedLms\Domain\Repository\UserCourseRecordRepositoryInterface;
+use Equed\EquedLms\Service\GptTranslationServiceInterface;
+use Equed\EquedLms\Enum\UserCourseStatus;
+
+/**
+ * Builds the dashboard tabs data for a user.
+ */
+final class TabsBuilder
+{
+    public function __construct(
+        private readonly UserCourseRecordRepositoryInterface $userCourseRecordRepo,
+        private readonly GptTranslationServiceInterface $translationService,
+    ) {
+    }
+
+    /**
+     * Build tab data grouped by running and completed course instances.
+     *
+     * @param FrontendUser $user
+     * @param array<int,\Equed\EquedLms\Domain\Model\CertificateDispatch> $latestCertificates
+     * @return array<string,array<int,array<string,mixed>>>
+     */
+    public function build(FrontendUser $user, array $latestCertificates): array
+    {
+        $records = $this->userCourseRecordRepo->findByUser($user);
+        $tabs    = ['running' => [], 'completed' => []];
+
+        foreach ($records as $record) {
+            $ci     = $record->getCourseInstance();
+            $status = $record->getStatus();
+            $tabKey = match ($status) {
+                UserCourseStatus::Validated, UserCourseStatus::Passed => 'completed',
+                default                                            => 'running',
+            };
+            $ciId   = $ci->getUid();
+            $certUrl = $latestCertificates[$ciId]?->getQrCodeUrl() ?? null;
+
+            $tabs[$tabKey][] = [
+                'id'               => $ciId,
+                'title'            => $this->translationService->translate(
+                    'dashboard.course.title',
+                    ['title' => $ci->getTitle()]
+                ),
+                'status'           => $status,
+                'progressPercent'  => $record->getProgressPercent(),
+                'participantCount' => $ci->getParticipantCount(),
+                'location'         => $ci->getLocation(),
+                'startDate'        => $ci->getStartDate()?->format('Y-m-d') ?? '',
+                'endDate'          => $ci->getEndDate()?->format('Y-m-d') ?? '',
+                'badgeIcon'        => $record->hasBadge() ? $record->getBadgeIconUrl() : null,
+                'certificateUrl'   => $certUrl,
+            ];
+        }
+
+        return $tabs;
+    }
+}

--- a/equed-lms/Tests/Unit/Service/FilterMetadataProviderTest.php
+++ b/equed-lms/Tests/Unit/Service/FilterMetadataProviderTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Tests\Unit\Service;
+
+use Equed\EquedLms\Service\Dashboard\FilterMetadataProvider;
+use Equed\EquedLms\Domain\Repository\CourseInstanceRepositoryInterface;
+use Equed\EquedLms\Domain\Repository\UserCourseRecordRepositoryInterface;
+use Equed\EquedLms\Domain\Model\UserCourseRecord;
+use PHPUnit\Framework\TestCase;
+
+class FilterMetadataProviderTest extends TestCase
+{
+
+    public function testGetMetadataReturnsFields(): void
+    {
+        $ciRepo = new class implements CourseInstanceRepositoryInterface {
+            public function findAllRequiringExternalExaminer(): array { return []; }
+            public function findDistinctField(string $field): array { return match($field){
+                'theme' => ['a'], 'language' => ['en'], 'eqfLevel' => [1], default => []}; }
+        };
+        $ucRepo = new class implements UserCourseRecordRepositoryInterface {
+            public function findByUuid(string $uuid): ?UserCourseRecord { return null; }
+            public function findCompletedWithoutBadge(): array { return []; }
+            public function findOneByUserAndCourse(int $userId, int $courseUid): ?UserCourseRecord { return null; }
+            public function findDistinctField(string $field): array { return ['none']; }
+        };
+
+        $provider = new FilterMetadataProvider($ciRepo, $ucRepo);
+
+        $result = $provider->getMetadata();
+
+        $this->assertSame(['a'], $result['theme']);
+        $this->assertSame(['en'], $result['language']);
+        $this->assertSame(['none'], $result['badgeStatus']);
+        $this->assertSame([1], $result['eqfLevel']);
+    }
+}

--- a/equed-lms/Tests/Unit/Service/TabsBuilderTest.php
+++ b/equed-lms/Tests/Unit/Service/TabsBuilderTest.php
@@ -1,0 +1,80 @@
+<?php
+declare(strict_types=1);
+
+namespace {
+    if (!class_exists('Equed\\EquedLms\\Domain\\Model\\FrontendUser', false)) {
+        class_alias(\stdClass::class, 'Equed\\EquedLms\\Domain\\Model\\FrontendUser');
+    }
+}
+
+namespace Equed\EquedLms\Tests\Unit\Service {
+
+use DateTimeImmutable;
+use Equed\EquedLms\Service\Dashboard\TabsBuilder;
+use Equed\EquedLms\Domain\Repository\UserCourseRecordRepositoryInterface;
+use Equed\EquedLms\Service\GptTranslationServiceInterface;
+use Equed\EquedLms\Domain\Model\CourseInstance;
+use Equed\EquedLms\Domain\Model\UserCourseRecord;
+use Equed\EquedLms\Enum\UserCourseStatus;
+use PHPUnit\Framework\TestCase;
+class TabsBuilderTest extends TestCase
+{
+
+    public function testBuildGroupsRecordsIntoTabs(): void
+    {
+        $user = new \stdClass();
+
+        $ci1 = new CourseInstance();
+        $ci1->_setProperty('uid', 1);
+        $ci1->setTitle('Course 1');
+        $ci1->setLocation('loc1');
+        $ci1->setStartDate(new DateTimeImmutable('2024-01-01'));
+        $ci1->setEndDate(new DateTimeImmutable('2024-01-02'));
+
+        $record1 = new UserCourseRecord();
+        $record1->setCourseInstance($ci1);
+        $record1->setStatus(UserCourseStatus::InProgress);
+        $record1->setProgressPercent(50.0);
+        $ci1->addUserCourseRecord($record1);
+
+        $ci2 = new CourseInstance();
+        $ci2->_setProperty('uid', 2);
+        $ci2->setTitle('Course 2');
+        $ci2->setLocation('loc2');
+        $ci2->setStartDate(new DateTimeImmutable('2024-02-01'));
+        $ci2->setEndDate(new DateTimeImmutable('2024-02-02'));
+
+        $record2 = new UserCourseRecord();
+        $record2->setCourseInstance($ci2);
+        $record2->setStatus(UserCourseStatus::Validated);
+        $record2->setProgressPercent(100.0);
+        $ci2->addUserCourseRecord($record2);
+
+        $repo = new class([$record1, $record2]) implements UserCourseRecordRepositoryInterface {
+            public function __construct(private array $records) {}
+            public function findByUuid(string $uuid): ?UserCourseRecord { return null; }
+            public function findCompletedWithoutBadge(): array { return []; }
+            public function findOneByUserAndCourse(int $userId, int $courseUid): ?UserCourseRecord { return null; }
+            public function findByUser($user): array { return $this->records; }
+        };
+
+        $translator = new class implements GptTranslationServiceInterface {
+            public function isEnabled(): bool { return true; }
+            public function translate(string $key, array $arguments = [], ?string $extension = null): ?string { return $arguments['title'] ?? null; }
+        };
+
+        $builder = new TabsBuilder($repo, $translator);
+
+        $cert = new class { public function getQrCodeUrl(): string { return 'cert'; } };
+
+        $result = $builder->build($user, [2 => $cert]);
+
+        $this->assertCount(1, $result['running']);
+        $this->assertSame(1, $result['running'][0]['id']);
+        $this->assertSame(50.0, $result['running'][0]['progressPercent']);
+
+        $this->assertCount(1, $result['completed']);
+        $this->assertSame('cert', $result['completed'][0]['certificateUrl']);
+    }
+}
+}

--- a/equed-lms/phpunit.xml.dist
+++ b/equed-lms/phpunit.xml.dist
@@ -40,6 +40,8 @@
         <file>./Tests/Unit/Service/CourseStatusUpdaterServiceTest.php</file>
         <file>./Tests/Unit/Service/ExamNotificationServiceTest.php</file>
         <file>./Tests/Unit/Service/TrainingRecordGeneratorServiceTest.php</file>
+        <file>./Tests/Unit/Service/TabsBuilderTest.php</file>
+        <file>./Tests/Unit/Service/FilterMetadataProviderTest.php</file>
         </testsuite>
         <testsuite name="functional">
             <directory>./Tests/Functional/</directory>


### PR DESCRIPTION
## Summary
- extract dashboard tabs and filter metadata into dedicated builders
- inject new builders into `DashboardService`
- adapt dashboard service logic
- cover builders with unit tests

## Testing
- `vendor/bin/phpunit Tests/Unit/Service/TabsBuilderTest.php Tests/Unit/Service/FilterMetadataProviderTest.php`

------
https://chatgpt.com/codex/tasks/task_e_684dbeb4b3b48324b259195a8c0cb55b