### PR TITLE
Introduce request DTOs for upload and course access

### DIFF
--- a/equed-lms/Classes/Controller/Api/AppUploadController.php
+++ b/equed-lms/Classes/Controller/Api/AppUploadController.php
@@ -7,6 +7,8 @@ namespace Equed\EquedLms\Controller\Api;
 use Equed\Core\Service\ConfigurationServiceInterface;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 use Equed\EquedLms\Domain\Service\MediaUploadServiceInterface;
+use Equed\EquedLms\Dto\UploadFileRequest;
+use Equed\EquedLms\Dto\UploadFileResult;
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Http\JsonResponse;
@@ -44,38 +46,34 @@ final class AppUploadController
             );
         }
 
-        $user = $this->context->getAspect('frontend.user')->get('user');
-        $userId = is_array($user) && isset($user['uid']) ? (int)$user['uid'] : null;
-        if ($userId === null) {
-            return new JsonResponse(
-                ['error' => $this->translationService->translate('api.upload.unauthorized')],
-                JsonResponse::HTTP_UNAUTHORIZED
-            );
-        }
-
-        $body = $request->getParsedBody() ?? [];
-        $type = isset($body['type']) ? (string)$body['type'] : 'general';
-        $description = isset($body['description']) ? (string)$body['description'] : '';
-
-        $files = $request->getUploadedFiles();
-        $file = $files['file'] ?? null;
-        if ($file === null || $file->getError() !== \UPLOAD_ERR_OK) {
+        try {
+            $dto = UploadFileRequest::fromRequest($request);
+        } catch (\InvalidArgumentException $e) {
             return new JsonResponse(
                 ['error' => $this->translationService->translate('api.upload.invalidFile')],
                 JsonResponse::HTTP_BAD_REQUEST
             );
         }
 
-        $filePath = $this->mediaUploadService->upload(
-            userId: $userId,
-            file: $file,
-            type: $type,
-            description: $description
-        );
+        if ($dto->getUserId() <= 0) {
+            return new JsonResponse(
+                ['error' => $this->translationService->translate('api.upload.unauthorized')],
+                JsonResponse::HTTP_UNAUTHORIZED
+            );
+        }
+
+        $result = $this->mediaUploadService->upload($dto);
+
+        if ($result->hasError()) {
+            return new JsonResponse(
+                ['error' => $this->translationService->translate('api.upload.invalidFile')],
+                JsonResponse::HTTP_BAD_REQUEST
+            );
+        }
 
         return new JsonResponse([
             'status'    => 'success',
-            'file_path' => $filePath,
+            'file'      => $result->getFileReference(),
         ]);
     }
 }

--- a/equed-lms/Classes/Domain/Service/CourseAccessServiceInterface.php
+++ b/equed-lms/Classes/Domain/Service/CourseAccessServiceInterface.php
@@ -5,11 +5,18 @@ declare(strict_types=1);
 namespace Equed\EquedLms\Domain\Service;
 
 use Equed\EquedLms\Domain\Model\Lesson;
+use Equed\EquedLms\Dto\CourseAccessRequest;
+use Equed\EquedLms\Dto\CourseAccessResult;
 
 interface CourseAccessServiceInterface
 {
     public function hasAccessToCourseInstance(int $feUserId, int $courseInstanceId): bool;
 
     public function isLessonUnlockedForUser(int $feUserId, Lesson $lesson): bool;
+
+    /**
+     * Check course program access for a user.
+     */
+    public function checkCourseProgramAccess(CourseAccessRequest $request): CourseAccessResult;
 }
 

--- a/equed-lms/Classes/Domain/Service/MediaUploadServiceInterface.php
+++ b/equed-lms/Classes/Domain/Service/MediaUploadServiceInterface.php
@@ -6,6 +6,8 @@ namespace Equed\EquedLms\Domain\Service;
 
 use Equed\EquedLms\Domain\Model\FrontendUser;
 use TYPO3\CMS\Extbase\Domain\Model\FileReference;
+use Equed\EquedLms\Dto\UploadFileRequest;
+use Equed\EquedLms\Dto\UploadFileResult;
 
 interface MediaUploadServiceInterface
 {
@@ -17,4 +19,9 @@ interface MediaUploadServiceInterface
      * @return FileReference|null Stored file reference or null on error
      */
     public function handleUpload(array $uploadedFile, FrontendUser $user): ?FileReference;
+
+    /**
+     * Handle a PSR-7 upload request.
+     */
+    public function upload(UploadFileRequest $request): UploadFileResult;
 }

--- a/equed-lms/Classes/Dto/CourseAccessRequest.php
+++ b/equed-lms/Classes/Dto/CourseAccessRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Dto;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+final class CourseAccessRequest
+{
+    public function __construct(
+        private readonly int $userId,
+        private readonly int $courseProgramId
+    ) {
+    }
+
+    public static function fromRequest(ServerRequestInterface $request): self
+    {
+        $user = $request->getAttribute('user');
+        $userId = is_array($user) && isset($user['uid']) ? (int)$user['uid'] : 0;
+
+        $params = $request->getQueryParams();
+        $programId = isset($params['programId']) ? (int)$params['programId'] : 0;
+
+        return new self($userId, $programId);
+    }
+
+    public function getUserId(): int
+    {
+        return $this->userId;
+    }
+
+    public function getCourseProgramId(): int
+    {
+        return $this->courseProgramId;
+    }
+}

--- a/equed-lms/Classes/Dto/CourseAccessResult.php
+++ b/equed-lms/Classes/Dto/CourseAccessResult.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Dto;
+
+final class CourseAccessResult implements \JsonSerializable
+{
+    public function __construct(
+        private readonly bool $granted,
+        private readonly ?string $error = null
+    ) {
+    }
+
+    public function isGranted(): bool
+    {
+        return $this->granted;
+    }
+
+    public function getError(): ?string
+    {
+        return $this->error;
+    }
+
+    public function hasError(): bool
+    {
+        return $this->error !== null;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'granted' => $this->granted,
+            'error' => $this->error,
+        ];
+    }
+}

--- a/equed-lms/Classes/Dto/UploadFileRequest.php
+++ b/equed-lms/Classes/Dto/UploadFileRequest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Dto;
+
+use InvalidArgumentException;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\UploadedFileInterface;
+
+final class UploadFileRequest
+{
+    public function __construct(
+        private readonly int $userId,
+        private readonly UploadedFileInterface $file,
+        private readonly string $type,
+        private readonly string $description
+    ) {
+    }
+
+    public static function fromRequest(ServerRequestInterface $request): self
+    {
+        $user = $request->getAttribute('user');
+        $userId = is_array($user) && isset($user['uid']) ? (int)$user['uid'] : 0;
+
+        $body = (array)$request->getParsedBody();
+        $type = isset($body['type']) && $body['type'] !== '' ? trim((string)$body['type']) : 'general';
+        $description = isset($body['description']) ? trim((string)$body['description']) : '';
+
+        $files = $request->getUploadedFiles();
+        if (!isset($files['file']) || !$files['file'] instanceof UploadedFileInterface) {
+            throw new InvalidArgumentException('Invalid uploaded file');
+        }
+
+        $file = $files['file'];
+        if ($file->getError() !== UPLOAD_ERR_OK) {
+            throw new InvalidArgumentException('File upload error');
+        }
+
+        return new self($userId, $file, $type, $description);
+    }
+
+    public function getUserId(): int
+    {
+        return $this->userId;
+    }
+
+    public function getFile(): UploadedFileInterface
+    {
+        return $this->file;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+}

--- a/equed-lms/Classes/Dto/UploadFileResult.php
+++ b/equed-lms/Classes/Dto/UploadFileResult.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Dto;
+
+use TYPO3\CMS\Extbase\Domain\Model\FileReference;
+
+final class UploadFileResult implements \JsonSerializable
+{
+    public function __construct(
+        private readonly ?FileReference $fileReference,
+        private readonly ?string $error = null
+    ) {
+    }
+
+    public function getFileReference(): ?FileReference
+    {
+        return $this->fileReference;
+    }
+
+    public function getError(): ?string
+    {
+        return $this->error;
+    }
+
+    public function hasError(): bool
+    {
+        return $this->error !== null;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'fileReference' => $this->fileReference,
+            'error' => $this->error,
+        ];
+    }
+}

--- a/equed-lms/Classes/Service/CourseAccessService.php
+++ b/equed-lms/Classes/Service/CourseAccessService.php
@@ -8,6 +8,8 @@ use Equed\EquedLms\Domain\Model\Lesson;
 use Equed\EquedLms\Domain\Model\UserCourseRecord;
 use Equed\EquedLms\Domain\Repository\UserCourseRecordRepositoryInterface;
 use Equed\EquedLms\Domain\Service\CourseAccessServiceInterface;
+use Equed\EquedLms\Dto\CourseAccessRequest;
+use Equed\EquedLms\Dto\CourseAccessResult;
 
 /**
  * Service to check access permissions for courses and lessons.
@@ -59,6 +61,21 @@ final class CourseAccessService implements CourseAccessServiceInterface
         }
 
         return false;
+    }
+
+    public function checkCourseProgramAccess(CourseAccessRequest $request): CourseAccessResult
+    {
+        $programId = $request->getCourseProgramId();
+        $userId = $request->getUserId();
+
+        foreach ($this->getUserCourseRecords($userId) as $record) {
+            $courseProgram = $record->getCourseInstance()?->getCourseProgram();
+            if ($courseProgram?->getUid() === $programId) {
+                return new CourseAccessResult(true);
+            }
+        }
+
+        return new CourseAccessResult(false);
     }
 
     /**


### PR DESCRIPTION
## Summary
- add `UploadFileRequest` and `CourseAccessRequest` DTOs with validation
- return typed results from upload and course access services
- update controllers to use the new DTOs

## Testing
- `composer phpstan` *(fails: php not installed)*
- `composer test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684f068dfa4483249b7c595be564172e