### PR TITLE
Add dependabot and security policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,50 @@
+version: 2
+updates:
+  - package-ecosystem: "composer"
+    directory: "/equed-core"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    security-updates: true
+  - package-ecosystem: "composer"
+    directory: "/equed-lms"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    security-updates: true
+  - package-ecosystem: "composer"
+    directory: "/equed-cert"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    security-updates: true
+  - package-ecosystem: "composer"
+    directory: "/equed-qms"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    security-updates: true
+  - package-ecosystem: "composer"
+    directory: "/equed-center"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    security-updates: true
+  - package-ecosystem: "composer"
+    directory: "/equed-instructor"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    security-updates: true
+  - package-ecosystem: "composer"
+    directory: "/equed-admin"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    security-updates: true
+  - package-ecosystem: "npm"
+    directory: "/equed-app"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    security-updates: true

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+This repository hosts the EquEdEU monorepo containing multiple TYPO3 extensions and a React application. It includes DSGVO‑relevant functionality such as file uploads, JWT based authentication and certificate verification. We take security and privacy very seriously.
+
+## Reporting a Vulnerability
+
+Please report potential security issues **privately** by email to [security@equed.eu](mailto:security@equed.eu). Include a detailed description and, if possible, steps to reproduce the problem. We aim to respond within three working days.
+
+Do **not** open public issues or pull requests for security reports.
+
+## Supported Versions
+
+Only the latest stable release of each extension is actively maintained. Older versions may not receive security updates.
+
+## Responsible Disclosure
+
+We appreciate responsible disclosure. After initial contact we will coordinate a fix and announce it through the usual release channels.


### PR DESCRIPTION
## Summary
- add dependabot configuration for Composer and npm packages in every extension
- document vulnerability reporting process and GDPR relevance

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684efd635e84832487698cb49ebceee6