### PR TITLE
Introduce DTOs for dashboard services and unify progress cache key

### DIFF
--- a/equed-lms/Classes/Domain/Service/DashboardServiceInterface.php
+++ b/equed-lms/Classes/Domain/Service/DashboardServiceInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Equed\EquedLms\Domain\Service;
 
 use Equed\EquedLms\Domain\Model\FrontendUser;
+use Equed\EquedLms\Dto\DashboardData;
 
 interface DashboardServiceInterface
 {
@@ -12,7 +13,6 @@ interface DashboardServiceInterface
      * Retrieve all dashboard data for a frontend user.
      *
      * @param FrontendUser $user
-     * @return array<string,mixed>
      */
-    public function getDashboardDataForUser(FrontendUser $user): array;
+    public function getDashboardDataForUser(FrontendUser $user): DashboardData;
 }

--- a/equed-lms/Classes/Dto/DashboardData.php
+++ b/equed-lms/Classes/Dto/DashboardData.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Dto;
+
+/**
+ * Data Transfer Object holding dashboard data for a user.
+ */
+final class DashboardData implements \JsonSerializable
+{
+    /**
+     * @param array<string,mixed>                             $user
+     * @param array<string,array<int,array<string,mixed>>>    $tabs
+     * @param array<string,mixed>                             $filters
+     * @param array<string,mixed>                             $progress
+     * @param array<int,array<string,mixed>>                  $notifications
+     * @param array<string,mixed>                             $cacheMeta
+     * @param array<string,mixed>                             $features
+     */
+    public function __construct(
+        private readonly array $user,
+        private readonly array $tabs,
+        private readonly array $filters,
+        private readonly array $progress,
+        private readonly array $notifications,
+        private readonly array $cacheMeta,
+        private readonly array $features,
+    ) {
+    }
+
+    /** @return array<string,mixed> */
+    public function getUser(): array
+    {
+        return $this->user;
+    }
+
+    /** @return array<string,array<int,array<string,mixed>>> */
+    public function getTabs(): array
+    {
+        return $this->tabs;
+    }
+
+    /** @return array<string,mixed> */
+    public function getFilters(): array
+    {
+        return $this->filters;
+    }
+
+    /** @return array<string,mixed> */
+    public function getProgress(): array
+    {
+        return $this->progress;
+    }
+
+    /** @return array<int,array<string,mixed>> */
+    public function getNotifications(): array
+    {
+        return $this->notifications;
+    }
+
+    /** @return array<string,mixed> */
+    public function getCacheMeta(): array
+    {
+        return $this->cacheMeta;
+    }
+
+    /** @return array<string,mixed> */
+    public function getFeatures(): array
+    {
+        return $this->features;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'user'          => $this->user,
+            'tabs'          => $this->tabs,
+            'filters'       => $this->filters,
+            'progress'      => $this->progress,
+            'notifications' => $this->notifications,
+            'cacheMeta'     => $this->cacheMeta,
+            'features'      => $this->features,
+        ];
+    }
+}

--- a/equed-lms/Classes/Dto/InstructorDashboardData.php
+++ b/equed-lms/Classes/Dto/InstructorDashboardData.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Dto;
+
+/**
+ * Data Transfer Object for instructor dashboard metrics.
+ */
+final class InstructorDashboardData implements \JsonSerializable
+{
+    public function __construct(
+        private readonly int $courseInstanceCount,
+        private readonly int $participantCount,
+        private readonly int $validatedRecords,
+        private readonly int $openTasks,
+    ) {
+    }
+
+    public function getCourseInstanceCount(): int
+    {
+        return $this->courseInstanceCount;
+    }
+
+    public function getParticipantCount(): int
+    {
+        return $this->participantCount;
+    }
+
+    public function getValidatedRecords(): int
+    {
+        return $this->validatedRecords;
+    }
+
+    public function getOpenTasks(): int
+    {
+        return $this->openTasks;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'courseInstanceCount' => $this->courseInstanceCount,
+            'participantCount'    => $this->participantCount,
+            'validatedRecords'    => $this->validatedRecords,
+            'openTasks'           => $this->openTasks,
+        ];
+    }
+}

--- a/equed-lms/Classes/Dto/ServiceCenterDashboardData.php
+++ b/equed-lms/Classes/Dto/ServiceCenterDashboardData.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Dto;
+
+/**
+ * Structured dashboard data for Service Centers.
+ */
+final class ServiceCenterDashboardData implements \JsonSerializable
+{
+    /**
+     * @param array<int,array<string,mixed>> $certificates
+     * @param array<int,array<string,mixed>> $submissions
+     * @param array<int,array<string,mixed>> $qmsCases
+     */
+    public function __construct(
+        private readonly int $centerId,
+        private readonly array $certificates = [],
+        private readonly array $submissions = [],
+        private readonly array $qmsCases = [],
+    ) {
+    }
+
+    public function getCenterId(): int
+    {
+        return $this->centerId;
+    }
+
+    /** @return array<int,array<string,mixed>> */
+    public function getCertificates(): array
+    {
+        return $this->certificates;
+    }
+
+    /** @return array<int,array<string,mixed>> */
+    public function getSubmissions(): array
+    {
+        return $this->submissions;
+    }
+
+    /** @return array<int,array<string,mixed>> */
+    public function getQmsCases(): array
+    {
+        return $this->qmsCases;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'centerId'     => $this->centerId,
+            'certificates' => $this->certificates,
+            'submissions'  => $this->submissions,
+            'qmsCases'     => $this->qmsCases,
+        ];
+    }
+}

--- a/equed-lms/Classes/Helper/ProgressCacheKeyHelper.php
+++ b/equed-lms/Classes/Helper/ProgressCacheKeyHelper.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Helper;
+
+/**
+ * Generates cache keys for user progress data.
+ */
+final class ProgressCacheKeyHelper
+{
+    public const TEMPLATE = 'progress_%d_%d';
+
+    public static function courseInstance(int $userId, int $courseInstanceId): string
+    {
+        return sprintf(self::TEMPLATE, $userId, $courseInstanceId);
+    }
+}

--- a/equed-lms/Classes/Service/InstructorDashboardService.php
+++ b/equed-lms/Classes/Service/InstructorDashboardService.php
@@ -7,6 +7,7 @@ namespace Equed\EquedLms\Service;
 use Equed\EquedLms\Domain\Repository\CourseInstanceRepositoryInterface;
 use Equed\EquedLms\Domain\Repository\UserCourseRecordRepositoryInterface;
 use Equed\EquedLms\Domain\Model\FrontendUser;
+use Equed\EquedLms\Dto\InstructorDashboardData;
 
 /**
  * Provides instructor-specific dashboard statistics and metrics.
@@ -23,9 +24,8 @@ final class InstructorDashboardService
      * Get aggregated dashboard data for the given instructor.
      *
      * @param FrontendUser $instructor
-     * @return array<string,mixed>
      */
-    public function getDashboardDataForInstructor(FrontendUser $instructor): array
+    public function getDashboardDataForInstructor(FrontendUser $instructor): InstructorDashboardData
     {
         $instructorId = (int)$instructor->getUid();
 
@@ -42,11 +42,11 @@ final class InstructorDashboardService
             fn ($r) => $r->getStatus() === \Equed\EquedLms\Enum\UserCourseStatus::InProgress
         );
 
-        return [
-            'courseInstanceCount' => count($instances),
-            'participantCount'    => count($records),
-            'validatedRecords'    => count($validatedRecords),
-            'openTasks'           => count($openTasks),
-        ];
+        return new InstructorDashboardData(
+            count($instances),
+            count($records),
+            count($validatedRecords),
+            count($openTasks),
+        );
     }
 }

--- a/equed-lms/Classes/Service/ProgressCalculationService.php
+++ b/equed-lms/Classes/Service/ProgressCalculationService.php
@@ -9,6 +9,7 @@ use Equed\EquedLms\Domain\Repository\UserCourseRecordRepositoryInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use Equed\EquedLms\Domain\Service\LanguageServiceInterface;
 use Equed\EquedLms\Enum\ProgressStatus;
+use Equed\EquedLms\Helper\ProgressCacheKeyHelper;
 
 /**
  * Service for calculating user progress in courses.
@@ -57,7 +58,7 @@ final class ProgressCalculationService
      */
     public function calculateCourseInstanceProgress(int $userId, int $courseInstanceId): float
     {
-        $cacheKey = sprintf('progress_%d_%d', $userId, $courseInstanceId);
+        $cacheKey = ProgressCacheKeyHelper::courseInstance($userId, $courseInstanceId);
         $cacheItem = $this->cachePool->getItem($cacheKey);
 
         if ($cacheItem->isHit()) {

--- a/equed-lms/Classes/Service/ProgressTrackingService.php
+++ b/equed-lms/Classes/Service/ProgressTrackingService.php
@@ -13,6 +13,7 @@ use Psr\Cache\CacheItemPoolInterface;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 use Equed\EquedLms\Domain\Service\LanguageServiceInterface;
 use Equed\EquedLms\Enum\ProgressStatus;
+use Equed\EquedLms\Helper\ProgressCacheKeyHelper;
 
 /**
  * Service for tracking and persisting user course progress.
@@ -99,7 +100,7 @@ final class ProgressTrackingService
      */
     private function clearCache(int $userId, int $courseInstanceId): void
     {
-        $cacheKey = sprintf('progress_%d_%d', $userId, $courseInstanceId);
+        $cacheKey = ProgressCacheKeyHelper::courseInstance($userId, $courseInstanceId);
         $this->cachePool->deleteItem($cacheKey);
     }
 

--- a/equed-lms/Classes/Service/ServiceCenterDashboardService.php
+++ b/equed-lms/Classes/Service/ServiceCenterDashboardService.php
@@ -11,6 +11,7 @@ use Equed\EquedLms\Domain\Repository\CertificateRepositoryInterface;
 use Equed\EquedLms\Domain\Repository\QmsCaseRepositoryInterface;
 use Equed\EquedLms\Domain\Repository\UserSubmissionRepositoryInterface;
 use Equed\EquedLms\Domain\Service\LanguageServiceInterface;
+use Equed\EquedLms\Dto\ServiceCenterDashboardData;
 
 /**
  * Service to gather dashboard data for a Service Center.
@@ -30,20 +31,19 @@ final class ServiceCenterDashboardService
      * Build dashboard data for a given Service Center.
      *
      * @param int $centerId UID of the Service Center
-     * @return array<string, mixed> Structured dashboard information
      */
-    public function getDashboardDataForServiceCenter(int $centerId): array
+    public function getDashboardDataForServiceCenter(int $centerId): ServiceCenterDashboardData
     {
         $certificates = $this->certificateRepository->findPendingByServiceCenter($centerId);
         $submissions  = $this->userSubmissionRepository->findPendingByServiceCenter($centerId);
         $qmsCases     = $this->qmsCaseRepository->findOpenByServiceCenter($centerId);
 
-        return [
-            'centerId'     => $centerId,
-            'certificates' => $this->mapCertificates($certificates),
-            'submissions'  => $this->mapSubmissions($submissions),
-            'qmsCases'     => $this->mapQmsCases($qmsCases),
-        ];
+        return new ServiceCenterDashboardData(
+            $centerId,
+            $this->mapCertificates($certificates),
+            $this->mapSubmissions($submissions),
+            $this->mapQmsCases($qmsCases),
+        );
     }
 
     /**


### PR DESCRIPTION
## Summary
- replace array return types with DTOs for dashboard services
- add ProgressCacheKeyHelper and use it in progress services
- update interface types accordingly

## Testing
- `phpunit -c phpunit.xml.dist --colors=always` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e93c277e48324afb4e9dcddf50b36