### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '0 3 * * 0'
 
+permissions:
+  contents: read
+
 jobs:
   audit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/MSAlpaka/EquEdEU/security/code-scanning/2](https://github.com/MSAlpaka/EquEdEU/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function. Since the workflow only performs a security audit and does not modify the repository, it only needs `contents: read` permissions. This change will ensure that the workflow adheres to the principle of least privilege and mitigates potential security risks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
