### PR TITLE
Adjust instructor dashboard counts

### DIFF
--- a/equed-lms/Classes/Service/InstructorDashboardService.php
+++ b/equed-lms/Classes/Service/InstructorDashboardService.php
@@ -32,11 +32,21 @@ final class InstructorDashboardService
         $instances = $this->courseInstanceRepository->findByInstructor($instructorId);
         $records   = $this->userCourseRecordRepository->findByInstructor($instructorId);
 
+        $validatedRecords = array_filter(
+            $records,
+            fn ($r) => $r->getStatus() === \Equed\EquedLms\Enum\UserCourseStatus::Validated
+        );
+
+        $openTasks = array_filter(
+            $records,
+            fn ($r) => $r->getStatus() === \Equed\EquedLms\Enum\UserCourseStatus::InProgress
+        );
+
         return [
             'courseInstanceCount' => count($instances),
             'participantCount'    => count($records),
-            'validatedRecords'    => array_filter($records, fn ($r) => $r->getStatus() === \Equed\EquedLms\Enum\UserCourseStatus::Validated),
-            'openTasks'           => array_filter($records, fn ($r) => $r->getStatus() === \Equed\EquedLms\Enum\UserCourseStatus::InProgress),
+            'validatedRecords'    => count($validatedRecords),
+            'openTasks'           => count($openTasks),
         ];
     }
 }

--- a/equed-lms/Tests/Unit/Service/InstructorDashboardServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/InstructorDashboardServiceTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Tests\Unit\Service;
+
+use Equed\EquedLms\Service\InstructorDashboardService;
+use Equed\EquedLms\Domain\Repository\CourseInstanceRepositoryInterface;
+use Equed\EquedLms\Domain\Repository\UserCourseRecordRepositoryInterface;
+use Equed\EquedLms\Domain\Model\FrontendUser;
+use Equed\EquedLms\Domain\Model\UserCourseRecord;
+use Equed\EquedLms\Domain\Model\CourseInstance;
+use Equed\EquedLms\Enum\UserCourseStatus;
+use PHPUnit\Framework\TestCase;
+use Equed\EquedLms\Tests\Traits\ProphecyTrait;
+
+final class InstructorDashboardServiceTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testAggregatesRecordCounts(): void
+    {
+        $ciRepo = $this->prophesize(CourseInstanceRepositoryInterface::class);
+        $ucRepo = $this->prophesize(UserCourseRecordRepositoryInterface::class);
+
+        $instances = [new CourseInstance(), new CourseInstance()];
+        $ciRepo->findByInstructor(5)->willReturn($instances);
+
+        $r1 = new UserCourseRecord();
+        $r1->setStatus(UserCourseStatus::Validated);
+        $r2 = new UserCourseRecord();
+        $r2->setStatus(UserCourseStatus::InProgress);
+        $r3 = new UserCourseRecord();
+        $r3->setStatus(UserCourseStatus::InProgress);
+
+        $ucRepo->findByInstructor(5)->willReturn([$r1, $r2, $r3]);
+
+        $service = new InstructorDashboardService($ciRepo->reveal(), $ucRepo->reveal());
+
+        $instructor = new FrontendUser();
+        $instructor->_setProperty('uid', 5);
+
+        $result = $service->getDashboardDataForInstructor($instructor);
+
+        $this->assertSame(2, $result['courseInstanceCount']);
+        $this->assertSame(3, $result['participantCount']);
+        $this->assertSame(1, $result['validatedRecords']);
+        $this->assertSame(2, $result['openTasks']);
+    }
+}

--- a/equed-lms/phpunit.xml.dist
+++ b/equed-lms/phpunit.xml.dist
@@ -42,6 +42,7 @@
         <file>./Tests/Unit/Service/TrainingRecordGeneratorServiceTest.php</file>
         <file>./Tests/Unit/Service/TabsBuilderTest.php</file>
         <file>./Tests/Unit/Service/FilterMetadataProviderTest.php</file>
+        <file>./Tests/Unit/Service/InstructorDashboardServiceTest.php</file>
         </testsuite>
         <testsuite name="functional">
             <directory>./Tests/Functional/</directory>


### PR DESCRIPTION
## Summary
- compute counts for validated and pending tasks
- cover InstructorDashboardService with a unit test
- include the new test in phpunit configuration

## Testing
- `composer install --no-interaction` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_684e8c792c0c83249f884db22990c2a6