### PR TITLE
Add EventBookingStatus enum

### DIFF
--- a/equed-lms/Classes/Domain/Model/EventBooking.php
+++ b/equed-lms/Classes/Domain/Model/EventBooking.php
@@ -8,6 +8,7 @@ use DateTimeImmutable;
 use Equed\Core\Service\ClockInterface;
 use Equed\Core\Service\UuidGeneratorInterface;
 use Equed\EquedLms\Enum\LanguageCode;
+use Equed\EquedLms\Enum\EventBookingStatus;
 use TYPO3\CMS\Extbase\Annotation\Inject;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 
@@ -28,7 +29,7 @@ final class EventBooking extends AbstractEntity
 
     protected int $eventSchedule = 0;
 
-    protected int $bookingStatus = 0;
+    protected EventBookingStatus $bookingStatus = EventBookingStatus::Pending;
 
     protected string $comment = '';
 
@@ -82,13 +83,17 @@ final class EventBooking extends AbstractEntity
         $this->eventSchedule = $eventSchedule;
     }
 
-    public function getBookingStatus(): int
+    public function getBookingStatus(): EventBookingStatus
     {
         return $this->bookingStatus;
     }
 
-    public function setBookingStatus(int $bookingStatus): void
+    public function setBookingStatus(EventBookingStatus|string $bookingStatus): void
     {
+        if (is_string($bookingStatus)) {
+            $bookingStatus = EventBookingStatus::from($bookingStatus);
+        }
+
         $this->bookingStatus = $bookingStatus;
     }
 

--- a/equed-lms/Classes/Enum/EventBookingStatus.php
+++ b/equed-lms/Classes/Enum/EventBookingStatus.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Enum;
+
+/**
+ * Possible status values for EventBooking entities.
+ */
+enum EventBookingStatus: string
+{
+    case Pending = 'pending';
+    case Confirmed = 'confirmed';
+    case Cancelled = 'cancelled';
+    case Attended = 'attended';
+}


### PR DESCRIPTION
## Summary
- add `EventBookingStatus` enum for valid booking states
- use the new enum in `EventBooking`

## Testing
- ❌ `composer install` (failed: command not found)
- ❌ `composer test` (not run due to failed install)

------
https://chatgpt.com/codex/tasks/task_e_684ddd6f1cf88324843ac795d96d0817