### PR TITLE
Fix PHPStan SARIF upload path

### DIFF
--- a/.github/workflows/ci-matrix.yml
+++ b/.github/workflows/ci-matrix.yml
@@ -38,20 +38,23 @@ jobs:
         working-directory: ${{ matrix.extension }}
       - name: Run PHPStan
         continue-on-error: true
+        shell: bash
         run: |
+          REPORT_DIR="${{ github.workspace }}/${{ matrix.extension }}/build/reports"
+          mkdir -p "$REPORT_DIR"
           if [ -f vendor/bin/phpstan ]; then
             echo "🔍 Running PHPStan..."
-            vendor/bin/phpstan analyse --error-format=sarif > phpstan.sarif || echo "⚠️ PHPStan failed – check baseline"
+            vendor/bin/phpstan analyse --error-format=sarif > "$REPORT_DIR/phpstan.sarif" || echo "⚠️ PHPStan failed – check baseline"
           else
             echo "ℹ️ PHPStan not installed"
-            echo '{}' > phpstan.sarif
+            echo '{}' > "$REPORT_DIR/phpstan.sarif"
           fi
         working-directory: ${{ matrix.extension }}
       - name: Upload PHPStan report
         if: always()
         uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: ${{ matrix.extension }}/phpstan.sarif
+          sarif_file: "${{ github.workspace }}/${{ matrix.extension }}/build/reports/phpstan.sarif"
       - name: Run PHPUnit
         continue-on-error: true
         run: |


### PR DESCRIPTION
## Summary
- output PHPStan SARIF to `build/reports` within each extension
- ensure `upload-sarif` points to the full path in `github.workspace`

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_684f023433f8832492e4b740e40c0128