### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-matrix.yml
+++ b/.github/workflows/ci-matrix.yml
@@ -8,6 +8,10 @@ on:
     paths:
       - 'equed-*/**'
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   discover:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/MSAlpaka/EquEdEU/security/code-scanning/4](https://github.com/MSAlpaka/EquEdEU/security/code-scanning/4)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's actions, the following permissions are appropriate:

- `contents: read` for reading repository contents.
- `security-events: write` for uploading SARIF files using the `github/codeql-action/upload-sarif` action.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within each job to customize permissions for specific tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
