### PR TITLE
Refactor roles to enum

### DIFF
--- a/equed-lms/Classes/Enum/UserRole.php
+++ b/equed-lms/Classes/Enum/UserRole.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Enum;
+
+/**
+ * Available frontend user roles.
+ */
+enum UserRole: string
+{
+    case Learner = 'learner';
+    case Instructor = 'instructor';
+    case Certifier = 'certifier';
+    case ServiceCenter = 'sc_user';
+}

--- a/equed-lms/Classes/Helper/AccessHelper.php
+++ b/equed-lms/Classes/Helper/AccessHelper.php
@@ -8,6 +8,7 @@ use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use Equed\EquedLms\Domain\Model\FrontendUser;
+use Equed\EquedLms\Enum\UserRole;
 
 /**
  * AccessHelper service for checking user roles and permissions.
@@ -28,7 +29,7 @@ final class AccessHelper
      */
     public function isInstructor(array|FrontendUser $user): bool
     {
-        return $this->hasRole($user, 'instructor');
+        return $this->hasRole($user, UserRole::Instructor);
     }
 
     /**
@@ -39,7 +40,7 @@ final class AccessHelper
      */
     public function isCertifier(array|FrontendUser $user): bool
     {
-        return $this->hasRole($user, 'certifier');
+        return $this->hasRole($user, UserRole::Certifier);
     }
 
     /**
@@ -50,7 +51,7 @@ final class AccessHelper
      */
     public function isServiceCenter(array|FrontendUser $user): bool
     {
-        return $this->hasRole($user, 'sc_user');
+        return $this->hasRole($user, UserRole::ServiceCenter);
     }
 
     /**
@@ -66,7 +67,7 @@ final class AccessHelper
      *
      * @param array<string, mixed>|FrontendUser $user
      */
-    public function hasRole(array|FrontendUser $user, string $targetRole): bool
+    public function hasRole(array|FrontendUser $user, UserRole $targetRole): bool
     {
         $rolesField = $user instanceof FrontendUser
             ? $user->getUsergroup()
@@ -81,7 +82,7 @@ final class AccessHelper
             }
         }
 
-        return in_array($targetRole, $roleList, true);
+        return in_array($targetRole->value, $roleList, true);
     }
 }
 // EOF

--- a/equed-lms/Classes/Service/AuthService.php
+++ b/equed-lms/Classes/Service/AuthService.php
@@ -6,6 +6,7 @@ namespace Equed\EquedLms\Service;
 
 use Equed\EquedLms\Domain\Model\UserProfile;
 use Equed\EquedLms\Domain\Repository\UserProfileRepositoryInterface;
+use Equed\EquedLms\Enum\UserRole;
 
 final class AuthService
 {
@@ -18,23 +19,22 @@ final class AuthService
      * Get the role of a frontend user.
      *
      * @param int $frontendUserId
-     * @return string One of 'certifier', 'instructor' or 'learner'
      */
-    public function getUserRole(int $frontendUserId): string
+    public function getUserRole(int $frontendUserId): UserRole
     {
         $profile = $this->userProfileRepository->findByFeUser($frontendUserId);
 
         if ($profile instanceof UserProfile) {
             if ($profile->isCertifier()) {
-                return 'certifier';
+                return UserRole::Certifier;
             }
 
             if ($profile->isInstructor()) {
-                return 'instructor';
+                return UserRole::Instructor;
             }
         }
 
-        return 'learner';
+        return UserRole::Learner;
     }
 
     /**
@@ -45,7 +45,7 @@ final class AuthService
      */
     public function isCertifier(int $frontendUserId): bool
     {
-        return $this->getUserRole($frontendUserId) === 'certifier';
+        return $this->getUserRole($frontendUserId) === UserRole::Certifier;
     }
 
     /**
@@ -56,7 +56,7 @@ final class AuthService
      */
     public function isInstructor(int $frontendUserId): bool
     {
-        return $this->getUserRole($frontendUserId) === 'instructor';
+        return $this->getUserRole($frontendUserId) === UserRole::Instructor;
     }
 
     /**
@@ -67,6 +67,6 @@ final class AuthService
      */
     public function isLearner(int $frontendUserId): bool
     {
-        return $this->getUserRole($frontendUserId) === 'learner';
+        return $this->getUserRole($frontendUserId) === UserRole::Learner;
     }
 }

--- a/equed-lms/Classes/ViewHelpers/UserRoleViewHelper.php
+++ b/equed-lms/Classes/ViewHelpers/UserRoleViewHelper.php
@@ -6,6 +6,7 @@ namespace Equed\EquedLms\ViewHelpers;
 
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 use Equed\EquedLms\Domain\Repository\UserProfileRepositoryInterface;
+use Equed\EquedLms\Enum\UserRole;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
@@ -49,16 +50,23 @@ final class UserRoleViewHelper extends AbstractViewHelper
         $userId = (int)$this->arguments['userId'];
         $profile = $this->profileRepository->findByFeUser($userId);
 
-        $roleKey = 'role.unknown';
+        $role = null;
         if ($profile !== null) {
-            $roleKey = $profile->getIsCertifier()
-                ? 'role.certifier'
+            $role = $profile->getIsCertifier()
+                ? UserRole::Certifier
                 : (
                     $profile->isInstructor()
-                    ? 'role.instructor'
-                    : 'role.participant'
+                    ? UserRole::Instructor
+                    : UserRole::Learner
                 );
         }
+
+        $roleKey = match ($role) {
+            UserRole::Certifier   => 'role.certifier',
+            UserRole::Instructor  => 'role.instructor',
+            UserRole::Learner     => 'role.participant',
+            default               => 'role.unknown',
+        };
 
         return $this->translate($roleKey) ?? ucfirst(str_replace('role.', '', $roleKey));
     }

--- a/equed-lms/Tests/Unit/Service/AuthServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/AuthServiceTest.php
@@ -7,6 +7,7 @@ namespace Equed\EquedLms\Tests\Unit\Service;
 use Equed\EquedLms\Domain\Model\UserProfile;
 use Equed\EquedLms\Domain\Repository\UserProfileRepository;
 use Equed\EquedLms\Service\AuthService;
+use Equed\EquedLms\Enum\UserRole;
 use Equed\EquedLms\Tests\Traits\ProphecyTrait;
 use PHPUnit\Framework\TestCase;
 
@@ -32,7 +33,7 @@ class AuthServiceTest extends TestCase
         $profile->isInstructor()->shouldNotBeCalled();
         $this->repository->findByFeUser(5)->willReturn($profile->reveal());
 
-        $this->assertSame('certifier', $this->subject->getUserRole(5));
+        $this->assertSame(UserRole::Certifier, $this->subject->getUserRole(5));
     }
 
     public function testReturnsInstructorRole(): void
@@ -42,13 +43,13 @@ class AuthServiceTest extends TestCase
         $profile->isInstructor()->willReturn(true);
         $this->repository->findByFeUser(7)->willReturn($profile->reveal());
 
-        $this->assertSame('instructor', $this->subject->getUserRole(7));
+        $this->assertSame(UserRole::Instructor, $this->subject->getUserRole(7));
     }
 
     public function testReturnsLearnerIfNoProfile(): void
     {
         $this->repository->findByFeUser(9)->willReturn(null);
 
-        $this->assertSame('learner', $this->subject->getUserRole(9));
+        $this->assertSame(UserRole::Learner, $this->subject->getUserRole(9));
     }
 }

--- a/equed-lms/Tests/Unit/ViewHelpers/UserRoleViewHelperTest.php
+++ b/equed-lms/Tests/Unit/ViewHelpers/UserRoleViewHelperTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Tests\Unit\ViewHelpers;
+
+use Equed\EquedLms\ViewHelpers\UserRoleViewHelper;
+use Equed\EquedLms\Service\GptTranslationServiceInterface;
+use Equed\EquedLms\Domain\Repository\UserProfileRepositoryInterface;
+use Equed\EquedLms\Domain\Model\UserProfile;
+use Equed\EquedLms\Tests\Traits\ProphecyTrait;
+use PHPUnit\Framework\TestCase;
+
+final class UserRoleViewHelperTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testRenderReturnsTranslatedRole(): void
+    {
+        $translator = $this->prophesize(GptTranslationServiceInterface::class);
+        $translator->isEnabled()->willReturn(true);
+        $translator->translate('role.instructor', [], 'equed_lms')->willReturn('Instructor');
+
+        $profile = $this->prophesize(UserProfile::class);
+        $profile->getIsCertifier()->willReturn(false);
+        $profile->isInstructor()->willReturn(true);
+
+        $repo = $this->prophesize(UserProfileRepositoryInterface::class);
+        $repo->findByFeUser(7)->willReturn($profile->reveal());
+
+        $viewHelper = new UserRoleViewHelper($translator->reveal(), $repo->reveal());
+        $ref = new \ReflectionProperty($viewHelper, 'arguments');
+        $ref->setAccessible(true);
+        $ref->setValue($viewHelper, ['userId' => 7]);
+
+        $this->assertSame('Instructor', $viewHelper->render());
+    }
+}


### PR DESCRIPTION
## Summary
- add `UserRole` enum for frontend user roles
- refactor `AuthService` and `AccessHelper` to use the enum
- adjust `UserRoleViewHelper` to leverage the enum
- update tests and add new `UserRoleViewHelperTest`

## Testing
- `vendor/bin/phpunit -c equed-lms/phpunit.xml.dist` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dfd17e05c83249583c89d2e5dbaf2