### PR TITLE
Refactor SearchController to use BaseApiController

### DIFF
--- a/equed-lms/Classes/Controller/Api/SearchController.php
+++ b/equed-lms/Classes/Controller/Api/SearchController.php
@@ -5,66 +5,46 @@ declare(strict_types=1);
 namespace Equed\EquedLms\Controller\Api;
 
 use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Http\JsonResponse;
-use TYPO3\CMS\Core\Database\ConnectionPool;
-use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
-use TYPO3\CMS\Core\Context\Context;
 use Equed\Core\Service\ConfigurationServiceInterface;
+use Equed\EquedLms\Domain\Service\ApiResponseServiceInterface;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
+use Equed\EquedLms\Service\SearchService;
+use Equed\EquedLms\Controller\Api\BaseApiController;
 
 /**
  * API controller for performing global search across entities.
  * Feature flag: <search_api>
  */
-final class SearchController extends ActionController
+final class SearchController extends BaseApiController
 {
     public function __construct(
-        private readonly ConnectionPool $connectionPool,
-        private readonly ConfigurationServiceInterface $configurationService,
-        private readonly GptTranslationServiceInterface $translationService,
-        private readonly Context $context
+        private readonly SearchService $searchService,
+        ConfigurationServiceInterface $configurationService,
+        ApiResponseServiceInterface $apiResponseService,
+        GptTranslationServiceInterface $translationService,
     ) {
-        parent::__construct();
+        parent::__construct($configurationService, $apiResponseService, $translationService);
     }
 
-    public function searchAction(ServerRequestInterface $request): ResponseInterface
+    public function searchAction(ServerRequestInterface $request): JsonResponse
     {
-        if (! $this->configurationService->isFeatureEnabled('search_api')) {
-            return new JsonResponse([
-                'error' => $this->translationService->translate('api.search.disabled'),
-            ], 403);
+        if (($check = $this->requireFeature('search_api')) !== null) {
+            return $check;
         }
 
         $params = $request->getQueryParams();
         $term = trim((string)($params['q'] ?? ''));
 
-        if (mb_strlen($term) < 2) {
-            return new JsonResponse([
-                'error' => $this->translationService->translate('api.search.tooShort'),
-            ], 400);
+        $results = $this->searchService->search($term);
+
+        if ($results->hasError()) {
+            return $this->jsonError('api.search.tooShort', JsonResponse::HTTP_BAD_REQUEST);
         }
 
-        $results = [];
-
-        // Example search: courses by title
-        $qb = $this->connectionPool->getQueryBuilderForTable('tx_equedlms_domain_model_course');
-        $courses = $qb
-            ->select('uid', 'title', 'description')
-            ->from('tx_equedlms_domain_model_course')
-            ->where(
-                $qb->expr()->like('title', $qb->createNamedParameter('%' . $term . '%')),
-                $qb->expr()->eq('deleted', 0)
-            )
-            ->setMaxResults(10)
-            ->executeQuery()
-            ->fetchAllAssociative();
-
-        $results['courses'] = $courses;
-
-        return new JsonResponse([
-            'status'  => 'success',
-            'results' => $results,
+        return $this->jsonSuccess([
+            'courses'  => $results->getCourses(),
+            'glossary' => $results->getGlossary(),
         ]);
     }
 }


### PR DESCRIPTION
## Summary
- extend `BaseApiController` in `SearchController`
- use `SearchService` for filtering search results
- build responses with `jsonSuccess()`/`jsonError()`

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f351783c88324aac60a2852009850