### PR TITLE
Inject UUID generation in EventBooking model

### DIFF
--- a/equed-lms/Classes/Domain/Model/EventBooking.php
+++ b/equed-lms/Classes/Domain/Model/EventBooking.php
@@ -6,6 +6,7 @@ namespace Equed\EquedLms\Domain\Model;
 
 use DateTimeImmutable;
 use Equed\Core\Service\ClockInterface;
+use Equed\Core\Service\UuidGeneratorInterface;
 use Equed\EquedLms\Enum\LanguageCode;
 use TYPO3\CMS\Extbase\Annotation\Inject;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
@@ -19,6 +20,9 @@ final class EventBooking extends AbstractEntity
 {
     #[Inject]
     protected ClockInterface $clock;
+
+    #[Inject]
+    protected UuidGeneratorInterface $uuidGenerator;
 
     protected int $user = 0;
 
@@ -44,6 +48,9 @@ final class EventBooking extends AbstractEntity
 
     public function initializeObject(): void
     {
+        if ($this->uuid === '') {
+            $this->uuid = $this->uuidGenerator->generate();
+        }
         $now = $this->clock->now();
 
         if (!isset($this->createdAt)) {


### PR DESCRIPTION
## Summary
- inject `UuidGeneratorInterface` into EventBooking model
- create a UUID during `initializeObject()`

## Testing
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dce9da66483248f6a00c479a863c2