### PR TITLE
Add token-based user middleware

### DIFF
--- a/equed-lms/Classes/Controller/Api/AppSyncController.php
+++ b/equed-lms/Classes/Controller/Api/AppSyncController.php
@@ -8,7 +8,6 @@ use Equed\Core\Service\ConfigurationServiceInterface;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 use Equed\EquedLms\Domain\Service\AppSyncServiceInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Http\JsonResponse;
 
 /**
@@ -23,8 +22,7 @@ final class AppSyncController
     public function __construct(
         private readonly AppSyncServiceInterface         $appSyncService,
         private readonly ConfigurationServiceInterface   $configurationService,
-        private readonly GptTranslationServiceInterface  $translationService,
-        private readonly Context                         $context
+        private readonly GptTranslationServiceInterface  $translationService
     ) {
     }
 
@@ -44,7 +42,7 @@ final class AppSyncController
             );
         }
 
-        $user = $this->context->getAspect('frontend.user')->get('user');
+        $user = $request->getAttribute('user');
         $userId = is_array($user) && isset($user['uid']) ? (int)$user['uid'] : null;
         if ($userId === null) {
             return new JsonResponse(
@@ -88,7 +86,7 @@ final class AppSyncController
             );
         }
 
-        $user = $this->context->getAspect('frontend.user')->get('user');
+        $user = $request->getAttribute('user');
         $userId = is_array($user) && isset($user['uid']) ? (int)$user['uid'] : null;
         if ($userId === null) {
             return new JsonResponse(

--- a/equed-lms/Classes/Controller/Api/AppUserController.php
+++ b/equed-lms/Classes/Controller/Api/AppUserController.php
@@ -8,7 +8,6 @@ use Equed\Core\Service\ConfigurationServiceInterface;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 use Equed\EquedLms\Domain\Repository\UserRepositoryInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Http\JsonResponse;
 
 /**
@@ -24,7 +23,6 @@ final class AppUserController
         private readonly UserRepositoryInterface         $userRepository,
         private readonly ConfigurationServiceInterface   $configurationService,
         private readonly GptTranslationServiceInterface  $translationService,
-        private readonly Context                         $context
     ) {
     }
 
@@ -44,7 +42,7 @@ final class AppUserController
             );
         }
 
-        $userContext = $this->context->getAspect('frontend.user')->get('user');
+        $userContext = $request->getAttribute('user');
         if (!is_array($userContext) || !isset($userContext['uid'])) {
             return new JsonResponse(
                 ['error' => $this->translationService->translate('api.userProfile.unauthorized')],

--- a/equed-lms/Classes/Controller/Api/AuditController.php
+++ b/equed-lms/Classes/Controller/Api/AuditController.php
@@ -7,7 +7,6 @@ namespace Equed\EquedLms\Controller\Api;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 use Equed\EquedLms\Domain\Repository\AuditLogRepositoryInterface;
 use Psr\Http\Message\ResponseInterface;
-use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 
 /**
@@ -22,7 +21,6 @@ final class AuditController extends ActionController
     public function __construct(
         private readonly AuditLogRepositoryInterface     $auditLogRepository,
         private readonly GptTranslationServiceInterface  $translationService,
-        private readonly Context                         $context
     ) {
         parent::__construct();
     }
@@ -35,7 +33,7 @@ final class AuditController extends ActionController
      */
     public function listAction(): ResponseInterface
     {
-        $userContext = $this->context->getAspect('frontend.user')->get('user');
+        $userContext = $this->request->getAttribute('user');
         $userId = is_array($userContext) && isset($userContext['uid'])
             ? (int)$userContext['uid']
             : 0;

--- a/equed-lms/Classes/Controller/Api/AuthController.php
+++ b/equed-lms/Classes/Controller/Api/AuthController.php
@@ -10,7 +10,6 @@ use Equed\Core\Service\PasswordHasherInterface;
 use Equed\EquedLms\Domain\Repository\UserRepositoryInterface;
 use Equed\EquedLms\Domain\Service\JwtServiceInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Http\JsonResponse;
 
 /**
@@ -28,7 +27,6 @@ final class AuthController
         private readonly PasswordHasherInterface        $passwordHasher,
         private readonly ConfigurationServiceInterface  $configurationService,
         private readonly GptTranslationServiceInterface $translationService,
-        private readonly Context                        $context
     ) {
     }
 
@@ -118,7 +116,7 @@ final class AuthController
             );
         }
 
-        $userContext = $this->context->getAspect('frontend.user')->get('user');
+        $userContext = $request->getAttribute('user');
         if (!is_array($userContext) || !isset($userContext['uid'])) {
             return new JsonResponse(
                 ['error' => $this->translationService->translate('api.auth.unauthorized')],

--- a/equed-lms/Classes/Controller/Api/BadgeController.php
+++ b/equed-lms/Classes/Controller/Api/BadgeController.php
@@ -7,7 +7,6 @@ namespace Equed\EquedLms\Controller\Api;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 use Equed\EquedLms\Domain\Repository\BadgeAwardRepositoryInterface;
 use Psr\Http\Message\ResponseInterface;
-use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 
 /**
@@ -21,7 +20,7 @@ final class BadgeController extends ActionController
     public function __construct(
         private readonly BadgeAwardRepositoryInterface  $awardRepository,
         private readonly GptTranslationServiceInterface $translationService,
-        private readonly Context                        $context,
+
     ) {
         parent::__construct();
     }
@@ -34,7 +33,7 @@ final class BadgeController extends ActionController
      */
     public function listAction(): ResponseInterface
     {
-        $userContext = $this->context->getAspect('frontend.user')->get('user');
+        $userContext = $this->request->getAttribute('user');
         $userId = is_array($userContext) && isset($userContext['uid'])
             ? (int)$userContext['uid']
             : 0;

--- a/equed-lms/Classes/Controller/Api/CertificateController.php
+++ b/equed-lms/Classes/Controller/Api/CertificateController.php
@@ -7,7 +7,6 @@ namespace Equed\EquedLms\Controller\Api;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Http\JsonResponse;
-use TYPO3\CMS\Core\Context\Context;
 use Equed\Core\Service\ConfigurationServiceInterface;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 use Equed\EquedLms\Domain\Repository\CertificateRepositoryInterface;
@@ -30,7 +29,6 @@ final class CertificateController
         private readonly BadgeServiceInterface          $badgeService,
         private readonly ConfigurationServiceInterface  $configurationService,
         private readonly GptTranslationServiceInterface $translationService,
-        private readonly Context                        $context
     ) {
     }
 
@@ -50,7 +48,7 @@ final class CertificateController
             );
         }
 
-        $user = $this->context->getAspect('frontend.user')->get('user');
+        $user = $request->getAttribute('user');
         $userId = is_array($user) && isset($user['uid'])
             ? (int)$user['uid']
             : null;
@@ -96,7 +94,7 @@ final class CertificateController
             );
         }
 
-        $user = $this->context->getAspect('frontend.user')->get('user');
+        $user = $request->getAttribute('user');
         $userId = is_array($user) && isset($user['uid'])
             ? (int)$user['uid']
             : null;
@@ -150,7 +148,7 @@ final class CertificateController
             );
         }
 
-        $user = $this->context->getAspect('frontend.user')->get('user');
+        $user = $request->getAttribute('user');
         $userId = is_array($user) && isset($user['uid'])
             ? (int)$user['uid']
             : null;

--- a/equed-lms/Classes/Controller/Api/CertifierController.php
+++ b/equed-lms/Classes/Controller/Api/CertifierController.php
@@ -7,7 +7,6 @@ namespace Equed\EquedLms\Controller\Api;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Http\JsonResponse;
-use TYPO3\CMS\Core\Context\Context;
 use Equed\Core\Service\ConfigurationServiceInterface;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 use Equed\EquedLms\Domain\Service\CertifierServiceInterface;
@@ -25,7 +24,6 @@ final class CertifierController
         private readonly CertifierServiceInterface        $certifierService,
         private readonly ConfigurationServiceInterface     $configurationService,
         private readonly GptTranslationServiceInterface    $translationService,
-        private readonly Context                           $context
     ) {
     }
 
@@ -45,7 +43,7 @@ final class CertifierController
             );
         }
 
-        $user = $this->context->getAspect('frontend.user')->get('user');
+        $user = $request->getAttribute('user');
         $certifierId = is_array($user) && isset($user['uid']) ? (int)$user['uid'] : null;
         if ($certifierId === null) {
             return new JsonResponse(
@@ -81,7 +79,7 @@ final class CertifierController
         $body = (array)$request->getParsedBody();
         $recordId = isset($body['recordId']) ? (int)$body['recordId'] : 0;
 
-        $user = $this->context->getAspect('frontend.user')->get('user');
+        $user = $request->getAttribute('user');
         $certifierId = is_array($user) && isset($user['uid']) ? (int)$user['uid'] : null;
 
         if ($certifierId === null || $recordId <= 0) {
@@ -119,7 +117,7 @@ final class CertifierController
         $recordId = isset($body['recordId']) ? (int)$body['recordId'] : 0;
         $feedback = isset($body['feedback']) ? trim((string)$body['feedback']) : '';
 
-        $user = $this->context->getAspect('frontend.user')->get('user');
+        $user = $request->getAttribute('user');
         $certifierId = is_array($user) && isset($user['uid']) ? (int)$user['uid'] : null;
 
         if ($certifierId === null || $recordId <= 0 || $feedback === '') {

--- a/equed-lms/Classes/Controller/Api/CourseBundleController.php
+++ b/equed-lms/Classes/Controller/Api/CourseBundleController.php
@@ -7,7 +7,6 @@ namespace Equed\EquedLms\Controller\Api;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Http\JsonResponse;
-use TYPO3\CMS\Core\Context\Context;
 use Equed\Core\Service\ConfigurationServiceInterface;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 use Equed\EquedLms\Domain\Service\CourseBundleServiceInterface;
@@ -25,7 +24,6 @@ final class CourseBundleController
         private readonly CourseBundleServiceInterface    $bundleService,
         private readonly ConfigurationServiceInterface   $configurationService,
         private readonly GptTranslationServiceInterface  $translationService,
-        private readonly Context                         $context
     ) {
     }
 
@@ -45,7 +43,7 @@ final class CourseBundleController
             );
         }
 
-        $user = $this->context->getAspect('frontend.user')->get('user');
+        $user = $request->getAttribute('user');
         $userId = is_array($user) && isset($user['uid']) ? (int)$user['uid'] : null;
         if ($userId === null) {
             return new JsonResponse(

--- a/equed-lms/Classes/Controller/Api/CourseOverviewController.php
+++ b/equed-lms/Classes/Controller/Api/CourseOverviewController.php
@@ -9,7 +9,6 @@ use TYPO3\CMS\Core\Http\JsonResponse;
 use Equed\Core\Service\ConfigurationServiceInterface;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 use Equed\EquedLms\Domain\Service\CourseOverviewServiceInterface;
-use TYPO3\CMS\Core\Context\Context;
 
 /**
  * API controller for providing course overview data:
@@ -25,7 +24,6 @@ final class CourseOverviewController
         private readonly CourseOverviewServiceInterface    $overviewService,
         private readonly ConfigurationServiceInterface     $configurationService,
         private readonly GptTranslationServiceInterface    $translationService,
-        private readonly Context                           $context
     ) {
     }
 
@@ -45,7 +43,7 @@ final class CourseOverviewController
             );
         }
 
-        $user = $this->context->getAspect('frontend.user')->get('user');
+        $user = $request->getAttribute('user');
         $userId = is_array($user) && isset($user['uid'])
             ? (int)$user['uid']
             : null;

--- a/equed-lms/Classes/Controller/Api/DashboardApiController.php
+++ b/equed-lms/Classes/Controller/Api/DashboardApiController.php
@@ -6,7 +6,6 @@ namespace Equed\EquedLms\Controller\Api;
 
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Http\JsonResponse;
-use TYPO3\CMS\Core\Context\Context;
 use Equed\Core\Service\ConfigurationServiceInterface;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 use Equed\EquedLms\Domain\Repository\UserRepositoryInterface;
@@ -27,7 +26,6 @@ final class DashboardApiController extends ActionController
         private readonly UserRepositoryInterface           $userRepository,
         private readonly ConfigurationServiceInterface     $configurationService,
         private readonly GptTranslationServiceInterface    $translationService,
-        private readonly Context                           $context
     ) {
         parent::__construct();
     }
@@ -48,7 +46,7 @@ final class DashboardApiController extends ActionController
             );
         }
 
-        $userContext = $this->context->getAspect('frontend.user')->get('user');
+        $userContext = $request->getAttribute('user');
         $userId = is_array($userContext) && isset($userContext['uid'])
             ? (int)$userContext['uid']
             : null;

--- a/equed-lms/Classes/Controller/Api/DashboardController.php
+++ b/equed-lms/Classes/Controller/Api/DashboardController.php
@@ -6,7 +6,6 @@ namespace Equed\EquedLms\Controller\Api;
 
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Http\JsonResponse;
-use TYPO3\CMS\Core\Context\Context;
 use Equed\Core\Service\ConfigurationServiceInterface;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 use Equed\EquedLms\Domain\Service\DashboardServiceInterface;
@@ -25,7 +24,6 @@ final class DashboardController extends ActionController
         private readonly DashboardServiceInterface         $dashboardService,
         private readonly ConfigurationServiceInterface     $configurationService,
         private readonly GptTranslationServiceInterface    $translationService,
-        private readonly Context                           $context
     ) {
         parent::__construct();
     }
@@ -46,7 +44,7 @@ final class DashboardController extends ActionController
             );
         }
 
-        $userContext = $this->context->getAspect('frontend.user')->get('user');
+        $userContext = $request->getAttribute('user');
         $userId = is_array($userContext) && isset($userContext['uid'])
             ? (int)$userContext['uid']
             : null;

--- a/equed-lms/Classes/Controller/Api/ExamController.php
+++ b/equed-lms/Classes/Controller/Api/ExamController.php
@@ -9,7 +9,6 @@ use TYPO3\CMS\Core\Http\JsonResponse;
 use Equed\Core\Service\ConfigurationServiceInterface;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 use Equed\EquedLms\Domain\Service\ExamServiceInterface;
-use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 
 /**
@@ -25,7 +24,6 @@ final class ExamController extends ActionController
         private readonly ExamServiceInterface              $examService,
         private readonly ConfigurationServiceInterface     $configurationService,
         private readonly GptTranslationServiceInterface    $translationService,
-        private readonly Context                           $context
     ) {
         parent::__construct();
     }
@@ -83,7 +81,7 @@ final class ExamController extends ActionController
             );
         }
 
-        $userContext = $this->context->getAspect('frontend.user')->get('user');
+        $userContext = $request->getAttribute('user');
         $userId      = is_array($userContext) && isset($userContext['uid']) ? (int)$userContext['uid'] : null;
         if ($userId === null) {
             return new JsonResponse(

--- a/equed-lms/Classes/Controller/Api/FeedbackController.php
+++ b/equed-lms/Classes/Controller/Api/FeedbackController.php
@@ -6,7 +6,6 @@ namespace Equed\EquedLms\Controller\Api;
 
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Http\JsonResponse;
-use TYPO3\CMS\Core\Context\Context;
 use Equed\Core\Service\ConfigurationServiceInterface;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 use Equed\EquedLms\Domain\Service\FeedbackServiceInterface;
@@ -25,7 +24,6 @@ final class FeedbackController extends ActionController
         private readonly FeedbackServiceInterface        $feedbackService,
         private readonly ConfigurationServiceInterface   $configurationService,
         private readonly GptTranslationServiceInterface  $translationService,
-        private readonly Context                         $context
     ) {
         parent::__construct();
     }
@@ -45,7 +43,7 @@ final class FeedbackController extends ActionController
             );
         }
 
-        $user = $this->context->getAspect('frontend.user')->get('user');
+        $user = $request->getAttribute('user');
         $userId = is_array($user) && isset($user['uid']) ? (int)$user['uid'] : null;
         if ($userId === null) {
             return new JsonResponse(
@@ -100,7 +98,7 @@ final class FeedbackController extends ActionController
             );
         }
 
-        $user = $this->context->getAspect('frontend.user')->get('user');
+        $user = $request->getAttribute('user');
         $userId = is_array($user) && isset($user['uid']) ? (int)$user['uid'] : null;
         if ($userId === null) {
             return new JsonResponse(

--- a/equed-lms/Classes/Controller/Api/InstructorActionController.php
+++ b/equed-lms/Classes/Controller/Api/InstructorActionController.php
@@ -6,7 +6,6 @@ namespace Equed\EquedLms\Controller\Api;
 
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Http\JsonResponse;
-use TYPO3\CMS\Core\Context\Context;
 use Equed\Core\Service\ConfigurationServiceInterface;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 use Equed\EquedLms\Service\InstructorService;
@@ -25,7 +24,6 @@ final class InstructorActionController extends ActionController
         private readonly InstructorService        $instructorService,
         private readonly ConfigurationServiceInterface     $configurationService,
         private readonly GptTranslationServiceInterface    $translationService,
-        private readonly Context                           $context
     ) {
         parent::__construct();
     }
@@ -46,7 +44,7 @@ final class InstructorActionController extends ActionController
             );
         }
 
-        $user = $this->context->getAspect('frontend.user')->get('user');
+        $user = $request->getAttribute('user');
         $instructorId = is_array($user) && isset($user['uid']) ? (int)$user['uid'] : null;
         if ($instructorId === null) {
             return new JsonResponse(
@@ -94,7 +92,7 @@ final class InstructorActionController extends ActionController
             );
         }
 
-        $user = $this->context->getAspect('frontend.user')->get('user');
+        $user = $request->getAttribute('user');
         $instructorId = is_array($user) && isset($user['uid']) ? (int)$user['uid'] : null;
         if ($instructorId === null) {
             return new JsonResponse(

--- a/equed-lms/Classes/Controller/Api/InstructorDashboardController.php
+++ b/equed-lms/Classes/Controller/Api/InstructorDashboardController.php
@@ -6,7 +6,6 @@ namespace Equed\EquedLms\Controller\Api;
 
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Http\JsonResponse;
-use TYPO3\CMS\Core\Context\Context;
 use Equed\Core\Service\ConfigurationServiceInterface;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 use Equed\EquedLms\Domain\Service\InstructorDashboardServiceInterface;
@@ -27,7 +26,6 @@ final class InstructorDashboardController extends ActionController
         private readonly InstructorDashboardServiceInterface $dashboardService,
         private readonly ConfigurationServiceInterface       $configurationService,
         private readonly GptTranslationServiceInterface      $translationService,
-        private readonly Context                             $context
     ) {
         parent::__construct();
     }
@@ -48,7 +46,7 @@ final class InstructorDashboardController extends ActionController
             );
         }
 
-        $user = $this->context->getAspect('frontend.user')->get('user');
+        $user = $request->getAttribute('user');
         $instructorId = is_array($user) && isset($user['uid']) ? (int)$user['uid'] : null;
         if ($instructorId === null || ! $this->dashboardService->isInstructor($instructorId)) {
             return new JsonResponse(

--- a/equed-lms/Classes/Controller/Api/LessonController.php
+++ b/equed-lms/Classes/Controller/Api/LessonController.php
@@ -7,7 +7,6 @@ namespace Equed\EquedLms\Controller\Api;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Http\JsonResponse;
-use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use Equed\EquedLms\Service\LessonProgressSyncService;
 use Equed\Core\Service\ConfigurationServiceInterface;
@@ -24,7 +23,6 @@ final class LessonController extends ActionController
         private readonly LessonProgressSyncService $progressService,
         private readonly ConfigurationServiceInterface $configurationService,
         private readonly GptTranslationServiceInterface $translationService,
-        private readonly Context $context
     ) {
         parent::__construct();
     }
@@ -37,7 +35,7 @@ final class LessonController extends ActionController
             ], 403);
         }
 
-        $userContext = $this->context->getAspect('frontend.user')->get('user');
+        $userContext = $request->getAttribute('user');
         $userId = is_array($userContext) && isset($userContext['uid']) ? (int)$userContext['uid'] : null;
 
         if ($userId === null) {

--- a/equed-lms/Classes/Controller/Api/LessonProgressController.php
+++ b/equed-lms/Classes/Controller/Api/LessonProgressController.php
@@ -6,7 +6,6 @@ namespace Equed\EquedLms\Controller\Api;
 
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Http\JsonResponse;
-use TYPO3\CMS\Core\Context\Context;
 use Equed\Core\Service\ConfigurationServiceInterface;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 use Equed\EquedLms\Domain\Service\LessonProgressServiceInterface;
@@ -25,7 +24,6 @@ final class LessonProgressController extends ActionController
         private readonly LessonProgressServiceInterface  $lessonProgressService,
         private readonly ConfigurationServiceInterface   $configurationService,
         private readonly GptTranslationServiceInterface $translationService,
-        private readonly Context                         $context
     ) {
         parent::__construct();
     }
@@ -45,7 +43,7 @@ final class LessonProgressController extends ActionController
             );
         }
 
-        $user = $this->context->getAspect('frontend.user')->get('user');
+        $user = $request->getAttribute('user');
         $userId = is_array($user) && isset($user['uid']) ? (int)$user['uid'] : null;
         if ($userId === null) {
             return new JsonResponse(
@@ -86,7 +84,7 @@ final class LessonProgressController extends ActionController
             );
         }
 
-        $user = $this->context->getAspect('frontend.user')->get('user');
+        $user = $request->getAttribute('user');
         $userId = is_array($user) && isset($user['uid']) ? (int)$user['uid'] : null;
         if ($userId === null) {
             return new JsonResponse(

--- a/equed-lms/Classes/Controller/Api/NotificationController.php
+++ b/equed-lms/Classes/Controller/Api/NotificationController.php
@@ -7,7 +7,6 @@ namespace Equed\EquedLms\Controller\Api;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Http\JsonResponse;
-use TYPO3\CMS\Core\Context\Context;
 use Equed\Core\Service\ConfigurationServiceInterface;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 use Equed\EquedLms\Domain\Service\NotificationServiceInterface;
@@ -26,7 +25,6 @@ final class NotificationController extends ActionController
         private readonly NotificationServiceInterface    $notificationService,
         private readonly ConfigurationServiceInterface   $configurationService,
         private readonly GptTranslationServiceInterface  $translationService,
-        private readonly Context                         $context
     ) {
         parent::__construct();
     }
@@ -43,7 +41,7 @@ final class NotificationController extends ActionController
             );
         }
 
-        $user = $this->context->getAspect('frontend.user')->get('user');
+        $user = $request->getAttribute('user');
         $userId = is_array($user) && isset($user['uid']) ? (int)$user['uid'] : null;
         if ($userId === null) {
             return new JsonResponse(
@@ -72,7 +70,7 @@ final class NotificationController extends ActionController
             );
         }
 
-        $user = $this->context->getAspect('frontend.user')->get('user');
+        $user = $request->getAttribute('user');
         $userId = is_array($user) && isset($user['uid']) ? (int)$user['uid'] : null;
         if ($userId === null) {
             return new JsonResponse(

--- a/equed-lms/Classes/Controller/Api/ProgressApiController.php
+++ b/equed-lms/Classes/Controller/Api/ProgressApiController.php
@@ -6,7 +6,6 @@ namespace Equed\EquedLms\Controller\Api;
 
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Http\JsonResponse;
-use TYPO3\CMS\Core\Context\Context;
 use Equed\Core\Service\ConfigurationServiceInterface;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 use Equed\EquedLms\Domain\Service\ProgressServiceInterface;
@@ -25,7 +24,6 @@ final class ProgressApiController extends ActionController
         private readonly ProgressServiceInterface          $progressService,
         private readonly ConfigurationServiceInterface     $configurationService,
         private readonly GptTranslationServiceInterface    $translationService,
-        private readonly Context                           $context
     ) {
         parent::__construct();
     }
@@ -46,7 +44,7 @@ final class ProgressApiController extends ActionController
             );
         }
 
-        $currentUser = $this->context->getAspect('frontend.user')->get('user');
+        $currentUser = $request->getAttribute('user');
         $currentUserId = is_array($currentUser) && isset($currentUser['uid']) ? (int)$currentUser['uid'] : null;
         if ($currentUserId === null) {
             return new JsonResponse(

--- a/equed-lms/Classes/Controller/Api/ProgressController.php
+++ b/equed-lms/Classes/Controller/Api/ProgressController.php
@@ -6,7 +6,6 @@ namespace Equed\EquedLms\Controller\Api;
 
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Http\JsonResponse;
-use TYPO3\CMS\Core\Context\Context;
 use Equed\Core\Service\ConfigurationServiceInterface;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 use Equed\EquedLms\Domain\Service\ProgressCalculationServiceInterface;
@@ -25,7 +24,6 @@ final class ProgressController extends ActionController
         private readonly ProgressCalculationServiceInterface $progressService,
         private readonly ConfigurationServiceInterface       $configurationService,
         private readonly GptTranslationServiceInterface      $translationService,
-        private readonly Context                             $context
     ) {
         parent::__construct();
     }
@@ -45,7 +43,7 @@ final class ProgressController extends ActionController
             );
         }
 
-        $user = $this->context->getAspect('frontend.user')->get('user');
+        $user = $request->getAttribute('user');
         $userId = is_array($user) && isset($user['uid']) ? (int)$user['uid'] : null;
         if ($userId === null) {
             return new JsonResponse(

--- a/equed-lms/Classes/Controller/Api/QmsController.php
+++ b/equed-lms/Classes/Controller/Api/QmsController.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Equed\EquedLms\Controller\Api;
 
 use Psr\Http\Message\ServerRequestInterface;
-use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Http\JsonResponse;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
@@ -23,7 +22,6 @@ final class QmsController extends ActionController
 {
     public function __construct(
         private readonly ConnectionPool                    $connectionPool,
-        private readonly Context                           $context,
         private readonly ConfigurationServiceInterface     $configurationService,
         private readonly GptTranslationServiceInterface    $translationService
     ) {
@@ -42,7 +40,7 @@ final class QmsController extends ActionController
             );
         }
 
-        $user = $this->context->getAspect('frontend.user')->get('user');
+        $user = $request->getAttribute('user');
         $userId = (is_array($user) && isset($user['uid'])) ? (int)$user['uid'] : null;
         if ($userId === null) {
             return new JsonResponse(
@@ -77,7 +75,7 @@ final class QmsController extends ActionController
                 JsonResponse::HTTP_FORBIDDEN
             );
         }
-        $user = $this->context->getAspect('frontend.user')->get('user');
+        $user = $request->getAttribute('user');
         $userId = (is_array($user) && isset($user['uid'])) ? (int)$user['uid'] : null;
         $body = (array)$request->getParsedBody();
         $recordId = (int)($body['recordId'] ?? 0);
@@ -124,7 +122,7 @@ final class QmsController extends ActionController
                 JsonResponse::HTTP_FORBIDDEN
             );
         }
-        $user = $this->context->getAspect('frontend.user')->get('user');
+        $user = $request->getAttribute('user');
         $userId = (is_array($user) && isset($user['uid'])) ? (int)$user['uid'] : null;
         $body = (array)$request->getParsedBody();
         $qmsId    = (int)($body['qmsId'] ?? 0);
@@ -170,7 +168,7 @@ final class QmsController extends ActionController
                 JsonResponse::HTTP_FORBIDDEN
             );
         }
-        $user = $this->context->getAspect('frontend.user')->get('user');
+        $user = $request->getAttribute('user');
         $userId = (is_array($user) && isset($user['uid'])) ? (int)$user['uid'] : null;
         $body = (array)$request->getParsedBody();
         $qmsId = (int)($body['qmsId'] ?? 0);

--- a/equed-lms/Classes/Controller/Api/RecognitionAwardController.php
+++ b/equed-lms/Classes/Controller/Api/RecognitionAwardController.php
@@ -7,7 +7,6 @@ namespace Equed\EquedLms\Controller\Api;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Http\JsonResponse;
-use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use Equed\Core\Service\ConfigurationServiceInterface;
@@ -25,7 +24,6 @@ final class RecognitionAwardController extends ActionController
         private readonly ConnectionPool $connectionPool,
         private readonly ConfigurationServiceInterface $configurationService,
         private readonly GptTranslationServiceInterface $translationService,
-        private readonly Context $context
     ) {
         parent::__construct();
     }
@@ -38,7 +36,7 @@ final class RecognitionAwardController extends ActionController
             ], 403);
         }
 
-        $user = $this->context->getAspect('frontend.user')->get('user');
+        $user = $request->getAttribute('user');
         $userId = is_array($user) && isset($user['uid']) ? (int)$user['uid'] : null;
 
         if ($userId === null) {

--- a/equed-lms/Classes/Controller/Api/ServiceCenterController.php
+++ b/equed-lms/Classes/Controller/Api/ServiceCenterController.php
@@ -7,7 +7,6 @@ namespace Equed\EquedLms\Controller\Api;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Http\JsonResponse;
-use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use Equed\Core\Service\ConfigurationServiceInterface;
@@ -25,7 +24,6 @@ final class ServiceCenterController extends ActionController
         private readonly ConnectionPool $connectionPool,
         private readonly ConfigurationServiceInterface $configurationService,
         private readonly GptTranslationServiceInterface $translationService,
-        private readonly Context $context
     ) {
         parent::__construct();
     }
@@ -38,7 +36,7 @@ final class ServiceCenterController extends ActionController
             ], 403);
         }
 
-        $user = $this->context->getAspect('frontend.user')->get('user');
+        $user = $request->getAttribute('user');
         $userGroups = is_array($user) ? $user['usergroup'] ?? [] : [];
 
         if (!is_array($userGroups) || !in_array('service_center', $userGroups)) {

--- a/equed-lms/Classes/Controller/Api/ServiceCenterDashboardApiController.php
+++ b/equed-lms/Classes/Controller/Api/ServiceCenterDashboardApiController.php
@@ -8,7 +8,6 @@ use Equed\EquedLms\Service\ServiceCenterDashboardService;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Http\JsonResponse;
-use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use Equed\Core\Service\ConfigurationServiceInterface;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
@@ -24,7 +23,6 @@ final class ServiceCenterDashboardApiController extends ActionController
         private readonly ServiceCenterDashboardService $dashboardService,
         private readonly ConfigurationServiceInterface $configurationService,
         private readonly GptTranslationServiceInterface $translationService,
-        private readonly Context $context
     ) {
         parent::__construct();
     }
@@ -37,7 +35,7 @@ final class ServiceCenterDashboardApiController extends ActionController
             ], 403);
         }
 
-        $user = $this->context->getAspect('frontend.user')->get('user');
+        $user = $request->getAttribute('user');
         $userGroups = is_array($user) ? ($user['usergroup'] ?? []) : [];
 
         if (!is_array($userGroups) || !in_array('service_center', $userGroups)) {

--- a/equed-lms/Classes/Controller/Api/SubmissionController.php
+++ b/equed-lms/Classes/Controller/Api/SubmissionController.php
@@ -9,7 +9,6 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Http\JsonResponse;
-use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 use Equed\EquedLms\Helper\AccessHelper;
@@ -26,7 +25,7 @@ final class SubmissionController extends ActionController
     public function __construct(
         private readonly ConnectionPool $connectionPool,
         private readonly GptTranslationServiceInterface $translationService,
-        private readonly Context $context,
+
         private readonly AccessHelper $accessHelper,
     ) {
     }
@@ -36,7 +35,7 @@ final class SubmissionController extends ActionController
      */
     public function submitAction(ServerRequestInterface $request): ResponseInterface
     {
-        $userContext = $this->context->getAspect('frontend.user')->get('user');
+        $userContext = $request->getAttribute('user');
         if (!is_array($userContext)) {
             return new JsonResponse([
                 'error' => $this->translationService->translate('api.submission.unauthorized'),
@@ -89,7 +88,7 @@ final class SubmissionController extends ActionController
      */
     public function listMineAction(ServerRequestInterface $request): ResponseInterface
     {
-        $userContext = $this->context->getAspect('frontend.user')->get('user');
+        $userContext = $request->getAttribute('user');
         $user = is_array($userContext) ? $userContext : null;
         if ($user === null) {
             return new JsonResponse([
@@ -116,7 +115,7 @@ final class SubmissionController extends ActionController
      */
     public function listByRecordAction(ServerRequestInterface $request): ResponseInterface
     {
-        $userContext = $this->context->getAspect('frontend.user')->get('user');
+        $userContext = $request->getAttribute('user');
         $user = is_array($userContext) ? $userContext : null;
         $recordId = (int)($request->getQueryParams()['recordId'] ?? 0);
 
@@ -145,7 +144,7 @@ final class SubmissionController extends ActionController
      */
     public function evaluateAction(ServerRequestInterface $request): ResponseInterface
     {
-        $userContext = $this->context->getAspect('frontend.user')->get('user');
+        $userContext = $request->getAttribute('user');
         $user = is_array($userContext) ? $userContext : null;
         if ($user === null) {
             return new JsonResponse([

--- a/equed-lms/Classes/Controller/Api/SubmissionRestController.php
+++ b/equed-lms/Classes/Controller/Api/SubmissionRestController.php
@@ -7,7 +7,6 @@ namespace Equed\EquedLms\Controller\Api;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Http\JsonResponse;
-use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 use Equed\EquedLms\Service\SubmissionSyncService;
@@ -17,7 +16,7 @@ final class SubmissionRestController extends ActionController
     public function __construct(
         private readonly SubmissionSyncService           $submissionService,
         private readonly GptTranslationServiceInterface $translationService,
-        private readonly Context                        $context,
+
     ) {
         parent::__construct();
     }
@@ -26,7 +25,7 @@ final class SubmissionRestController extends ActionController
     {
         $userId = (int)($request->getQueryParams()['userId'] ?? 0);
         if ($userId <= 0) {
-            $user = $this->context->getAspect('frontend.user')->get('user');
+            $user = $request->getAttribute('user');
             $userId = is_array($user) && isset($user['uid']) ? (int)$user['uid'] : 0;
         }
         if ($userId <= 0) {
@@ -51,7 +50,7 @@ final class SubmissionRestController extends ActionController
     {
         $data = $request->getParsedBody();
         if (empty($data['userId'])) {
-            $user = $this->context->getAspect('frontend.user')->get('user');
+            $user = $request->getAttribute('user');
             $data['userId'] = is_array($user) && isset($user['uid']) ? (int)$user['uid'] : 0;
         }
         if (empty($data['userId']) || !isset($data['submission'])) {

--- a/equed-lms/Classes/Controller/Api/SyncController.php
+++ b/equed-lms/Classes/Controller/Api/SyncController.php
@@ -7,7 +7,6 @@ namespace Equed\EquedLms\Controller\Api;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Http\JsonResponse;
-use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 use Equed\EquedLms\Service\SyncService;
@@ -19,7 +18,7 @@ final class SyncController extends ActionController
         private readonly SyncService                    $syncService,
         private readonly UserProfileRepositoryInterface $profileRepository,
         private readonly GptTranslationServiceInterface $translationService,
-        private readonly Context                        $context,
+
     ) {
         parent::__construct();
     }
@@ -28,7 +27,7 @@ final class SyncController extends ActionController
     {
         $userId = (int)($request->getQueryParams()['userId'] ?? 0);
         if ($userId <= 0) {
-            $user = $this->context->getAspect('frontend.user')->get('user');
+            $user = $request->getAttribute('user');
             $userId = is_array($user) && isset($user['uid']) ? (int)$user['uid'] : 0;
         }
         if ($userId <= 0) {
@@ -55,7 +54,7 @@ final class SyncController extends ActionController
     {
         $data = $request->getParsedBody();
         if (empty($data['userId'])) {
-            $user = $this->context->getAspect('frontend.user')->get('user');
+            $user = $request->getAttribute('user');
             $data['userId'] = is_array($user) && isset($user['uid']) ? (int)$user['uid'] : 0;
         }
 

--- a/equed-lms/Classes/Controller/Api/UserCourseRecordController.php
+++ b/equed-lms/Classes/Controller/Api/UserCourseRecordController.php
@@ -9,7 +9,6 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Http\JsonResponse;
-use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 
@@ -25,7 +24,7 @@ final class UserCourseRecordController extends ActionController
     public function __construct(
         private readonly ConnectionPool $connectionPool,
         private readonly GptTranslationServiceInterface $translationService,
-        private readonly Context $context,
+
     ) {
     }
 
@@ -34,7 +33,7 @@ final class UserCourseRecordController extends ActionController
      */
     public function listAction(ServerRequestInterface $request): ResponseInterface
     {
-        $userContext = $this->context->getAspect('frontend.user')->get('user');
+        $userContext = $request->getAttribute('user');
         $user = is_array($userContext) ? $userContext : null;
         if ($user === null) {
             return new JsonResponse([
@@ -61,7 +60,7 @@ final class UserCourseRecordController extends ActionController
      */
     public function showAction(ServerRequestInterface $request): ResponseInterface
     {
-        $userContext = $this->context->getAspect('frontend.user')->get('user');
+        $userContext = $request->getAttribute('user');
         $user = is_array($userContext) ? $userContext : null;
         $id = (int)($request->getQueryParams()['uid'] ?? 0);
         if ($user === null || $id <= 0) {
@@ -94,7 +93,7 @@ final class UserCourseRecordController extends ActionController
      */
     public function updateAction(ServerRequestInterface $request): ResponseInterface
     {
-        $userContext = $this->context->getAspect('frontend.user')->get('user');
+        $userContext = $request->getAttribute('user');
         $user = is_array($userContext) ? $userContext : null;
         $body = $request->getParsedBody();
         $id = (int)($body['uid'] ?? 0);
@@ -130,7 +129,7 @@ final class UserCourseRecordController extends ActionController
      */
     public function deleteAction(ServerRequestInterface $request): ResponseInterface
     {
-        $userContext = $this->context->getAspect('frontend.user')->get('user');
+        $userContext = $request->getAttribute('user');
         $user = is_array($userContext) ? $userContext : null;
         $id = (int)($request->getQueryParams()['uid'] ?? 0);
         if ($user === null || $id <= 0) {

--- a/equed-lms/Classes/Controller/Api/UserProfileController.php
+++ b/equed-lms/Classes/Controller/Api/UserProfileController.php
@@ -9,7 +9,6 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Http\JsonResponse;
-use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 
@@ -25,7 +24,7 @@ final class UserProfileController extends ActionController
     public function __construct(
         private readonly ConnectionPool $connectionPool,
         private readonly GptTranslationServiceInterface $translationService,
-        private readonly Context $context,
+
     ) {
     }
 
@@ -34,7 +33,7 @@ final class UserProfileController extends ActionController
      */
     public function showAction(ServerRequestInterface $request): ResponseInterface
     {
-        $userContext = $this->context->getAspect('frontend.user')->get('user');
+        $userContext = $request->getAttribute('user');
         $user = is_array($userContext) ? $userContext : null;
         if ($user === null) {
             return new JsonResponse([
@@ -65,7 +64,7 @@ final class UserProfileController extends ActionController
      */
     public function updateAction(ServerRequestInterface $request): ResponseInterface
     {
-        $userContext = $this->context->getAspect('frontend.user')->get('user');
+        $userContext = $request->getAttribute('user');
         $user = is_array($userContext) ? $userContext : null;
         $body = $request->getParsedBody();
         if ($user === null) {

--- a/equed-lms/Classes/Controller/Api/UserProgressController.php
+++ b/equed-lms/Classes/Controller/Api/UserProgressController.php
@@ -9,7 +9,6 @@ use Equed\EquedLms\Trait\ErrorResponseTrait;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Http\JsonResponse;
-use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 
@@ -25,7 +24,7 @@ final class UserProgressController extends ActionController
     public function __construct(
         private readonly ProgressService $progressService,
         private readonly GptTranslationServiceInterface $translationService,
-        private readonly Context $context,
+
     ) {
     }
 
@@ -36,7 +35,7 @@ final class UserProgressController extends ActionController
      */
     public function showAction(ServerRequestInterface $request): ResponseInterface
     {
-        $userContext = $this->context->getAspect('frontend.user')->get('user');
+        $userContext = $request->getAttribute('user');
         $user = is_array($userContext) ? $userContext : null;
         if ($user === null) {
             return new JsonResponse([
@@ -60,7 +59,7 @@ final class UserProgressController extends ActionController
      */
     public function courseAction(ServerRequestInterface $request): ResponseInterface
     {
-        $userContext = $this->context->getAspect('frontend.user')->get('user');
+        $userContext = $request->getAttribute('user');
         $user = is_array($userContext) ? $userContext : null;
         $params = $request->getQueryParams();
         $recordId = (int)($params['recordId'] ?? 0);

--- a/equed-lms/Classes/Controller/CourseController.php
+++ b/equed-lms/Classes/Controller/CourseController.php
@@ -7,7 +7,6 @@ namespace Equed\EquedLms\Controller;
 use Equed\EquedLms\Service\CourseProgressServiceInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 
 /**
@@ -19,8 +18,7 @@ use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 final class CourseController extends ActionController
 {
     public function __construct(
-        private readonly CourseProgressServiceInterface $courseProgressService,
-        private readonly Context $context
+        private readonly CourseProgressServiceInterface $courseProgressService
     ) {
         parent::__construct();
     }
@@ -31,7 +29,8 @@ final class CourseController extends ActionController
     public function showAction(ServerRequestInterface $request): ResponseInterface
     {
         $courseUid = (int)($this->settings['course'] ?? 0);
-        $userId = (int)$this->context->getAspect('frontend.user')->get('id');
+        $userAttr = $request->getAttribute('user');
+        $userId   = is_array($userAttr) && isset($userAttr['uid']) ? (int)$userAttr['uid'] : 0;
 
         $data = $this->courseProgressService->getCourseViewModel($courseUid, $userId);
 

--- a/equed-lms/Classes/Controller/ProfileController.php
+++ b/equed-lms/Classes/Controller/ProfileController.php
@@ -7,7 +7,6 @@ namespace Equed\EquedLms\Controller;
 use Equed\Core\Service\GptTranslationServiceInterface;
 use Equed\EquedLms\Service\ProfileService;
 use Psr\Http\Message\ResponseInterface;
-use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Messaging\AbstractMessage;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 
@@ -22,8 +21,7 @@ final class ProfileController extends ActionController
 {
     public function __construct(
         private readonly ProfileService                 $profileService,
-        private readonly GptTranslationServiceInterface $translationService,
-        private readonly Context                        $context
+        private readonly GptTranslationServiceInterface $translationService
     ) {
         parent::__construct();
     }
@@ -36,7 +34,7 @@ final class ProfileController extends ActionController
      */
     public function showAction(): ResponseInterface
     {
-        $user = $this->context->getAspect('frontend.user')->get('user');
+        $user = $this->request->getAttribute('user');
         if (!is_array($user) || !isset($user['uid'])) {
             $message = $this->translationService->translate('controller.profile.unauthenticated');
             $accept = $this->request->getHeaderLine('Accept');

--- a/equed-lms/Classes/Controller/QuizController.php
+++ b/equed-lms/Classes/Controller/QuizController.php
@@ -8,7 +8,6 @@ use Equed\EquedLms\Service\QuizManagerInterface;
 use Equed\EquedLms\Dto\QuizSubmissionRequest;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Messaging\AbstractMessage;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 
@@ -22,8 +21,7 @@ use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 final class QuizController extends ActionController
 {
     public function __construct(
-        private readonly QuizManagerInterface $quizManager,
-        private readonly Context $context
+        private readonly QuizManagerInterface $quizManager
     ) {
         parent::__construct();
     }
@@ -36,7 +34,7 @@ final class QuizController extends ActionController
      */
     public function listAction(ServerRequestInterface $request): ResponseInterface
     {
-        $user = $this->context->getAspect('frontend.user')->get('user');
+        $user = $request->getAttribute('user');
         $userId = is_array($user) && isset($user['uid']) ? (int)$user['uid'] : 0;
 
         $data = $this->quizManager->listQuizzes($userId);
@@ -89,7 +87,7 @@ final class QuizController extends ActionController
     {
         $quizId = (int)($request->getParsedBody()['quiz'] ?? 0);
         $answers = (array)($request->getParsedBody()['answers'] ?? []);
-        $user = $this->context->getAspect('frontend.user')->get('user');
+        $user = $request->getAttribute('user');
         $userId = is_array($user) && isset($user['uid']) ? (int)$user['uid'] : 0;
 
         $dto = new QuizSubmissionRequest($quizId, $userId, $answers);

--- a/equed-lms/Classes/Middleware/CourseAccessMiddleware.php
+++ b/equed-lms/Classes/Middleware/CourseAccessMiddleware.php
@@ -29,17 +29,20 @@ final class CourseAccessMiddleware implements MiddlewareInterface
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        $user = $request->getAttribute('feUser');
+        $userAttr = $request->getAttribute('user');
+        $userId   = is_object($userAttr) && method_exists($userAttr, 'getUid')
+            ? $userAttr->getUid()
+            : (is_array($userAttr) && isset($userAttr['uid']) ? (int)$userAttr['uid'] : 0);
         $courseInstanceId = (int)$request->getAttribute('courseInstance');
 
-        if ($user === null || $courseInstanceId <= 0) {
+        if ($userId <= 0 || $courseInstanceId <= 0) {
             return new JsonResponse(
                 ['error' => 'Invalid request'],
                 JsonResponse::STATUS_BAD_REQUEST
             );
         }
 
-        $accessList = $this->accessMapRepository->findByFeUser($user->getUid());
+        $accessList = $this->accessMapRepository->findByFeUser($userId);
         $hasAccess = false;
 
         foreach ($accessList as $access) {

--- a/equed-lms/Classes/Middleware/TokenUserMiddleware.php
+++ b/equed-lms/Classes/Middleware/TokenUserMiddleware.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Middleware;
+
+use Equed\EquedLms\Service\TokenService;
+use Laminas\Diactoros\Response\JsonResponse;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Middleware authenticating API requests via bearer tokens and
+ * injecting a simplified user array under the 'user' attribute.
+ */
+final class TokenUserMiddleware implements MiddlewareInterface
+{
+    public function __construct(private readonly TokenService $tokenService)
+    {
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $token = $this->extractToken($request);
+        if ($token === null) {
+            return new JsonResponse(['error' => 'Missing token'], JsonResponse::STATUS_UNAUTHORIZED);
+        }
+
+        $user = $this->tokenService->validateToken($token);
+        if ($user === null) {
+            return new JsonResponse(['error' => 'Invalid token'], JsonResponse::STATUS_UNAUTHORIZED);
+        }
+
+        $request = $request->withAttribute('user', ['uid' => $user->getUid()]);
+
+        return $handler->handle($request);
+    }
+
+    private function extractToken(ServerRequestInterface $request): ?string
+    {
+        $header = $request->getHeaderLine('Authorization');
+        if ($header !== '' && str_starts_with($header, 'Bearer ')) {
+            $token = substr($header, 7);
+            return $token !== '' ? $token : null;
+        }
+
+        $fallback = $request->getHeaderLine('X-Api-Token');
+        return $fallback !== '' ? $fallback : null;
+    }
+}
+
+// EOF

--- a/equed-lms/Configuration/RequestMiddlewares.php
+++ b/equed-lms/Configuration/RequestMiddlewares.php
@@ -21,17 +21,14 @@ return [
             'target' => \Equed\EquedLms\Middleware\LmsLoggingMiddleware::class,
             'after' => ['equed-lms/language'],
         ],
-        'equed-lms/token' => [
-            'target' => \Equed\EquedLms\Middleware\ApiTokenMiddleware::class,
-            'before' => ['equed-lms/user'],
-        ],
-        'equed-lms/user' => [
-            'target' => \Equed\EquedLms\Middleware\FrontendUserMiddleware::class,
-            'after' => ['equed-lms/token'],
+        // Validate bearer or API tokens and populate request user attribute
+        'equed-lms/auth' => [
+            'target' => \Equed\EquedLms\Middleware\TokenUserMiddleware::class,
+            'after'  => ['equed-lms/logging'],
         ],
         'equed-lms/course-access' => [
             'target' => \Equed\EquedLms\Middleware\CourseAccessMiddleware::class,
-            'after' => ['equed-lms/user'],
+            'after' => ['equed-lms/auth'],
         ],
     ],
 ];


### PR DESCRIPTION
## Summary
- implement `TokenUserMiddleware` for bearer token auth
- document the new middleware in `RequestMiddlewares.php`
- use request attributes in controllers instead of Context
- adjust `CourseAccessMiddleware` to expect `user` attribute

## Testing
- `composer install --no-interaction` *(fails: ext-dom missing)*

------
https://chatgpt.com/codex/tasks/task_e_684f087d601c8324b764aebfe86fbbbc