### PR TITLE
Persist TrainingCenter relations

### DIFF
--- a/equed-lms/Classes/Domain/Model/TrainingCenter.php
+++ b/equed-lms/Classes/Domain/Model/TrainingCenter.php
@@ -12,6 +12,7 @@ use TYPO3\CMS\Extbase\Annotation\Inject;
 use TYPO3\CMS\Extbase\Annotation\ORM\Cascade;
 use TYPO3\CMS\Extbase\Annotation\ORM\Lazy;
 use TYPO3\CMS\Extbase\Annotation\ORM\ManyToOne;
+use TYPO3\CMS\Extbase\Annotation\ORM\ManyToMany;
 use TYPO3\CMS\Extbase\Domain\Model\FileReference;
 use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 use Equed\EquedLms\Domain\Model\CourseProgram;
@@ -74,11 +75,13 @@ final class TrainingCenter extends AbstractEntity
     /**
      * @var ObjectStorage<CourseProgram>
      */
+    #[ManyToMany(targetEntity: CourseProgram::class, cascade: ['remove'], lazy: true)]
     protected ObjectStorage $allowedPrograms;
 
     /**
      * @var ObjectStorage<FrontendUser>
      */
+    #[ManyToMany(targetEntity: FrontendUser::class, cascade: ['remove'], lazy: true)]
     protected ObjectStorage $instructors;
 
     #[ManyToOne]

--- a/equed-lms/Configuration/TCA/Overrides/tx_equedlms_domain_model_trainingcenter.php
+++ b/equed-lms/Configuration/TCA/Overrides/tx_equedlms_domain_model_trainingcenter.php
@@ -101,22 +101,26 @@ use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
         'allowed_programs' => [
             'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:trainingcenter.allowed_programs',
             'config' => [
-                'type' => 'inline',
+                'type' => 'select',
+                'renderType' => 'selectMultipleSideBySide',
                 'foreign_table' => 'tx_equedlms_domain_model_courseprogram',
-                'foreign_field' => 'training_center',
-                'maxitems' => 999,
+                'MM' => 'tx_equedlms_trainingcenter_program_mm',
+                'size' => 8,
+                'autoSizeMax' => 20,
+                'multiple' => 1,
             ],
         ],
         'instructors' => [
             'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:trainingcenter.instructors',
             'config' => [
-                'type' => 'inline',
+                'type' => 'select',
+                'renderType' => 'selectMultipleSideBySide',
                 'foreign_table' => 'fe_users',
-                'foreign_sortby' => 'last_name',
-                'foreign_match_fields' => [
-                    'usergroup' => 'Instructor',
-                ],
-                'maxitems' => 999,
+                'foreign_table_where' => 'AND fe_users.is_instructor = 1',
+                'MM' => 'tx_equedlms_trainingcenter_instructor_mm',
+                'size' => 8,
+                'autoSizeMax' => 20,
+                'multiple' => 1,
             ],
         ],
         'uuid' => [

--- a/equed-lms/Configuration/TCA/tx_equedlms_domain_model_trainingcenter.php
+++ b/equed-lms/Configuration/TCA/tx_equedlms_domain_model_trainingcenter.php
@@ -101,16 +101,27 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_trainingcenter.allowed_programs',
             'config' => [
-                'type' => 'input',
-                'eval' => 'trim'
+                'type' => 'select',
+                'renderType' => 'selectMultipleSideBySide',
+                'foreign_table' => 'tx_equedlms_domain_model_courseprogram',
+                'MM' => 'tx_equedlms_trainingcenter_program_mm',
+                'size' => 8,
+                'autoSizeMax' => 20,
+                'multiple' => 1,
             ]
         ],
         'instructors' => [
             'exclude' => true,
             'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_trainingcenter.instructors',
             'config' => [
-                'type' => 'input',
-                'eval' => 'trim'
+                'type' => 'select',
+                'renderType' => 'selectMultipleSideBySide',
+                'foreign_table' => 'fe_users',
+                'foreign_table_where' => 'AND fe_users.is_instructor = 1',
+                'MM' => 'tx_equedlms_trainingcenter_instructor_mm',
+                'size' => 8,
+                'autoSizeMax' => 20,
+                'multiple' => 1,
             ]
         ],
         'uuid' => [


### PR DESCRIPTION
## Summary
- make `allowedPrograms` and `instructors` persistent relations
- configure `allowed_programs` and `instructors` fields as multi-selects

## Testing
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dcccd6fd88324abc3be17c10ae567