### PR TITLE
Add configurable upload size limit

### DIFF
--- a/equed-lms/Configuration/Services/Services.yaml
+++ b/equed-lms/Configuration/Services/Services.yaml
@@ -1,5 +1,6 @@
 parameters:
   equed_lms.training_record_output_path: '%kernel.project_dir%/var/training_records'
+  equed_lms.max_upload_size: 5242880
 
 services:
   _defaults:
@@ -78,6 +79,8 @@ services:
 
   Equed\EquedLms\Domain\Service\MediaUploadServiceInterface:
     class: Equed\EquedLms\Service\MediaUploadService
+    arguments:
+      $maxFileSize: '%equed_lms.max_upload_size%'
 
   Equed\EquedLms\Domain\Service\DocumentServiceInterface:
     class: Equed\EquedLms\Service\DocumentService


### PR DESCRIPTION
## Summary
- enforce a maximum upload size in `MediaUploadService`
- catch TYPO3 FileOperationErrorException
- make file size parameter configurable in Services.yaml
- test size rejection logic

## Testing
- `vendor/bin/phpunit -c equed-lms/phpunit.xml.dist` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dc33ec3c88324951bc19f39b4aa30