### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/translation-sync.yml
+++ b/.github/workflows/translation-sync.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '0 4 * * 1'
 
+permissions:
+  contents: read
+
 jobs:
   sync:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/MSAlpaka/EquEdEU/security/code-scanning/1](https://github.com/MSAlpaka/EquEdEU/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function. Based on the steps in the workflow, it appears that the workflow primarily reads repository contents and does not require write access. Therefore, we will set `contents: read` as the permission. If additional permissions are required in the future, they can be added explicitly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
