### PR TITLE
Document service returns and add boundary tests

### DIFF
--- a/equed-core/Classes/Service/AuthorizationService.php
+++ b/equed-core/Classes/Service/AuthorizationService.php
@@ -31,21 +31,42 @@ class AuthorizationService
         $this->roles = array_map('strtolower', $roles);
     }
 
+    /**
+     * Check if the current user has the given role.
+     *
+     * @param string $role Role identifier
+     * @return bool True if the user has the role
+     */
     private function hasRole(string $role): bool
     {
         return in_array(strtolower($role), $this->roles, true);
     }
 
+    /**
+     * Determine whether the current user is a certifier.
+     *
+     * @return bool True when the user has the certifier role
+     */
     public function isCertifier(): bool
     {
         return $this->hasRole('certifier');
     }
 
+    /**
+     * Determine whether the current user is a service center.
+     *
+     * @return bool True when the user has the service center role
+     */
     public function isServiceCenter(): bool
     {
         return $this->hasRole('servicecenter');
     }
 
+    /**
+     * Determine whether the current user is an instructor.
+     *
+     * @return bool True when the user has the instructor role
+     */
     public function isInstructor(): bool
     {
         return $this->hasRole('instructor');

--- a/equed-core/Classes/Service/GptClientInterface.php
+++ b/equed-core/Classes/Service/GptClientInterface.php
@@ -14,9 +14,11 @@ interface GptClientInterface
     /**
      * Send a POST request with a JSON payload.
      *
-     * @param string               $url     Request URL
-     * @param array<string,string> $headers HTTP headers
-     * @param array<string,mixed>  $payload JSON body payload
+    * @param string               $url     Request URL
+    * @param array<string,string> $headers HTTP headers
+    * @param array<string,mixed>  $payload JSON body payload
+     *
+     * @return ResponseInterface HTTP response from the GPT service
      */
     public function postJson(string $url, array $headers, array $payload): ResponseInterface;
 }

--- a/equed-core/Classes/Service/GptTranslationService.php
+++ b/equed-core/Classes/Service/GptTranslationService.php
@@ -6,6 +6,9 @@ namespace Equed\EquedCore\Service;
 
 use Equed\EquedCore\Service\GptClientInterface;
 
+/**
+ * Basic GPT-based translation helper.
+ */
 class GptTranslationService
 {
     /** @internal */
@@ -25,16 +28,33 @@ class GptTranslationService
         $this->endpoint = $endpoint ?? (string) getenv(self::ENV_ENDPOINT);
     }
 
+    /**
+     * Retrieve the API key used for requests.
+     *
+     * @return string API key
+     */
     public function getApiKey(): string
     {
         return $this->apiKey;
     }
 
+    /**
+     * Retrieve the API endpoint URL.
+     *
+     * @return string Endpoint URL
+     */
     public function getEndpoint(): string
     {
         return $this->endpoint;
     }
 
+    /**
+     * Translate a string into the requested language.
+     *
+     * @param string $text       Text to translate
+     * @param string $targetLang Target ISO language code
+     * @return string Translated text (empty string on failure)
+     */
     public function translate(string $text, string $targetLang): string
     {
         $response = $this->gptClient->postJson(

--- a/equed-core/Classes/Service/LmsIntegrationService.php
+++ b/equed-core/Classes/Service/LmsIntegrationService.php
@@ -6,6 +6,9 @@ namespace Equed\EquedCore\Service;
 
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
+/**
+ * Lightweight client for forwarding data to an external LMS.
+ */
 class LmsIntegrationService
 {
     private const DEFAULT_API_URL = 'https://equed-lms.local/api';
@@ -25,6 +28,13 @@ class LmsIntegrationService
             ?? (string)(getenv(self::ENV_KEY) ?: self::DEFAULT_API_URL);
     }
 
+    /**
+     * Push the instructor level for a user to the remote LMS.
+     *
+     * @param int    $userId User identifier
+     * @param string $level  Instructor level
+     * @return void
+     */
     public function syncInstructorLevel(int $userId, string $level): void
     {
         $this->httpClient->request('POST', $this->apiBase . '/instructor', [

--- a/equed-core/Classes/Service/Psr18GptClient.php
+++ b/equed-core/Classes/Service/Psr18GptClient.php
@@ -21,6 +21,11 @@ final class Psr18GptClient implements GptClientInterface
     ) {
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @return ResponseInterface Response from the HTTP client
+     */
     public function postJson(string $url, array $headers, array $payload): ResponseInterface
     {
         $headers['Content-Type'] = $headers['Content-Type'] ?? 'application/json';

--- a/equed-lms/Classes/Service/CertificateService.php
+++ b/equed-lms/Classes/Service/CertificateService.php
@@ -28,6 +28,12 @@ final class CertificateService implements CertificateServiceInterface
         $this->qrCodeBaseUrl = rtrim($qrCodeBaseUrl, '/') . '/';
     }
 
+    /**
+     * Issue a certificate for the given user course record if none exists yet.
+     *
+     * @param UserCourseRecord $userCourseRecord Course participation record
+     * @return CertificateDispatch Newly created or existing dispatch entity
+     */
     public function issueCertificate(UserCourseRecord $userCourseRecord): CertificateDispatch
     {
         $existing = $this->certificateDispatchRepository->findByUserCourseRecord($userCourseRecord);
@@ -49,6 +55,12 @@ final class CertificateService implements CertificateServiceInterface
         return $dispatch;
     }
 
+    /**
+     * Build an absolute QR code URL for the certificate.
+     *
+     * @param UserCourseRecord|CertificateDispatch $source Source entity
+     * @return string QR code URL
+     */
     private function generateQrCodeUrl(UserCourseRecord|CertificateDispatch $source): string
     {
         $userId = $source->getFeUser()?->getUid() ?? 0;
@@ -57,6 +69,12 @@ final class CertificateService implements CertificateServiceInterface
         return sprintf('%s%s/%s', $this->qrCodeBaseUrl, $userId, $timestamp);
     }
 
+    /**
+     * Send a notification to the user that a certificate was issued.
+     *
+     * @param CertificateDispatch $dispatch Certificate dispatch record
+     * @return void
+     */
     public function sendCertificateNotification(CertificateDispatch $dispatch): void
     {
         $subject = (string)$this->translationService->translate(

--- a/equed-lms/Classes/Service/CourseStatusUpdaterService.php
+++ b/equed-lms/Classes/Service/CourseStatusUpdaterService.php
@@ -28,7 +28,8 @@ final class CourseStatusUpdaterService
     /**
      * Finalize the given UserCourseRecord.
      *
-     * @param UserCourseRecord $record
+     * @param UserCourseRecord $record Course record to finalize
+     * @return void
      */
     public function finalize(UserCourseRecord $record): void
     {

--- a/equed-lms/Classes/Service/ExamNotificationService.php
+++ b/equed-lms/Classes/Service/ExamNotificationService.php
@@ -24,6 +24,11 @@ final class ExamNotificationService implements ExamNotificationServiceInterface
     ) {
     }
 
+    /**
+     * Notify all upcoming examiners about their assigned course instances.
+     *
+     * @return int Number of notifications sent
+     */
     public function notifyAll(): int
     {
         $instances = $this->courseInstanceRepository->findAllRequiringExternalExaminer();

--- a/equed-lms/Classes/Service/GptTranslationServiceInterface.php
+++ b/equed-lms/Classes/Service/GptTranslationServiceInterface.php
@@ -4,9 +4,23 @@ declare(strict_types=1);
 
 namespace Equed\EquedLms\Service;
 
+/**
+ * Contract for GPT-based translation helpers.
+ */
 interface GptTranslationServiceInterface
 {
+    /**
+     * Determine whether GPT translations are enabled.
+     */
     public function isEnabled(): bool;
 
+    /**
+     * Translate the given key using GPT.
+     *
+     * @param string               $key       Translation key
+     * @param array<string,mixed>  $arguments Placeholder arguments
+     * @param string|null          $extension Optional extension key
+     * @return string|null Translated string or null if unavailable
+     */
     public function translate(string $key, array $arguments = [], ?string $extension = null): ?string;
 }

--- a/equed-lms/Classes/Service/LessonProgressSyncService.php
+++ b/equed-lms/Classes/Service/LessonProgressSyncService.php
@@ -24,6 +24,12 @@ final class LessonProgressSyncService
     ) {
     }
 
+    /**
+     * Export progress entries for synchronisation with the mobile app.
+     *
+     * @param int $userId Frontend user identifier
+     * @return array<int, array<string, mixed>> Serializable progress data
+     */
     public function exportForApp(int $userId): array
     {
         $entries = $this->progressRepository->findByUserId($userId);
@@ -42,6 +48,13 @@ final class LessonProgressSyncService
         return $result;
     }
 
+    /**
+     * Import progress information from the mobile app.
+     *
+     * @param array<int, array<string, mixed>> $progressData Data from the app
+     * @param int                               $userId       Frontend user id
+     * @return void
+     */
     public function syncFromApp(array $progressData, int $userId): void
     {
         foreach ($progressData as $item) {

--- a/equed-lms/Classes/Service/MailServiceInterface.php
+++ b/equed-lms/Classes/Service/MailServiceInterface.php
@@ -9,12 +9,24 @@ namespace Equed\EquedLms\Service;
  */
 interface MailServiceInterface
 {
+    /**
+     * Send a simple plain text mail.
+     */
     public function sendMail(string $email, string $subject, string $body): void;
 
+    /**
+     * Inform a user that a certificate was issued.
+     */
     public function sendCertificateIssuedMail(string $recipientEmail, string $certificateNumber): void;
 
+    /**
+     * Send a notification about a new QMS case.
+     */
     public function sendQmsNotification(string $recipientEmail, string $caseId): void;
 
+    /**
+     * Send a reminder for an open QMS case.
+     */
     public function sendQmsReminder(string $recipientEmail, string $caseId): void;
 
     /**
@@ -22,6 +34,7 @@ interface MailServiceInterface
      * @param string      $subject
      * @param string      $body
      * @param string|null $attachmentPath
+     * @return void
      */
     public function sendEmail(array $recipients, string $subject, string $body, ?string $attachmentPath = null): void;
 }

--- a/equed-lms/Classes/Service/NotificationService.php
+++ b/equed-lms/Classes/Service/NotificationService.php
@@ -27,6 +27,14 @@ final class NotificationService implements NotificationServiceInterface
     ) {
     }
 
+    /**
+     * Send a notification e-mail to a user.
+     *
+     * @param FrontendUser $user    Recipient user
+     * @param string       $subject Mail subject
+     * @param string       $body    Mail body
+     * @return void
+     */
     public function notify(FrontendUser $user, string $subject, string $body): void
     {
         $email = $user->getEmail();
@@ -37,6 +45,13 @@ final class NotificationService implements NotificationServiceInterface
         $this->mailService->sendMail($email, $subject, $body);
     }
 
+    /**
+     * Inform a certifier about a course they need to review.
+     *
+     * @param string $email       Recipient address
+     * @param string $courseTitle Course title
+     * @return void
+     */
     public function notifyCertifier(string $email, string $courseTitle): void
     {
         $subject = $this->languageService->translate('notification.certifier.subject', ['course' => $courseTitle]);
@@ -44,6 +59,13 @@ final class NotificationService implements NotificationServiceInterface
         $this->mailService->sendMail($email, $subject, $body);
     }
 
+    /**
+     * Notify an instructor about a pending submission.
+     *
+     * @param string $email        Recipient address
+     * @param string $submissionId Submission identifier
+     * @return void
+     */
     public function notifyInstructorOfSubmission(string $email, string $submissionId): void
     {
         $subject = $this->languageService->translate('notification.instructor.subject', ['submission' => $submissionId]);
@@ -51,6 +73,13 @@ final class NotificationService implements NotificationServiceInterface
         $this->mailService->sendMail($email, $subject, $body);
     }
 
+    /**
+     * Inform a user that their certificate is ready for download.
+     *
+     * @param string $email            Recipient address
+     * @param string $certificateNumber Certificate number
+     * @return void
+     */
     public function notifyUserCertificateReady(string $email, string $certificateNumber): void
     {
         $subject = $this->languageService->translate('notification.user.subject', ['certificate' => $certificateNumber]);
@@ -58,6 +87,13 @@ final class NotificationService implements NotificationServiceInterface
         $this->mailService->sendMail($email, $subject, $body);
     }
 
+    /**
+     * Send a notice that a course has been completed.
+     *
+     * @param FrontendUser $user            Recipient user
+     * @param int          $courseInstanceId Course instance UID
+     * @return void
+     */
     public function sendCourseCompletedNotice(FrontendUser $user, int $courseInstanceId): void
     {
         $email = $user->getEmail();
@@ -71,6 +107,13 @@ final class NotificationService implements NotificationServiceInterface
         $this->mailService->sendMail($email, $subject, $body);
     }
 
+    /**
+     * Send certificate issued information with QR code link.
+     *
+     * @param FrontendUser $user      Recipient user
+     * @param string       $qrCodeUrl QR code URL
+     * @return void
+     */
     public function sendCertificateIssuedInfo(FrontendUser $user, string $qrCodeUrl): void
     {
         $email = $user->getEmail();
@@ -84,6 +127,12 @@ final class NotificationService implements NotificationServiceInterface
         $this->mailService->sendMail($email, $subject, $body);
     }
 
+    /**
+     * Retrieve notifications for the given user.
+     *
+     * @param int $userId Frontend user identifier
+     * @return array<int, \Equed\EquedLms\Domain\Model\Notification>
+     */
     public function getNotificationsForUser(int $userId): array
     {
         $query = $this->frontendUserRepository->createQuery();
@@ -96,6 +145,13 @@ final class NotificationService implements NotificationServiceInterface
         return $this->notificationRepository->findLatestByUser($user);
     }
 
+    /**
+     * Mark a notification as read for the given user.
+     *
+     * @param int $userId         User identifier
+     * @param int $notificationId Notification UID
+     * @return void
+     */
     public function markAsRead(int $userId, int $notificationId): void
     {
         $notification = $this->notificationRepository->findByUid($notificationId);

--- a/equed-lms/Classes/Service/ProgressCalculationService.php
+++ b/equed-lms/Classes/Service/ProgressCalculationService.php
@@ -24,6 +24,13 @@ final class ProgressCalculationService
     ) {
     }
 
+    /**
+     * Calculate the overall progress for a course program.
+     *
+     * @param int $userId          Frontend user id
+     * @param int $courseProgramId Course program uid
+     * @return float Progress percentage between 0 and 100
+     */
     public function calculateCourseProgramProgress(int $userId, int $courseProgramId): float
     {
         $instances = $this->courseInstanceRepository->findByCourseProgram($courseProgramId);
@@ -41,6 +48,13 @@ final class ProgressCalculationService
         return $sum / $total;
     }
 
+    /**
+     * Calculate progress for a single course instance.
+     *
+     * @param int $userId          User identifier
+     * @param int $courseInstanceId Course instance uid
+     * @return float Progress percentage
+     */
     public function calculateCourseInstanceProgress(int $userId, int $courseInstanceId): float
     {
         $cacheKey = sprintf('progress_%d_%d', $userId, $courseInstanceId);
@@ -69,6 +83,12 @@ final class ProgressCalculationService
         return $progress;
     }
 
+    /**
+     * Translate a human readable label for a progress value.
+     *
+     * @param float $progress Progress percent
+     * @return string Localized label
+     */
     public function getProgressLabel(float $progress): string
     {
         $status = match (true) {

--- a/equed-lms/Classes/Service/QmsEscalationService.php
+++ b/equed-lms/Classes/Service/QmsEscalationService.php
@@ -30,6 +30,8 @@ final class QmsEscalationService
 
     /**
      * Escaliert einen QMS-Eintrag basierend auf den übergebenen Daten.
+     *
+     * @return void
      */
     public function escalate(QmsCase $case): void
     {

--- a/equed-lms/Classes/Service/RandomTokenGenerator.php
+++ b/equed-lms/Classes/Service/RandomTokenGenerator.php
@@ -9,6 +9,11 @@ namespace Equed\EquedLms\Service;
  */
 final class RandomTokenGenerator implements TokenGeneratorInterface
 {
+    /**
+     * {@inheritDoc}
+     *
+     * @return string Random token bytes
+     */
     public function generate(int $length): string
     {
         return random_bytes($length);

--- a/equed-lms/Classes/Service/RecognitionAwardService.php
+++ b/equed-lms/Classes/Service/RecognitionAwardService.php
@@ -27,6 +27,12 @@ final class RecognitionAwardService
     ) {
     }
 
+    /**
+     * Determine whether the user qualifies for the advanced title badge.
+     *
+     * @param int $userId User identifier
+     * @return bool True when the user qualifies
+     */
     public function qualifiesForAdvancedTitle(int $userId): bool
     {
         $cacheKey = sprintf('qualifyAdvanced_%d', $userId);
@@ -44,6 +50,13 @@ final class RecognitionAwardService
         return $qualifies;
     }
 
+    /**
+     * Assign a recognition badge of the given type to a user.
+     *
+     * @param int    $userId User identifier
+     * @param string $type   Badge type
+     * @return UserBadge Newly created or existing badge entity
+     */
     public function assignRecognitionBadge(int $userId, string $type): UserBadge
     {
         $existing = $this->userBadgeRepository->findByUserAndType($userId, $type);

--- a/equed-lms/Classes/Service/ServiceCenterDashboardService.php
+++ b/equed-lms/Classes/Service/ServiceCenterDashboardService.php
@@ -26,6 +26,12 @@ final class ServiceCenterDashboardService
     ) {
     }
 
+    /**
+     * Build dashboard data for a given Service Center.
+     *
+     * @param int $centerId UID of the Service Center
+     * @return array<string, mixed> Structured dashboard information
+     */
     public function getDashboardDataForServiceCenter(int $centerId): array
     {
         $certificates = $this->certificateRepository->findPendingByServiceCenter($centerId);
@@ -40,6 +46,12 @@ final class ServiceCenterDashboardService
         ];
     }
 
+    /**
+     * Map certificate entities to simple arrays for output.
+     *
+     * @param Certificate[] $certificates
+     * @return array<int, array<string, mixed>>
+     */
     private function mapCertificates(array $certificates): array
     {
         return array_map(
@@ -52,6 +64,12 @@ final class ServiceCenterDashboardService
         );
     }
 
+    /**
+     * Map submission entities for dashboard output.
+     *
+     * @param UserSubmission[] $submissions
+     * @return array<int, array<string, mixed>>
+     */
     private function mapSubmissions(array $submissions): array
     {
         return array_map(
@@ -71,6 +89,12 @@ final class ServiceCenterDashboardService
         );
     }
 
+    /**
+     * Map QMS cases for dashboard output.
+     *
+     * @param QmsCase[] $cases
+     * @return array<int, array<string, mixed>>
+     */
     private function mapQmsCases(array $cases): array
     {
         return array_map(

--- a/equed-lms/Classes/Service/SyncService.php
+++ b/equed-lms/Classes/Service/SyncService.php
@@ -22,6 +22,12 @@ final class SyncService
     ) {
     }
 
+    /**
+     * Convert a user profile into the array structure used by the app.
+     *
+     * @param UserProfile $profile Profile entity
+     * @return array<string, mixed> Serializable representation
+     */
     public function pushToApp(UserProfile $profile): array
     {
         return [
@@ -34,6 +40,12 @@ final class SyncService
         ];
     }
 
+    /**
+     * Merge profile data coming from the app.
+     *
+     * @param array<string, mixed> $data Incoming app payload
+     * @return UserProfile Updated profile entity
+     */
     public function pullFromApp(array $data): UserProfile
     {
         $userId = isset($data['userId']) ? (int) $data['userId'] : 0;

--- a/equed-lms/Classes/Service/SystemClock.php
+++ b/equed-lms/Classes/Service/SystemClock.php
@@ -12,6 +12,11 @@ use Equed\EquedLms\Domain\Service\ClockInterface;
  */
 final class SystemClock implements ClockInterface
 {
+    /**
+     * {@inheritDoc}
+     *
+     * @return DateTimeImmutable Current immutable datetime instance
+     */
     public function now(): DateTimeImmutable
     {
         return new DateTimeImmutable();

--- a/equed-lms/Classes/Service/TokenGeneratorInterface.php
+++ b/equed-lms/Classes/Service/TokenGeneratorInterface.php
@@ -11,6 +11,9 @@ interface TokenGeneratorInterface
 {
     /**
      * Generate a random string of the given length in bytes.
+     *
+     * @param int $length Number of bytes to generate
+     * @return string Random binary string
      */
     public function generate(int $length): string;
 }

--- a/equed-lms/Classes/Service/TranslatedLoggerTrait.php
+++ b/equed-lms/Classes/Service/TranslatedLoggerTrait.php
@@ -16,6 +16,13 @@ trait TranslatedLoggerTrait
     protected GptTranslationServiceInterface|LanguageServiceInterface $translationService;
     protected LogService $logService;
 
+    /**
+     * Inject services used for translated logging.
+     *
+     * @param GptTranslationServiceInterface|LanguageServiceInterface $translationService Service used for translations
+     * @param LogService                                              $logService         Logger instance
+     * @return void
+     */
     public function injectTranslatedLogger(
         GptTranslationServiceInterface|LanguageServiceInterface $translationService,
         LogService $logService

--- a/equed-lms/Classes/Service/Translator.php
+++ b/equed-lms/Classes/Service/Translator.php
@@ -9,6 +9,11 @@ use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
 final class Translator implements TranslatorInterface
 {
+    /**
+     * {@inheritDoc}
+     *
+     * @return string|null Translated string if available
+     */
     public function translate(string $key, array $arguments = [], ?string $extension = null): ?string
     {
         return LocalizationUtility::translate($key, $extension, $arguments);

--- a/equed-lms/Tests/Unit/Service/RandomTokenGeneratorTest.php
+++ b/equed-lms/Tests/Unit/Service/RandomTokenGeneratorTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Tests\Unit\Service;
+
+use Equed\EquedLms\Service\RandomTokenGenerator;
+use PHPUnit\Framework\TestCase;
+
+final class RandomTokenGeneratorTest extends TestCase
+{
+    public function testGenerateReturnsCorrectLength(): void
+    {
+        $gen = new RandomTokenGenerator();
+        $token = $gen->generate(8);
+        $this->assertSame(8, strlen($token));
+    }
+
+    public function testGenerateZeroLengthThrowsException(): void
+    {
+        $gen = new RandomTokenGenerator();
+        $this->expectException(\ValueError::class);
+        $gen->generate(0);
+    }
+}

--- a/equed-lms/Tests/Unit/Service/SearchServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/SearchServiceTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TYPO3\CMS\Core\Database;
+if (!class_exists(ConnectionPool::class)) {
+    class ConnectionPool {
+        public function getQueryBuilderForTable(string $table) { return null; }
+    }
+}
+
+namespace Equed\EquedLms\Tests\Unit\Service;
+
+use Equed\EquedLms\Service\SearchService;
+use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+final class SearchServiceTest extends TestCase
+{
+    public function testReturnsErrorForTooShortTerm(): void
+    {
+        $service = new SearchService(new ConnectionPool());
+        $result = $service->search('a');
+        $this->assertTrue($result->hasError());
+        $this->assertSame('Search term too short.', $result->getError());
+    }
+}

--- a/equed-lms/Tests/Unit/Service/SystemClockTest.php
+++ b/equed-lms/Tests/Unit/Service/SystemClockTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Tests\Unit\Service;
+
+use Equed\EquedLms\Service\SystemClock;
+use PHPUnit\Framework\TestCase;
+
+final class SystemClockTest extends TestCase
+{
+    public function testNowReturnsCurrentTime(): void
+    {
+        $clock = new SystemClock();
+        $before = time();
+        $now = $clock->now();
+        $this->assertGreaterThanOrEqual($before, $now->getTimestamp());
+        $this->assertLessThanOrEqual(time(), $now->getTimestamp());
+    }
+}


### PR DESCRIPTION
## Summary
- document return values and exceptions across services
- cover boundary behavior for token generator, clock and search services

## Testing
- `vendor/bin/phpunit Tests/Unit/Service/SearchServiceTest.php Tests/Unit/Service/RandomTokenGeneratorTest.php Tests/Unit/Service/SystemClockTest.php`

------
https://chatgpt.com/codex/tasks/task_e_684e9157e8788324a543a082f7c6d496