### PR TITLE
Handle invalid updatedAt timestamps

### DIFF
--- a/equed-lms/Tests/Unit/Service/UserProgressSyncServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/UserProgressSyncServiceTest.php
@@ -8,9 +8,12 @@ use Equed\EquedLms\Domain\Model\UserCourseRecord;
 use Equed\EquedLms\Domain\Repository\UserCourseRecordRepositoryInterface;
 use Equed\EquedLms\Enum\UserCourseStatus;
 use Equed\EquedLms\Service\UserProgressSyncService;
+use Equed\EquedLms\Service\LogService;
 use Equed\EquedLms\Tests\Traits\ProphecyTrait;
 use PHPUnit\Framework\TestCase;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
+use Psr\Log\LoggerInterface;
+use Prophecy\Argument;
 
 class UserProgressSyncServiceTest extends TestCase
 {
@@ -19,14 +22,18 @@ class UserProgressSyncServiceTest extends TestCase
     private UserProgressSyncService $subject;
     private $repo;
     private $persistence;
+    private $logger;
 
     protected function setUp(): void
     {
         $this->repo = $this->prophesize(UserCourseRecordRepositoryInterface::class);
         $this->persistence = $this->prophesize(PersistenceManagerInterface::class);
+        $this->logger = $this->prophesize(LoggerInterface::class);
+        $logService = new LogService($this->logger->reveal());
         $this->subject = new UserProgressSyncService(
             $this->repo->reveal(),
-            $this->persistence->reveal()
+            $this->persistence->reveal(),
+            $logService
         );
     }
 
@@ -66,5 +73,29 @@ class UserProgressSyncServiceTest extends TestCase
 
         $this->assertSame(1, $count);
         $this->assertSame('passed', $record->getStatus()->value ?? (string)$record->getStatus());
+    }
+
+    public function testSyncUserProgressSkipsInvalidDate(): void
+    {
+        $record = new UserCourseRecord();
+        $record->_setProperty('uid', 9);
+        $record->setStatus(UserCourseStatus::InProgress);
+        $record->setUpdatedAt(new \DateTimeImmutable('2024-01-01 00:00:00'));
+
+        $this->repo->findByUid(9)->willReturn($record);
+        $this->repo->update($record)->shouldNotBeCalled();
+        $this->persistence->persistAll()->shouldNotBeCalled();
+        $this->logger->warning('Invalid timestamp for progress sync', Argument::type('array'))->shouldBeCalled();
+
+        $count = $this->subject->syncUserProgress([
+            [
+                'recordId' => 9,
+                'status' => 'passed',
+                'updatedAt' => 'not-a-date',
+            ],
+        ]);
+
+        $this->assertSame(0, $count);
+        $this->assertSame('inProgress', $record->getStatus()->value ?? (string)$record->getStatus());
     }
 }


### PR DESCRIPTION
## Summary
- add `LogService` to SyncService and UserProgressSyncService
- catch invalid `updatedAt` values during sync
- record warning messages
- test that malformed dates don't throw exceptions

## Testing
- `composer install --no-interaction` *(fails: composer not found)*
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dc4205fd083249b3211fbf8852c89