### PR TITLE
Refactor lesson API controller

### DIFF
--- a/equed-lms/Classes/Service/LessonService.php
+++ b/equed-lms/Classes/Service/LessonService.php
@@ -8,6 +8,7 @@ use Equed\EquedLms\Domain\Model\Lesson;
 use Equed\EquedLms\Domain\Model\Asset;
 use Equed\EquedLms\Domain\Model\Page;
 use Equed\EquedLms\Domain\Repository\LessonRepositoryInterface;
+use Equed\EquedLms\Service\LessonServiceInterface;
 use Psr\Cache\CacheItemPoolInterface;
 
 /**
@@ -15,7 +16,7 @@ use Psr\Cache\CacheItemPoolInterface;
  *
  * Caches result using PSR-6 cache pool to improve performance.
  */
-final class LessonService
+final class LessonService implements LessonServiceInterface
 {
     private const CACHE_TTL_SECONDS = 86400;
     public function __construct(
@@ -67,5 +68,18 @@ final class LessonService
         $this->cachePool->save($cacheItem);
 
         return $data;
+    }
+
+    /**
+     * Finds a lesson by UID and returns its data array.
+     */
+    public function getLessonDataById(int $lessonId): ?array
+    {
+        $lesson = $this->lessonRepository->findByUid($lessonId);
+        if ($lesson === null) {
+            return null;
+        }
+
+        return $this->getLessonDataArray($lesson);
     }
 }

--- a/equed-lms/Classes/Service/LessonServiceInterface.php
+++ b/equed-lms/Classes/Service/LessonServiceInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Service;
+
+use Equed\EquedLms\Domain\Model\Lesson;
+
+/**
+ * Contract for lesson related data retrieval.
+ */
+interface LessonServiceInterface
+{
+    /**
+     * Builds a structured lesson data array.
+     *
+     * @param Lesson $lesson
+     * @return array<string, mixed>
+     */
+    public function getLessonDataArray(Lesson $lesson): array;
+
+    /**
+     * Retrieves lesson data by identifier.
+     *
+     * @param int $lessonId
+     * @return array<string, mixed>|null
+     */
+    public function getLessonDataById(int $lessonId): ?array;
+}


### PR DESCRIPTION
## Summary
- extend `BaseApiController` for `AppLessonController`
- introduce `LessonServiceInterface` and add `getLessonDataById()`
- use base controller helpers for feature toggle and json responses

## Testing
- `composer test` *(fails: Cannot declare interface UuidGeneratorInterface)*

------
https://chatgpt.com/codex/tasks/task_e_684f2c0d67508324b3bad102fa355bca