### PR TITLE
Add enums for notification type/status

### DIFF
--- a/equed-lms/Classes/Domain/Model/Notification.php
+++ b/equed-lms/Classes/Domain/Model/Notification.php
@@ -13,6 +13,8 @@ use TYPO3\CMS\Extbase\Annotation\ORM\ManyToOne;
 use Equed\EquedLms\Domain\Model\FrontendUser;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 use Equed\EquedLms\Enum\LanguageCode;
+use Equed\EquedLms\Enum\NotificationType;
+use Equed\EquedLms\Enum\NotificationStatus;
 
 /**
  * Domain model for system notifications.
@@ -59,14 +61,14 @@ final class Notification extends AbstractEntity
     protected ?UserCourseRecord $userCourseRecord = null;
 
     /**
-     * @var string
+     * @var NotificationType
      */
-    protected string $type = 'system';
+    protected NotificationType $type = NotificationType::System;
 
     /**
-     * @var string
+     * @var NotificationStatus
      */
-    protected string $status = 'active';
+    protected NotificationStatus $status = NotificationStatus::Active;
 
     /**
      * @var bool
@@ -193,32 +195,40 @@ final class Notification extends AbstractEntity
     /**
      * Returns notification type.
      */
-    public function getType(): string
+    public function getType(): NotificationType
     {
         return $this->type;
     }
 
     /**
-     * @param string $type
+     * @param NotificationType|string $type
      */
-    public function setType(string $type): void
+    public function setType(NotificationType|string $type): void
     {
+        if (is_string($type)) {
+            $type = NotificationType::from($type);
+        }
+
         $this->type = $type;
     }
 
     /**
      * Returns notification status.
      */
-    public function getStatus(): string
+    public function getStatus(): NotificationStatus
     {
         return $this->status;
     }
 
     /**
-     * @param string $status
+     * @param NotificationStatus|string $status
      */
-    public function setStatus(string $status): void
+    public function setStatus(NotificationStatus|string $status): void
     {
+        if (is_string($status)) {
+            $status = NotificationStatus::from($status);
+        }
+
         $this->status = $status;
     }
 

--- a/equed-lms/Classes/Enum/NotificationStatus.php
+++ b/equed-lms/Classes/Enum/NotificationStatus.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Enum;
+
+/**
+ * Possible status values for notifications.
+ */
+enum NotificationStatus: string
+{
+    case Active = 'active';
+}
+

--- a/equed-lms/Classes/Enum/NotificationType.php
+++ b/equed-lms/Classes/Enum/NotificationType.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Enum;
+
+/**
+ * Allowed types for notifications.
+ */
+enum NotificationType: string
+{
+    case Info = 'info';
+    case Success = 'success';
+    case Warning = 'warning';
+    case Alert = 'alert';
+    case Certificate = 'certificate';
+    case Submission = 'submission';
+    case System = 'system';
+}
+

--- a/equed-lms/Classes/EventListener/CertificateNotificationListener.php
+++ b/equed-lms/Classes/EventListener/CertificateNotificationListener.php
@@ -11,6 +11,8 @@ use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 use TYPO3\CMS\Core\Messaging\FlashMessageService;
 use TYPO3\CMS\Core\Annotations\EventListener;
 use Equed\EquedLms\Enum\LanguageCode;
+use Equed\EquedLms\Enum\NotificationType;
+use Equed\EquedLms\Enum\NotificationStatus;
 
 /**
  * Sends a notification when a certificate is issued.
@@ -57,9 +59,9 @@ final class CertificateNotificationListener
             'recipient'      => $user,
             'titleKey'       => $messageKey,
             'customMessage'  => $message,
-            'type'           => 'certificate',
+            'type'           => NotificationType::Certificate,
             'language'       => $user->getUserProfile()?->getLanguage() ?? LanguageCode::EN,
-            'status'         => 'active',
+            'status'         => NotificationStatus::Active,
             'isRead'         => false,
             'isArchived'     => false,
             'createdAt'      => new \DateTimeImmutable(),

--- a/equed-lms/Configuration/TCA/Overrides/tx_equedlms_domain_model_notification.php
+++ b/equed-lms/Configuration/TCA/Overrides/tx_equedlms_domain_model_notification.php
@@ -3,6 +3,8 @@
 defined('TYPO3') or die();
 
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+use Equed\EquedLms\Enum\NotificationType;
+use Equed\EquedLms\Enum\NotificationStatus;
 
 (function () {
     ExtensionManagementUtility::addTCAcolumns('tx_equedlms_domain_model_notification', [
@@ -41,15 +43,15 @@ use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
             'config' => [
                 'type' => 'select',
                 'items' => [
-                    ['Info', 'info'],
-                    ['Success', 'success'],
-                    ['Warning', 'warning'],
-                    ['Alert', 'alert'],
-                    ['Certificate', 'certificate'],
-                    ['Submission', 'submission'],
-                    ['System', 'system'],
+                    ['Info', NotificationType::Info->value],
+                    ['Success', NotificationType::Success->value],
+                    ['Warning', NotificationType::Warning->value],
+                    ['Alert', NotificationType::Alert->value],
+                    ['Certificate', NotificationType::Certificate->value],
+                    ['Submission', NotificationType::Submission->value],
+                    ['System', NotificationType::System->value],
                 ],
-                'default' => 'info',
+                'default' => NotificationType::Info->value,
             ],
         ],
         'status' => [
@@ -57,6 +59,7 @@ use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
             'config' => [
                 'type' => 'input',
                 'eval' => 'trim',
+                'default' => NotificationStatus::Active->value,
             ],
         ],
         'is_read' => [


### PR DESCRIPTION
## Summary
- introduce `NotificationType` and `NotificationStatus` enums
- use the new enums in `Notification` model
- update certificate notification listener to use enum values
- reference enums in TCA override for notifications

## Testing
- `composer lint` *(fails: `composer` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eed3413308324bba27f865dc95d2d