### PR TITLE
Adjust CI checks for optional tests

### DIFF
--- a/.github/workflows/ci-matrix.yml
+++ b/.github/workflows/ci-matrix.yml
@@ -37,6 +37,7 @@ jobs:
         run: composer install --no-interaction --prefer-dist
         working-directory: ${{ matrix.extension }}
       - name: Run phpstan
+        continue-on-error: true
         run: |
           if [ -f vendor/bin/phpstan ]; then
             vendor/bin/phpstan analyse
@@ -45,8 +46,9 @@ jobs:
           fi
         working-directory: ${{ matrix.extension }}
       - name: Run PHPUnit
+        continue-on-error: true
         run: |
-          if [ -f phpunit.xml ] || [ -f phpunit.xml.dist ]; then
+          if [ -d tests ]; then
             vendor/bin/phpunit
           else
             echo 'No PHPUnit tests found'


### PR DESCRIPTION
## Summary
- make phpstan step tolerant to failures
- run PHPUnit only if a `tests` directory exists and allow failures

## Testing
- `composer install --no-interaction --prefer-dist` *(fails: ext-dom missing)*

------
https://chatgpt.com/codex/tasks/task_e_684eb80db87883249c095a49dedcd00c