### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/monorepo-check.yml
+++ b/.github/workflows/monorepo-check.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/MSAlpaka/EquEdEU/security/code-scanning/3](https://github.com/MSAlpaka/EquEdEU/security/code-scanning/3)

To fix the issue, add a `permissions` block at the root level of the workflow file. This block will apply to all jobs in the workflow unless overridden by job-specific permissions. Since the workflow only reads repository contents and does not require write access, the permissions should be set to `contents: read`. This change ensures that the workflow operates with the minimum required privileges.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
