### PR TITLE
Add enums for submission attachments

### DIFF
--- a/equed-lms/Classes/Domain/Model/SubmissionAttachment.php
+++ b/equed-lms/Classes/Domain/Model/SubmissionAttachment.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Equed\EquedLms\Domain\Model;
 use Equed\EquedLms\Enum\LanguageCode;
+use Equed\EquedLms\Enum\AttachmentType;
+use Equed\EquedLms\Enum\AttachmentVisibility;
+use Equed\EquedLms\Enum\AttachmentStatus;
 
 use DateTimeImmutable;
 use Equed\Core\Service\ClockInterface;
@@ -38,11 +41,11 @@ final class SubmissionAttachment extends AbstractEntity
 
     protected string $title = '';
 
-    protected string $type = 'fallbericht';
+    protected AttachmentType $type = AttachmentType::Fallbericht;
 
-    protected string $visibility = 'instructor_only';
+    protected AttachmentVisibility $visibility = AttachmentVisibility::InstructorOnly;
 
-    protected string $status = 'active';
+    protected AttachmentStatus $status = AttachmentStatus::Active;
 
     protected LanguageCode $lang = LanguageCode::EN;
 
@@ -139,61 +142,58 @@ final class SubmissionAttachment extends AbstractEntity
 
     /**
      * Gets the type of attachment.
-     *
-     * @return string
      */
-    public function getType(): string
+    public function getType(): AttachmentType
     {
         return $this->type;
     }
 
     /**
      * Sets the type of attachment.
-     *
-     * @param string $type
      */
-    public function setType(string $type): void
+    public function setType(AttachmentType|string $type): void
     {
+        if (is_string($type)) {
+            $type = AttachmentType::from($type);
+        }
         $this->type = $type;
     }
 
     /**
      * Gets the visibility.
-     *
-     * @return string
      */
-    public function getVisibility(): string
+    public function getVisibility(): AttachmentVisibility
     {
         return $this->visibility;
     }
 
     /**
      * Sets the visibility.
-     *
-     * @param string $visibility
      */
-    public function setVisibility(string $visibility): void
+    public function setVisibility(AttachmentVisibility|string $visibility): void
     {
+        if (is_string($visibility)) {
+            $visibility = AttachmentVisibility::from($visibility);
+        }
         $this->visibility = $visibility;
     }
 
     /**
      * Gets the status of the attachment.
-     *
-     * @return string
      */
-    public function getStatus(): string
+    public function getStatus(): AttachmentStatus
     {
         return $this->status;
     }
 
     /**
      * Sets the status of the attachment.
-     *
-     * @param string $status
      */
-    public function setStatus(string $status): void
+    public function setStatus(AttachmentStatus|string $status): void
     {
+        if (is_string($status)) {
+            $status = AttachmentStatus::from($status);
+        }
         $this->status = $status;
     }
 

--- a/equed-lms/Classes/Enum/AttachmentStatus.php
+++ b/equed-lms/Classes/Enum/AttachmentStatus.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Enum;
+
+/**
+ * Status values for submission attachments.
+ */
+enum AttachmentStatus: string
+{
+    case Active = 'active';
+}

--- a/equed-lms/Classes/Enum/AttachmentType.php
+++ b/equed-lms/Classes/Enum/AttachmentType.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Enum;
+
+/**
+ * Possible attachment types for submission attachments.
+ */
+enum AttachmentType: string
+{
+    case Fallbericht = 'fallbericht';
+}

--- a/equed-lms/Classes/Enum/AttachmentVisibility.php
+++ b/equed-lms/Classes/Enum/AttachmentVisibility.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Enum;
+
+/**
+ * Visibility options for submission attachments.
+ */
+enum AttachmentVisibility: string
+{
+    case InstructorOnly = 'instructor_only';
+}


### PR DESCRIPTION
## Summary
- create enums for attachment type, visibility and status
- use new enums in `SubmissionAttachment`

## Testing
- `phpunit --version` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ef03b2e7c8324a465a18567cf2a96