### PR TITLE
Add missing service interfaces

### DIFF
--- a/equed-lms/Classes/Controller/Api/CertificateController.php
+++ b/equed-lms/Classes/Controller/Api/CertificateController.php
@@ -11,7 +11,7 @@ use TYPO3\CMS\Core\Context\Context;
 use Equed\Core\Service\ConfigurationServiceInterface;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 use Equed\EquedLms\Domain\Repository\CertificateRepositoryInterface;
-use Equed\EquedLms\Service\CertificateService;
+use Equed\EquedLms\Domain\Service\CertificateServiceInterface;
 use Equed\EquedLms\Domain\Service\BadgeServiceInterface;
 
 /**
@@ -26,7 +26,7 @@ final class CertificateController
 {
     public function __construct(
         private readonly CertificateRepositoryInterface $certificateRepository,
-        private readonly CertificateService    $certificateService,
+        private readonly CertificateServiceInterface    $certificateService,
         private readonly BadgeServiceInterface          $badgeService,
         private readonly ConfigurationServiceInterface  $configurationService,
         private readonly GptTranslationServiceInterface $translationService,
@@ -181,3 +181,4 @@ final class CertificateController
     }
 }
 // End of file
+

--- a/equed-lms/Classes/Domain/Service/ApiResponseServiceInterface.php
+++ b/equed-lms/Classes/Domain/Service/ApiResponseServiceInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Domain\Service;
+
+interface ApiResponseServiceInterface
+{
+    /**
+     * Builds a successful API response.
+     *
+     * @param array<string, mixed> $data Optional payload data
+     * @param string $messageKey Translation key for the message
+     * @param string|null $language ISO language code to translate into
+     *
+     * @return array<string, mixed>
+     */
+    public function success(array $data = [], string $messageKey = 'ok', ?string $language = null): array;
+
+    /**
+     * Builds an error API response.
+     *
+     * @param string $messageKey Translation key for the error message
+     * @param int $code HTTP-like error code
+     * @param string|null $language ISO language code to translate into
+     *
+     * @return array<string, mixed>
+     */
+    public function error(string $messageKey = 'error', int $code = 400, ?string $language = null): array;
+}
+

--- a/equed-lms/Classes/Domain/Service/BadgeAwardServiceInterface.php
+++ b/equed-lms/Classes/Domain/Service/BadgeAwardServiceInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Domain\Service;
+
+interface BadgeAwardServiceInterface
+{
+    /**
+     * Award badges for completed courses and learning paths.
+     *
+     * @return int Number of badges awarded
+     */
+    public function awardPendingBadges(): int;
+}
+

--- a/equed-lms/Classes/Domain/Service/CertificateServiceInterface.php
+++ b/equed-lms/Classes/Domain/Service/CertificateServiceInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Domain\Service;
+
+use Equed\EquedLms\Domain\Model\CertificateDispatch;
+use Equed\EquedLms\Domain\Model\UserCourseRecord;
+
+interface CertificateServiceInterface
+{
+    public function issueCertificate(UserCourseRecord $userCourseRecord): CertificateDispatch;
+
+    public function sendCertificateNotification(CertificateDispatch $dispatch): void;
+}
+

--- a/equed-lms/Classes/Domain/Service/CourseAccessServiceInterface.php
+++ b/equed-lms/Classes/Domain/Service/CourseAccessServiceInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Domain\Service;
+
+use Equed\EquedLms\Domain\Model\Lesson;
+
+interface CourseAccessServiceInterface
+{
+    public function hasAccessToCourseInstance(int $feUserId, int $courseInstanceId): bool;
+
+    public function isLessonUnlockedForUser(int $feUserId, Lesson $lesson): bool;
+}
+

--- a/equed-lms/Classes/EventListener/CourseValidationListener.php
+++ b/equed-lms/Classes/EventListener/CourseValidationListener.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Equed\EquedLms\EventListener;
 
 use Equed\EquedLms\Event\Course\CourseValidatedEvent;
-use Equed\EquedLms\Service\CertificateService;
+use Equed\EquedLms\Domain\Service\CertificateServiceInterface;
 use Equed\EquedLms\Service\LogService;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use TYPO3\CMS\Core\SingletonInterface;
@@ -16,7 +16,7 @@ use TYPO3\CMS\Core\SingletonInterface;
 final class CourseValidationListener implements EventSubscriberInterface, SingletonInterface
 {
     public function __construct(
-        protected readonly CertificateService $certificateService,
+        protected readonly CertificateServiceInterface $certificateService,
         protected readonly LogService $logService
     ) {
     }
@@ -50,3 +50,4 @@ final class CourseValidationListener implements EventSubscriberInterface, Single
     }
 }
 // EOF
+

--- a/equed-lms/Classes/Scheduler/BadgeAwardTask.php
+++ b/equed-lms/Classes/Scheduler/BadgeAwardTask.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Equed\EquedLms\Scheduler;
 
-use Equed\EquedLms\Service\BadgeAwardService;
+use Equed\EquedLms\Domain\Service\BadgeAwardServiceInterface;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use TYPO3\CMS\Core\Messaging\FlashMessage;
@@ -19,7 +19,7 @@ final class BadgeAwardTask extends AbstractTask implements LoggerAwareInterface
     use LoggerAwareTrait;
 
     public function __construct(
-        private readonly BadgeAwardService $badgeAwardService,
+        private readonly BadgeAwardServiceInterface $badgeAwardService,
         ObjectManagerInterface $objectManager = null
     ) {
         parent::__construct($objectManager);
@@ -43,3 +43,4 @@ final class BadgeAwardTask extends AbstractTask implements LoggerAwareInterface
     }
 }
 // EOF
+

--- a/equed-lms/Classes/Service/ApiResponseService.php
+++ b/equed-lms/Classes/Service/ApiResponseService.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Equed\EquedLms\Service;
 
+use Equed\EquedLms\Domain\Service\ApiResponseServiceInterface;
+
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 
 /**
  * Provides standardized API responses with multilingual support.
  */
-final class ApiResponseService
+final class ApiResponseService implements ApiResponseServiceInterface
 {
     public function __construct(
         private readonly GptTranslationServiceInterface $translationService
@@ -58,3 +60,4 @@ final class ApiResponseService
         ];
     }
 }
+

--- a/equed-lms/Classes/Service/BadgeAwardService.php
+++ b/equed-lms/Classes/Service/BadgeAwardService.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Equed\EquedLms\Service;
 
+use Equed\EquedLms\Domain\Service\BadgeAwardServiceInterface;
+
 use Equed\EquedLms\Domain\Repository\BadgeAwardRepositoryInterface;
 use Equed\EquedLms\Domain\Repository\UserCourseRecordRepositoryInterface;
 use Equed\EquedLms\Domain\Repository\LearningPathRepositoryInterface;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 
-final class BadgeAwardService
+final class BadgeAwardService implements BadgeAwardServiceInterface
 {
     public function __construct(
         private readonly BadgeAwardRepositoryInterface       $awardRepo,
@@ -70,3 +72,4 @@ final class BadgeAwardService
         return $awarded;
     }
 }
+

--- a/equed-lms/Classes/Service/CertificateService.php
+++ b/equed-lms/Classes/Service/CertificateService.php
@@ -11,8 +11,9 @@ use Equed\EquedLms\Domain\Repository\CertificateDispatchRepositoryInterface;
 use Equed\EquedLms\Factory\CertificateDispatchFactoryInterface;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 use Equed\EquedLms\Domain\Service\NotificationServiceInterface;
+use Equed\EquedLms\Domain\Service\CertificateServiceInterface;
 
-final class CertificateService
+final class CertificateService implements CertificateServiceInterface
 {
     private string $qrCodeBaseUrl;
 
@@ -76,3 +77,4 @@ final class CertificateService
         }
     }
 }
+

--- a/equed-lms/Classes/Service/CourseAccessService.php
+++ b/equed-lms/Classes/Service/CourseAccessService.php
@@ -7,11 +7,12 @@ namespace Equed\EquedLms\Service;
 use Equed\EquedLms\Domain\Model\Lesson;
 use Equed\EquedLms\Domain\Model\UserCourseRecord;
 use Equed\EquedLms\Domain\Repository\UserCourseRecordRepositoryInterface;
+use Equed\EquedLms\Domain\Service\CourseAccessServiceInterface;
 
 /**
  * Service to check access permissions for courses and lessons.
  */
-final class CourseAccessService
+final class CourseAccessService implements CourseAccessServiceInterface
 {
     private array $userRecordsCache = [];
 
@@ -75,3 +76,4 @@ final class CourseAccessService
         return $this->userRecordsCache[$feUserId];
     }
 }
+

--- a/equed-lms/Classes/Service/CourseStatusUpdaterService.php
+++ b/equed-lms/Classes/Service/CourseStatusUpdaterService.php
@@ -8,7 +8,7 @@ use Equed\EquedLms\Domain\Service\ClockInterface;
 use Equed\EquedLms\Domain\Model\UserCourseRecord;
 use Equed\EquedLms\Domain\Repository\UserCourseRecordRepositoryInterface;
 use Equed\EquedLms\Enum\CourseStatus;
-use Equed\EquedLms\Service\CertificateService;
+use Equed\EquedLms\Domain\Service\CertificateServiceInterface;
 use Equed\EquedLms\Domain\Service\NotificationServiceInterface;
 
 /**
@@ -18,7 +18,7 @@ use Equed\EquedLms\Domain\Service\NotificationServiceInterface;
 final class CourseStatusUpdaterService
 {
     public function __construct(
-        private readonly CertificateService    $certificateService,
+        private readonly CertificateServiceInterface    $certificateService,
         private readonly NotificationServiceInterface   $notificationService,
         private readonly UserCourseRecordRepositoryInterface $userCourseRecordRepository,
         private readonly ClockInterface        $clock
@@ -54,3 +54,4 @@ final class CourseStatusUpdaterService
         );
     }
 }
+

--- a/equed-lms/Classes/Task/CertificateDispatchTask.php
+++ b/equed-lms/Classes/Task/CertificateDispatchTask.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Equed\EquedLms\Task;
 
 use TYPO3\CMS\Scheduler\Task\AbstractTask;
-use Equed\EquedLms\Service\CertificateService;
+use Equed\EquedLms\Domain\Service\CertificateServiceInterface;
 
 /**
  * Scheduler task to dispatch certificates in queue.
@@ -13,7 +13,7 @@ use Equed\EquedLms\Service\CertificateService;
 final class CertificateDispatchTask extends AbstractTask
 {
     public function __construct(
-        private readonly CertificateService $certificateService
+        private readonly CertificateServiceInterface $certificateService
     ) {
     }
 
@@ -30,3 +30,4 @@ final class CertificateDispatchTask extends AbstractTask
     }
 }
 // EOF
+

--- a/equed-lms/Tests/Unit/Service/ApiResponseServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/ApiResponseServiceTest.php
@@ -7,6 +7,7 @@ namespace Equed\EquedLms\Tests\Unit\Service;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Equed\EquedLms\Tests\Traits\ProphecyTrait;
+use Equed\EquedLms\Domain\Service\ApiResponseServiceInterface;
 use Equed\EquedLms\Service\ApiResponseService;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 
@@ -14,7 +15,7 @@ class ApiResponseServiceTest extends TestCase
 {
     use ProphecyTrait;
 
-    private ApiResponseService $subject;
+    private ApiResponseServiceInterface $subject;
     private $translationService;
 
     protected function setUp(): void

--- a/equed-lms/Tests/Unit/Service/BadgeAwardServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/BadgeAwardServiceTest.php
@@ -15,6 +15,7 @@ namespace Equed\EquedLms\Domain\Repository {
 namespace Equed\EquedLms\Tests\Unit\Service;
 
 use Equed\EquedLms\Service\BadgeAwardService;
+use Equed\EquedLms\Domain\Service\BadgeAwardServiceInterface;
 use Equed\EquedLms\Domain\Repository\BadgeAwardRepositoryInterface;
 use Equed\EquedLms\Domain\Repository\UserCourseRecordRepositoryInterface;
 use Equed\EquedLms\Domain\Repository\LearningPathRepositoryInterface;
@@ -61,6 +62,7 @@ class BadgeAwardServiceTest extends TestCase
             $translator->reveal()
         );
 
+        /** @var BadgeAwardServiceInterface $service */
         $count = $service->awardPendingBadges();
         $this->assertSame(2, $count);
     }

--- a/equed-lms/Tests/Unit/Service/CertificateServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/CertificateServiceTest.php
@@ -9,6 +9,7 @@ use Equed\EquedLms\Domain\Model\UserCourseRecord;
 use Equed\EquedLms\Domain\Repository\CertificateDispatchRepository;
 use Equed\EquedLms\Factory\CertificateDispatchFactoryInterface;
 use Equed\EquedLms\Service\CertificateService;
+use Equed\EquedLms\Domain\Service\CertificateServiceInterface;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 use Equed\EquedLms\Domain\Service\ClockInterface;
 use Equed\EquedLms\Domain\Service\NotificationServiceInterface;
@@ -19,7 +20,7 @@ class CertificateServiceTest extends TestCase
 {
     use ProphecyTrait;
 
-    private CertificateService $subject;
+    private CertificateServiceInterface $subject;
     private $repository;
     private $factory;
     private $translator;

--- a/equed-lms/Tests/Unit/Service/CourseAccessServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/CourseAccessServiceTest.php
@@ -10,6 +10,7 @@ use Equed\EquedLms\Domain\Model\Lesson;
 use Equed\EquedLms\Domain\Model\UserCourseRecord;
 use Equed\EquedLms\Domain\Repository\UserCourseRecordRepository;
 use Equed\EquedLms\Service\CourseAccessService;
+use Equed\EquedLms\Domain\Service\CourseAccessServiceInterface;
 use Equed\EquedLms\Tests\Traits\ProphecyTrait;
 use PHPUnit\Framework\TestCase;
 
@@ -17,7 +18,7 @@ class CourseAccessServiceTest extends TestCase
 {
     use ProphecyTrait;
 
-    private CourseAccessService $subject;
+    private CourseAccessServiceInterface $subject;
     private $repository;
 
     protected function setUp(): void

--- a/equed-lms/Tests/Unit/Service/CourseStatusUpdaterServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/CourseStatusUpdaterServiceTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Equed\EquedLms\Tests\Unit\Service;
 
 use Equed\EquedLms\Service\CourseStatusUpdaterService;
-use Equed\EquedLms\Service\CertificateService;
+use Equed\EquedLms\Domain\Service\CertificateServiceInterface;
 use Equed\EquedLms\Domain\Service\NotificationServiceInterface;
 use Equed\EquedLms\Domain\Repository\UserCourseRecordRepositoryInterface;
 use Equed\EquedLms\Domain\Service\ClockInterface;
@@ -30,7 +30,7 @@ class CourseStatusUpdaterServiceTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->certificateService = $this->prophesize(CertificateService::class);
+        $this->certificateService = $this->prophesize(CertificateServiceInterface::class);
         $this->notificationService = $this->prophesize(NotificationServiceInterface::class);
         $this->repository = $this->prophesize(UserCourseRecordRepositoryInterface::class);
         $this->clock = $this->prophesize(ClockInterface::class);


### PR DESCRIPTION
## Summary
- add service interfaces for API responses, badge awards, certificate dispatch and course access
- implement new interfaces in services
- reference interfaces in constructors and tests

## Testing
- `composer install --no-interaction` *(fails: command not found)*
- `phpunit -c phpunit.xml.dist` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dfed0260c8324935c3e8a4b044a15