### PR TITLE
Type language fields using LanguageCode enum

### DIFF
--- a/equed-lms/Classes/Domain/Model/CertificateTemplate.php
+++ b/equed-lms/Classes/Domain/Model/CertificateTemplate.php
@@ -13,6 +13,7 @@ use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 use TYPO3\CMS\Extbase\Domain\Model\FileReference;
 use Equed\EquedLms\Enum\BadgeLevel;
 use Equed\EquedLms\Enum\CertificateDesignType;
+use Equed\EquedLms\Enum\LanguageCode;
 
 /**
  * CertificateTemplate
@@ -50,9 +51,9 @@ final class CertificateTemplate extends AbstractEntity
     /**
      * Language ISO code
      *
-     * @var string
+     * @var LanguageCode
      */
-    protected string $language = 'en';
+    protected LanguageCode $language = LanguageCode::EN;
 
     /**
      * Required badge level to use this template
@@ -138,12 +139,12 @@ final class CertificateTemplate extends AbstractEntity
         $this->courseProgram = $courseProgram;
     }
 
-    public function getLanguage(): string
+    public function getLanguage(): LanguageCode
     {
         return $this->language;
     }
 
-    public function setLanguage(string $language): void
+    public function setLanguage(LanguageCode $language): void
     {
         $this->language = $language;
     }

--- a/equed-lms/Classes/Domain/Model/CourseCertificate.php
+++ b/equed-lms/Classes/Domain/Model/CourseCertificate.php
@@ -11,6 +11,7 @@ use TYPO3\CMS\Extbase\Annotation\ORM\Lazy;
 use TYPO3\CMS\Extbase\Annotation\ORM\ManyToOne;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 use Equed\EquedLms\Enum\BadgeLevel;
+use Equed\EquedLms\Enum\LanguageCode;
 
 /**
  * CourseCertificate
@@ -41,7 +42,7 @@ final class CourseCertificate extends AbstractEntity
     protected string $certificateNumber = '';
 
     /** Language for generated text */
-    protected string $language = 'en';
+    protected LanguageCode $language = LanguageCode::EN;
 
     /** Badge level represented by this certificate */
     protected BadgeLevel $badgeLevel = BadgeLevel::None;
@@ -121,12 +122,12 @@ final class CourseCertificate extends AbstractEntity
         $this->certificateNumber = $certificateNumber;
     }
 
-    public function getLanguage(): string
+    public function getLanguage(): LanguageCode
     {
         return $this->language;
     }
 
-    public function setLanguage(string $language): void
+    public function setLanguage(LanguageCode $language): void
     {
         $this->language = $language;
     }

--- a/equed-lms/Classes/Domain/Model/CourseFeedback.php
+++ b/equed-lms/Classes/Domain/Model/CourseFeedback.php
@@ -12,6 +12,7 @@ use TYPO3\CMS\Extbase\Annotation\ORM\ManyToOne;
 use TYPO3\CMS\Extbase\Domain\Model\FileReference;
 use Equed\EquedLms\Domain\Model\FrontendUser;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
+use Equed\EquedLms\Enum\LanguageCode;
 
 final class CourseFeedback extends AbstractEntity
 {
@@ -50,7 +51,7 @@ final class CourseFeedback extends AbstractEntity
     protected bool $isVisibleToTrainingCenter = false;
 
     /** Language of free text fields */
-    protected string $language = 'en';
+    protected LanguageCode $language = LanguageCode::EN;
 
     /** Optional wishes for future courses */
     protected ?string $courseWishes = null;
@@ -170,12 +171,12 @@ final class CourseFeedback extends AbstractEntity
         $this->isVisibleToTrainingCenter = $visible;
     }
 
-    public function getLanguage(): string
+    public function getLanguage(): LanguageCode
     {
         return $this->language;
     }
 
-    public function setLanguage(string $language): void
+    public function setLanguage(LanguageCode $language): void
     {
         $this->language = $language;
     }

--- a/equed-lms/Classes/Domain/Model/CourseGoal.php
+++ b/equed-lms/Classes/Domain/Model/CourseGoal.php
@@ -8,6 +8,7 @@ use DateTimeImmutable;
 use Equed\Core\Service\ClockInterface;
 use TYPO3\CMS\Extbase\Annotation\Inject;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
+use Equed\EquedLms\Enum\LanguageCode;
 
 /**
  * CourseGoal
@@ -49,7 +50,7 @@ final class CourseGoal extends AbstractEntity
 
     protected string $notes = '';
 
-    protected string $language = '';
+    protected LanguageCode $language = LanguageCode::EN;
 
     protected string $uuid = '';
 
@@ -220,12 +221,12 @@ final class CourseGoal extends AbstractEntity
         $this->notes = $notes;
     }
 
-    public function getLanguage(): string
+    public function getLanguage(): LanguageCode
     {
         return $this->language;
     }
 
-    public function setLanguage(string $language): void
+    public function setLanguage(LanguageCode $language): void
     {
         $this->language = $language;
     }

--- a/equed-lms/Classes/Domain/Model/CourseInstance.php
+++ b/equed-lms/Classes/Domain/Model/CourseInstance.php
@@ -13,6 +13,7 @@ use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 use Equed\EquedLms\Domain\Model\FrontendUser;
 use Equed\EquedLms\Enum\ValidationMode;
+use Equed\EquedLms\Enum\LanguageCode;
 
 /**
  * CourseInstance Domain Model
@@ -55,9 +56,9 @@ final class CourseInstance extends AbstractEntity
     /**
      * Language of instruction
      *
-     * @var string
+     * @var LanguageCode
      */
-    protected string $language = 'en';
+    protected LanguageCode $language = LanguageCode::EN;
 
     /** @var int */
     protected int $seatsTotal = 0;
@@ -187,12 +188,12 @@ final class CourseInstance extends AbstractEntity
         $this->location = $location;
     }
 
-    public function getLanguage(): string
+    public function getLanguage(): LanguageCode
     {
         return $this->language;
     }
 
-    public function setLanguage(string $language): void
+    public function setLanguage(LanguageCode $language): void
     {
         $this->language = $language;
     }

--- a/equed-lms/Classes/Domain/Model/FeedbackEntry.php
+++ b/equed-lms/Classes/Domain/Model/FeedbackEntry.php
@@ -9,6 +9,7 @@ use Ramsey\Uuid\Uuid;
 use TYPO3\CMS\Extbase\Annotation\ORM\Lazy;
 use TYPO3\CMS\Extbase\Annotation\ORM\ManyToOne;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
+use Equed\EquedLms\Enum\LanguageCode;
 
 /**
  * FeedbackEntry
@@ -35,7 +36,7 @@ final class FeedbackEntry extends AbstractEntity
 
     protected bool $isRequired = false;
 
-    protected string $language = 'en';
+    protected LanguageCode $language = LanguageCode::EN;
 
     protected bool $isArchived = false;
 
@@ -126,12 +127,12 @@ final class FeedbackEntry extends AbstractEntity
         $this->isRequired = $isRequired;
     }
 
-    public function getLanguage(): string
+    public function getLanguage(): LanguageCode
     {
         return $this->language;
     }
 
-    public function setLanguage(string $language): void
+    public function setLanguage(LanguageCode $language): void
     {
         $this->language = $language;
     }

--- a/equed-lms/Classes/Domain/Model/GlossaryEntry.php
+++ b/equed-lms/Classes/Domain/Model/GlossaryEntry.php
@@ -9,6 +9,7 @@ use Ramsey\Uuid\Uuid;
 use TYPO3\CMS\Extbase\Annotation\ORM\Lazy;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 use TYPO3\CMS\Extbase\Annotation\ORM\ManyToOne;
+use Equed\EquedLms\Enum\LanguageCode;
 
 /**
  * GlossaryEntry
@@ -38,7 +39,7 @@ final class GlossaryEntry extends AbstractEntity
     protected ?CourseProgram $courseProgram = null;
 
     /** Language of the entry */
-    protected string $language = 'en';
+    protected LanguageCode $language = LanguageCode::EN;
 
     /** Archive flag */
     protected bool $isArchived = false;
@@ -112,12 +113,12 @@ final class GlossaryEntry extends AbstractEntity
         $this->courseProgram = $courseProgram;
     }
 
-    public function getLanguage(): string
+    public function getLanguage(): LanguageCode
     {
         return $this->language;
     }
 
-    public function setLanguage(string $language): void
+    public function setLanguage(LanguageCode $language): void
     {
         $this->language = $language;
     }

--- a/equed-lms/Classes/Domain/Model/GlossarySuggestion.php
+++ b/equed-lms/Classes/Domain/Model/GlossarySuggestion.php
@@ -9,6 +9,7 @@ use Ramsey\Uuid\Uuid;
 use TYPO3\CMS\Extbase\Annotation\ORM\ManyToOne;
 use TYPO3\CMS\Extbase\Annotation\ORM\Lazy;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
+use Equed\EquedLms\Enum\LanguageCode;
 
 /**
  * GlossarySuggestion
@@ -62,7 +63,7 @@ final class GlossarySuggestion extends AbstractEntity
      *
      * @var string
      */
-    protected string $language = 'en';
+    protected LanguageCode $language = LanguageCode::EN;
 
     /**
      * Current review status (pending | approved | rejected)
@@ -162,12 +163,12 @@ final class GlossarySuggestion extends AbstractEntity
         $this->submittedBy = $submittedBy;
     }
 
-    public function getLanguage(): string
+    public function getLanguage(): LanguageCode
     {
         return $this->language;
     }
 
-    public function setLanguage(string $language): void
+    public function setLanguage(LanguageCode $language): void
     {
         $this->language = $language;
     }

--- a/equed-lms/Classes/Domain/Model/InstructorFeedback.php
+++ b/equed-lms/Classes/Domain/Model/InstructorFeedback.php
@@ -11,6 +11,7 @@ use TYPO3\CMS\Extbase\Annotation\ORM\Lazy;
 use TYPO3\CMS\Extbase\Annotation\ORM\ManyToOne;
 use Equed\EquedLms\Domain\Model\FrontendUser;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
+use Equed\EquedLms\Enum\LanguageCode;
 
 /**
  * InstructorFeedback
@@ -47,7 +48,7 @@ final class InstructorFeedback extends AbstractEntity
 
     protected bool $isArchived = false;
 
-    protected string $language = 'en';
+    protected LanguageCode $language = LanguageCode::EN;
 
     #[ManyToOne]
     #[Lazy]
@@ -170,12 +171,12 @@ final class InstructorFeedback extends AbstractEntity
         $this->isArchived = $archived;
     }
 
-    public function getLanguage(): string
+    public function getLanguage(): LanguageCode
     {
         return $this->language;
     }
 
-    public function setLanguage(string $language): void
+    public function setLanguage(LanguageCode $language): void
     {
         $this->language = $language;
     }

--- a/equed-lms/Classes/Domain/Model/Notification.php
+++ b/equed-lms/Classes/Domain/Model/Notification.php
@@ -12,6 +12,7 @@ use TYPO3\CMS\Extbase\Annotation\ORM\Lazy;
 use TYPO3\CMS\Extbase\Annotation\ORM\ManyToOne;
 use Equed\EquedLms\Domain\Model\FrontendUser;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
+use Equed\EquedLms\Enum\LanguageCode;
 
 /**
  * Domain model for system notifications.
@@ -78,9 +79,9 @@ final class Notification extends AbstractEntity
     protected bool $isArchived = false;
 
     /**
-     * @var string
+     * @var LanguageCode
      */
-    protected string $language = 'en';
+    protected LanguageCode $language = LanguageCode::EN;
 
     /**
      * @var string|null
@@ -256,15 +257,15 @@ final class Notification extends AbstractEntity
     /**
      * Returns the language of the notification.
      */
-    public function getLanguage(): string
+    public function getLanguage(): LanguageCode
     {
         return $this->language;
     }
 
     /**
-     * @param string $language
+     * @param LanguageCode $language
      */
-    public function setLanguage(string $language): void
+    public function setLanguage(LanguageCode $language): void
     {
         $this->language = $language;
     }

--- a/equed-lms/Classes/Domain/Model/ObservationTemplate.php
+++ b/equed-lms/Classes/Domain/Model/ObservationTemplate.php
@@ -12,6 +12,7 @@ use TYPO3\CMS\Extbase\Annotation\ORM\Lazy;
 use TYPO3\CMS\Extbase\Annotation\ORM\ManyToOne;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 use Equed\EquedLms\Domain\Model\CourseProgram;
+use Equed\EquedLms\Enum\LanguageCode;
 
 /**
  * Domain model for observation templates.
@@ -40,7 +41,7 @@ final class ObservationTemplate extends AbstractEntity
 
     protected bool $isActive = true;
 
-    protected string $language = 'en';
+    protected LanguageCode $language = LanguageCode::EN;
 
     protected bool $isArchived = false;
 
@@ -171,7 +172,7 @@ final class ObservationTemplate extends AbstractEntity
     /**
      * Gets language code.
      */
-    public function getLanguage(): string
+    public function getLanguage(): LanguageCode
     {
         return $this->language;
     }
@@ -179,7 +180,7 @@ final class ObservationTemplate extends AbstractEntity
     /**
      * Sets language code.
      */
-    public function setLanguage(string $language): void
+    public function setLanguage(LanguageCode $language): void
     {
         $this->language = $language;
     }

--- a/equed-lms/Classes/Domain/Model/QmsCase.php
+++ b/equed-lms/Classes/Domain/Model/QmsCase.php
@@ -16,6 +16,7 @@ use TYPO3\CMS\Extbase\Annotation\ORM\ManyToOne;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 use TYPO3\CMS\Extbase\Domain\Model\FileReference;
 use Equed\EquedLms\Domain\Model\FrontendUser;
+use Equed\EquedLms\Enum\LanguageCode;
 
 /**
  * Domain model for QMS cases.
@@ -78,7 +79,7 @@ final class QmsCase extends AbstractEntity
 
     protected bool $isArchived = false;
 
-    protected string $language = 'en';
+    protected LanguageCode $language = LanguageCode::EN;
 
     protected DateTimeImmutable $createdAt;
 
@@ -421,7 +422,7 @@ final class QmsCase extends AbstractEntity
     /**
      * Gets the language code.
      */
-    public function getLanguage(): string
+    public function getLanguage(): LanguageCode
     {
         return $this->language;
     }
@@ -429,7 +430,7 @@ final class QmsCase extends AbstractEntity
     /**
      * Sets the language code.
      */
-    public function setLanguage(string $language): void
+    public function setLanguage(LanguageCode $language): void
     {
         $this->language = $language;
     }

--- a/equed-lms/Classes/Domain/Model/StandardCheckItem.php
+++ b/equed-lms/Classes/Domain/Model/StandardCheckItem.php
@@ -11,6 +11,7 @@ use TYPO3\CMS\Extbase\Annotation\Inject;
 use TYPO3\CMS\Extbase\Annotation\ORM\Lazy;
 use TYPO3\CMS\Extbase\Annotation\ORM\ManyToOne;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
+use Equed\EquedLms\Enum\LanguageCode;
 
 /**
  * Domain model for standard check items.
@@ -41,7 +42,7 @@ final class StandardCheckItem extends AbstractEntity
 
     protected bool $isArchived = false;
 
-    protected string $language = 'en';
+    protected LanguageCode $language = LanguageCode::EN;
 
     protected DateTimeImmutable $createdAt;
 
@@ -187,7 +188,7 @@ final class StandardCheckItem extends AbstractEntity
     /**
      * Gets the language code.
      */
-    public function getLanguage(): string
+    public function getLanguage(): LanguageCode
     {
         return $this->language;
     }
@@ -195,7 +196,7 @@ final class StandardCheckItem extends AbstractEntity
     /**
      * Sets the language code.
      */
-    public function setLanguage(string $language): void
+    public function setLanguage(LanguageCode $language): void
     {
         $this->language = $language;
     }

--- a/equed-lms/Classes/Domain/Model/TrainingCenterFeedback.php
+++ b/equed-lms/Classes/Domain/Model/TrainingCenterFeedback.php
@@ -11,6 +11,7 @@ use TYPO3\CMS\Extbase\Annotation\Inject;
 use TYPO3\CMS\Extbase\Annotation\ORM\Lazy;
 use TYPO3\CMS\Extbase\Annotation\ORM\ManyToOne;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
+use Equed\EquedLms\Enum\LanguageCode;
 
 /**
  * Domain model for training center feedback.
@@ -49,7 +50,7 @@ final class TrainingCenterFeedback extends AbstractEntity
 
     protected bool $visibleToAdmin = true;
 
-    protected string $language = 'en';
+    protected LanguageCode $language = LanguageCode::EN;
 
     protected bool $isArchived = false;
 
@@ -235,7 +236,7 @@ final class TrainingCenterFeedback extends AbstractEntity
     /**
      * Gets the language code.
      */
-    public function getLanguage(): string
+    public function getLanguage(): LanguageCode
     {
         return $this->language;
     }
@@ -243,7 +244,7 @@ final class TrainingCenterFeedback extends AbstractEntity
     /**
      * Sets the language code.
      */
-    public function setLanguage(string $language): void
+    public function setLanguage(LanguageCode $language): void
     {
         $this->language = $language;
     }

--- a/equed-lms/Classes/Domain/Model/UserProfile.php
+++ b/equed-lms/Classes/Domain/Model/UserProfile.php
@@ -13,6 +13,7 @@ use TYPO3\CMS\Extbase\Annotation\ORM\OneToOne;
 use Equed\EquedLms\Domain\Model\FrontendUser;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 use Equed\EquedLms\Enum\BadgeLevel;
+use Equed\EquedLms\Enum\LanguageCode;
 
 /**
  * Domain model for user profiles.
@@ -71,7 +72,7 @@ final class UserProfile extends AbstractEntity
      */
     protected bool $onboardingComplete = false;
 
-    protected string $language = 'en';
+    protected LanguageCode $language = LanguageCode::EN;
 
     protected ?DateTimeImmutable $lastLoginAt = null;
 
@@ -237,12 +238,12 @@ final class UserProfile extends AbstractEntity
         $this->hasProAccess = $hasAccess;
     }
 
-    public function getLanguage(): string
+    public function getLanguage(): LanguageCode
     {
         return $this->language;
     }
 
-    public function setLanguage(string $language): void
+    public function setLanguage(LanguageCode $language): void
     {
         $this->language = $language;
     }

--- a/equed-lms/Classes/EventListener/CertificateNotificationListener.php
+++ b/equed-lms/Classes/EventListener/CertificateNotificationListener.php
@@ -10,6 +10,7 @@ use Equed\EquedLms\Service\GptTranslationServiceInterface;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 use TYPO3\CMS\Core\Messaging\FlashMessageService;
 use TYPO3\CMS\Core\Annotations\EventListener;
+use Equed\EquedLms\Enum\LanguageCode;
 
 /**
  * Sends a notification when a certificate is issued.
@@ -57,7 +58,7 @@ final class CertificateNotificationListener
             'titleKey'       => $messageKey,
             'customMessage'  => $message,
             'type'           => 'certificate',
-            'language'       => $user->getUserProfile()?->getLanguage() ?? 'en',
+            'language'       => $user->getUserProfile()?->getLanguage() ?? LanguageCode::EN,
             'status'         => 'active',
             'isRead'         => false,
             'isArchived'     => false,

--- a/equed-lms/Classes/Service/SyncService.php
+++ b/equed-lms/Classes/Service/SyncService.php
@@ -10,6 +10,7 @@ use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 use Ramsey\Uuid\Uuid;
 use Equed\EquedLms\Domain\Service\ClockInterface;
 use Equed\EquedLms\Service\LogService;
+use Equed\EquedLms\Enum\LanguageCode;
 
 final class SyncService
 {
@@ -27,7 +28,7 @@ final class SyncService
             'userId'      => $profile->getFeUser(),
             'uuid'        => $profile->getUuid(),
             'displayName' => $profile->getDisplayName(),
-            'language'    => $profile->getLanguage(),
+            'language'    => $profile->getLanguage()->value,
             'country'     => $profile->getCountry(),
             'updatedAt'   => $profile->getUpdatedAt()?->format(DATE_ATOM),
         ];
@@ -71,7 +72,7 @@ final class SyncService
                 $profile->setDisplayName((string) $data['displayName']);
             }
             if (isset($data['language'])) {
-                $profile->setLanguage((string) $data['language']);
+                $profile->setLanguage(LanguageCode::from((string) $data['language']));
             }
             if (isset($data['country'])) {
                 $profile->setCountry((string) $data['country']);

--- a/equed-lms/Tests/Unit/Controller/SyncControllerTest.php
+++ b/equed-lms/Tests/Unit/Controller/SyncControllerTest.php
@@ -89,7 +89,7 @@ class SyncControllerTest extends TestCase
         $profile->initializeObject();
         $profile->setFeUser(5);
         $profile->setDisplayName('John');
-        $profile->setLanguage('en');
+        $profile->setLanguage(\Equed\EquedLms\Enum\LanguageCode::EN);
         $profile->setCountry('US');
 
         $this->repo->findByUserId(5)->willReturn($profile)->shouldBeCalled();

--- a/equed-lms/Tests/Unit/Domain/Model/CourseInstanceTest.php
+++ b/equed-lms/Tests/Unit/Domain/Model/CourseInstanceTest.php
@@ -48,10 +48,10 @@ namespace Equed\EquedLms\Tests\Unit\Domain\Model {
 
         public function testSetAndGetLanguageAndSeatsTotal(): void
         {
-            $this->subject->setLanguage('de');
+            $this->subject->setLanguage(\Equed\EquedLms\Enum\LanguageCode::DE);
             $this->subject->setSeatsTotal(10);
 
-            $this->assertSame('de', $this->subject->getLanguage());
+            $this->assertSame(\Equed\EquedLms\Enum\LanguageCode::DE, $this->subject->getLanguage());
             $this->assertSame(10, $this->subject->getSeatsTotal());
         }
 

--- a/equed-lms/Tests/Unit/Service/SyncServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/SyncServiceTest.php
@@ -84,7 +84,7 @@ class SyncServiceTest extends TestCase
         $profile->initializeObject();
         $profile->setFeUser(5);
         $profile->setDisplayName('John');
-        $profile->setLanguage('de');
+        $profile->setLanguage(\Equed\EquedLms\Enum\LanguageCode::DE);
         $profile->setCountry('DE');
         $profile->setUpdatedAt(new \DateTimeImmutable('2024-01-01T00:00:00+00:00'));
 


### PR DESCRIPTION
## Summary
- type various `$language` properties with `LanguageCode`
- adjust getter/setter methods
- update SyncService and listener logic
- update related unit tests

## Testing
- `composer lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684de19bdcc08324bb5285252672e64c