### PR TITLE
Remove generated PDF after zip creation

### DIFF
--- a/equed-lms/Classes/Service/TrainingRecordGeneratorService.php
+++ b/equed-lms/Classes/Service/TrainingRecordGeneratorService.php
@@ -134,6 +134,8 @@ final class TrainingRecordGeneratorService implements TrainingRecordGeneratorInt
         $zip->addFile($pdfPath, basename($pdfPath));
         $zip->close();
 
+        $this->filesystem->remove($pdfPath);
+
         return $zipFilePath;
     }
 }

--- a/equed-lms/Tests/Unit/Service/TrainingRecordGeneratorServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/TrainingRecordGeneratorServiceTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace TCPDF { if (!class_exists(\TCPDF::class)) { class TCPDF { public function AddPage(){} public function SetFont($a,$b,$c){} public function Write($a,$b){} public function Ln(){} public function Output($d,$t){ return 'pdf'; } } } }
 namespace ZipArchiveNS { if (!class_exists(\ZipArchive::class)) { class ZipArchive { public $files=[]; public function open($file,$flags){ $this->path=$file; return true; } public function addFile($file,$name){ $this->files[]=$name; } public function close(){} } } }
 
-namespace Symfony\Component\Filesystem { if (!class_exists(Filesystem::class)) { class Filesystem { public array $dumped=[]; public array $mkdir=[]; public function exists($p){return false;} public function mkdir($p,$m=0777){$this->mkdir[]=$p;} public function dumpFile($p,$c){$this->dumped[$p]=$c;} } class Exception { interface IOExceptionInterface {} } }
+namespace Symfony\Component\Filesystem { if (!class_exists(Filesystem::class)) { class Filesystem { public array $dumped=[]; public array $mkdir=[]; public array $removed=[]; public function exists($p){return false;} public function mkdir($p,$m=0777){$this->mkdir[]=$p;} public function dumpFile($p,$c){$this->dumped[$p]=$c;} public function remove($p){$this->removed[]=$p;} } class Exception { interface IOExceptionInterface {} } }
 
 namespace Equed\EquedLms\Tests\Unit\Service;
 
@@ -31,6 +31,7 @@ class TrainingRecordGeneratorServiceTest extends TestCase
         $service = new TrainingRecordGeneratorService('/tmp', $fs, fn() => new TCPDF(), fn() => new ZipArchive());
         $path = $service->generateZip(['course'=>'c','cert_number'=>'n2','issued_on'=>'2024']);
         $this->assertStringEndsWith('.zip', $path);
+        $this->assertContains('/tmp/n2.pdf', $fs->removed);
     }
 
     public function testFactoriesAreInvoked(): void
@@ -52,5 +53,6 @@ class TrainingRecordGeneratorServiceTest extends TestCase
         $this->assertTrue($zipCalled);
         $this->assertStringEndsWith('.pdf', $pdfPath);
         $this->assertStringEndsWith('.zip', $zipPath);
+        $this->assertContains('/tmp/n4.pdf', $fs->removed);
     }
 }


### PR DESCRIPTION
## Summary
- delete temporary PDF file after adding it to the ZIP archive
- track removed files in the Filesystem stub
- assert PDF deletion in unit tests

## Testing
- `phpunit -c phpunit.xml.dist Tests/Unit/Service/TrainingRecordGeneratorServiceTest.php` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dc8aec96c8324998e111929384c90