### PR TITLE
Refactor GPT services to use PSR‑18 client

### DIFF
--- a/equed-core/Classes/Service/GptClientInterface.php
+++ b/equed-core/Classes/Service/GptClientInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedCore\Service;
+
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Thin wrapper around a PSR-18 HTTP client for GPT requests.
+ */
+interface GptClientInterface
+{
+    /**
+     * Send a POST request with a JSON payload.
+     *
+     * @param string               $url     Request URL
+     * @param array<string,string> $headers HTTP headers
+     * @param array<string,mixed>  $payload JSON body payload
+     */
+    public function postJson(string $url, array $headers, array $payload): ResponseInterface;
+}

--- a/equed-core/Classes/Service/GptTranslationService.php
+++ b/equed-core/Classes/Service/GptTranslationService.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Equed\EquedCore\Service;
 
-use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Equed\EquedCore\Service\GptClientInterface;
 
 class GptTranslationService
 {
@@ -17,7 +17,7 @@ class GptTranslationService
     private string $endpoint;
 
     public function __construct(
-        private readonly HttpClientInterface $httpClient,
+        private readonly GptClientInterface $gptClient,
         ?string $apiKey = null,
         ?string $endpoint = null,
     ) {
@@ -37,17 +37,16 @@ class GptTranslationService
 
     public function translate(string $text, string $targetLang): string
     {
-        $response = $this->httpClient->request('POST', $this->endpoint, [
-            'json' => [
-                'text' => $text,
+        $response = $this->gptClient->postJson(
+            $this->endpoint,
+            ['Authorization' => 'Bearer ' . $this->apiKey],
+            [
+                'text'   => $text,
                 'target' => $targetLang,
-            ],
-            'headers' => [
-                'Authorization' => 'Bearer ' . $this->apiKey,
-            ],
-        ]);
+            ]
+        );
 
-        $data = $response->toArray();
+        $data = json_decode($response->getBody()->getContents(), true);
 
         return (string) ($data['translation'] ?? '');
     }

--- a/equed-core/Classes/Service/Psr18GptClient.php
+++ b/equed-core/Classes/Service/Psr18GptClient.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedCore\Service;
+
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Default implementation of {@link GptClientInterface} using PSR-18 client.
+ */
+final class Psr18GptClient implements GptClientInterface
+{
+    public function __construct(
+        private readonly ClientInterface $client,
+        private readonly RequestFactoryInterface $requestFactory,
+        private readonly StreamFactoryInterface $streamFactory
+    ) {
+    }
+
+    public function postJson(string $url, array $headers, array $payload): ResponseInterface
+    {
+        $headers['Content-Type'] = $headers['Content-Type'] ?? 'application/json';
+        $body    = $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR));
+        $request = $this->requestFactory->createRequest('POST', $url);
+        foreach ($headers as $name => $value) {
+            $request = $request->withHeader($name, $value);
+        }
+        $request = $request->withBody($body);
+        return $this->client->sendRequest($request);
+    }
+}

--- a/equed-core/Tests/Unit/Service/GptTranslationServiceTest.php
+++ b/equed-core/Tests/Unit/Service/GptTranslationServiceTest.php
@@ -3,8 +3,8 @@
 namespace Equed\EquedCore\Tests\Unit\Service;
 
 use Equed\EquedCore\Service\GptTranslationService;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
+use Psr\Http\Message\ResponseInterface;
+use Equed\EquedCore\Service\GptClientInterface;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
 class GptTranslationServiceTest extends UnitTestCase
@@ -16,19 +16,18 @@ class GptTranslationServiceTest extends UnitTestCase
 
         $response = $this->createMock(ResponseInterface::class);
         $response->expects($this->once())
-            ->method('toArray')
-            ->willReturn(['translation' => 'Hallo']);
+            ->method('getBody')
+            ->willReturn($this->createConfiguredMock(\Psr\Http\Message\StreamInterface::class, [
+                'getContents' => json_encode(['translation' => 'Hallo']),
+            ]));
 
-        $client = $this->createMock(HttpClientInterface::class);
+        $client = $this->createMock(GptClientInterface::class);
         $client->expects($this->once())
-            ->method('request')
+            ->method('postJson')
             ->with(
-                'POST',
                 'https://api.example.com/translate',
-                [
-                    'json' => ['text' => 'Hello', 'target' => 'de'],
-                    'headers' => ['Authorization' => 'Bearer secret'],
-                ]
+                ['Authorization' => 'Bearer secret'],
+                ['text' => 'Hello', 'target' => 'de']
             )
             ->willReturn($response);
 
@@ -45,19 +44,18 @@ class GptTranslationServiceTest extends UnitTestCase
     {
         $response = $this->createMock(ResponseInterface::class);
         $response->expects($this->once())
-            ->method('toArray')
-            ->willReturn(['translation' => 'Hola']);
+            ->method('getBody')
+            ->willReturn($this->createConfiguredMock(\Psr\Http\Message\StreamInterface::class, [
+                'getContents' => json_encode(['translation' => 'Hola']),
+            ]));
 
-        $client = $this->createMock(HttpClientInterface::class);
+        $client = $this->createMock(GptClientInterface::class);
         $client->expects($this->once())
-            ->method('request')
+            ->method('postJson')
             ->with(
-                'POST',
                 'https://gpt.local/translate',
-                [
-                    'json' => ['text' => 'Hi', 'target' => 'es'],
-                    'headers' => ['Authorization' => 'Bearer key123'],
-                ]
+                ['Authorization' => 'Bearer key123'],
+                ['text' => 'Hi', 'target' => 'es']
             )
             ->willReturn($response);
 

--- a/equed-lms/Classes/Service/FeedbackAnalysisService.php
+++ b/equed-lms/Classes/Service/FeedbackAnalysisService.php
@@ -9,7 +9,7 @@ use JsonException;
 use Psr\Http\Client\ClientExceptionInterface;
 use Equed\EquedLms\Service\LogService;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
-use TYPO3\CMS\Core\Http\RequestFactory;
+use Equed\EquedCore\Service\GptClientInterface;
 use Equed\EquedLms\Service\TranslatedLoggerTrait;
 
 /**
@@ -22,7 +22,7 @@ final class FeedbackAnalysisService
     private const MIN_TEXT_LENGTH = 10;
 
     public function __construct(
-        private readonly RequestFactory $requestFactory,
+        private readonly GptClientInterface $gptClient,
         GptTranslationServiceInterface $translationService,
         LogService $logService,
         private readonly string $openAiApiKey,
@@ -65,14 +65,10 @@ final class FeedbackAnalysisService
         ];
 
         try {
-            $response = $this->requestFactory->request(
+            $response = $this->gptClient->postJson(
                 self::GPT_API_URL,
-                'POST',
-                [
-                    'headers' => $headers,
-                    'body'    => json_encode($payload, JSON_THROW_ON_ERROR),
-                    'timeout' => 15,
-                ]
+                $headers,
+                $payload
             );
 
             $body = $response->getBody()->getContents();

--- a/equed-lms/Classes/Service/GptEvaluationService.php
+++ b/equed-lms/Classes/Service/GptEvaluationService.php
@@ -9,7 +9,7 @@ use JsonException;
 use Psr\Http\Client\ClientExceptionInterface;
 use Equed\EquedLms\Service\LogService;
 use Equed\EquedLms\Service\TranslatedLoggerTrait;
-use TYPO3\CMS\Core\Http\RequestFactory;
+use Equed\EquedCore\Service\GptClientInterface;
 use Equed\EquedLms\Domain\Model\Submission;
 use Equed\EquedLms\Domain\Repository\SubmissionRepositoryInterface;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
@@ -24,7 +24,7 @@ final class GptEvaluationService
 
     public function __construct(
         private readonly SubmissionRepositoryInterface $submissionRepository,
-        private readonly RequestFactory $requestFactory,
+        private readonly GptClientInterface $gptClient,
         GptTranslationServiceInterface $translationService,
         LogService $logService,
         private readonly string $openAiApiKey,
@@ -88,14 +88,10 @@ final class GptEvaluationService
         ];
 
         try {
-            $response = $this->requestFactory->request(
+            $response = $this->gptClient->postJson(
                 $this->openAiApiUrl,
-                'POST',
-                [
-                    'headers' => $headers,
-                    'body'    => json_encode($payload, JSON_THROW_ON_ERROR),
-                    'timeout' => 15,
-                ]
+                $headers,
+                $payload
             );
 
             $body   = $response->getBody()->getContents();


### PR DESCRIPTION
## Summary
- introduce `GptClientInterface` and `Psr18GptClient`
- update `GptTranslationService` to use the new client
- refactor LMS GPT services to depend on the wrapper
- adjust unit tests with mocks for the new client

## Testing
- `phpunit -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e03cbc3f483249ada761b1877dee2