### PR TITLE
Refactor UserProfileController for service-based API

### DIFF
--- a/equed-lms/Classes/Domain/Service/UserAccountServiceInterface.php
+++ b/equed-lms/Classes/Domain/Service/UserAccountServiceInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Domain\Service;
+
+/**
+ * Provides access to frontend user profile data.
+ */
+interface UserAccountServiceInterface
+{
+    /**
+     * Retrieve profile information for the given user.
+     *
+     * @param int $userId FE user identifier
+     * @return array<string,mixed>|null Profile data or null if not found
+     */
+    public function getProfile(int $userId): ?array;
+
+    /**
+     * Update profile fields for the given user.
+     *
+     * @param int $userId FE user identifier
+     * @param array<string,mixed> $fields Fields to update
+     */
+    public function updateProfile(int $userId, array $fields): void;
+}
+

--- a/equed-lms/Classes/Service/UserAccountService.php
+++ b/equed-lms/Classes/Service/UserAccountService.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Service;
+
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+use Equed\EquedLms\Domain\Service\UserAccountServiceInterface;
+
+/**
+ * Default implementation for retrieving and updating frontend user profiles.
+ */
+final class UserAccountService implements UserAccountServiceInterface
+{
+    public function __construct(private readonly ConnectionPool $connectionPool)
+    {
+    }
+
+    public function getProfile(int $userId): ?array
+    {
+        $qb = $this->getQueryBuilder('fe_users');
+        $qb->select('uid', 'username', 'name', 'email', 'usergroup')
+            ->from('fe_users')
+            ->where(
+                $qb->expr()->eq('uid', $qb->createNamedParameter($userId, \PDO::PARAM_INT)),
+                $qb->expr()->eq('deleted', 0)
+            );
+
+        $profile = $qb->executeQuery()->fetchAssociative();
+
+        return $profile === false ? null : $profile;
+    }
+
+    public function updateProfile(int $userId, array $fields): void
+    {
+        $fields['tstamp'] = time();
+        $connection = $this->connectionPool->getConnectionForTable('fe_users');
+        $connection->update('fe_users', $fields, ['uid' => $userId]);
+    }
+
+    private function getQueryBuilder(string $table): QueryBuilder
+    {
+        return $this->connectionPool->getQueryBuilderForTable($table);
+    }
+}
+


### PR DESCRIPTION
## Summary
- refactor `UserProfileController` to extend `BaseApiController`
- add `UserAccountService` and interface for profile retrieval and updates
- use feature flag check `requireFeature('user_profile_api')` and new service

## Testing
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684f3a6372e08324a796f044aecb431d