### PR TITLE
Refactor auth controller to use AuthService

### DIFF
--- a/equed-lms/Classes/Controller/Api/AppLoginController.php
+++ b/equed-lms/Classes/Controller/Api/AppLoginController.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Equed\EquedLms\Controller\Api;
 
 use Equed\Core\Service\ConfigurationServiceInterface;
-use Equed\EquedLms\Service\GptTranslationServiceInterface;
-use Equed\EquedLms\Domain\Service\AuthenticationServiceInterface;
-use Equed\EquedLms\Domain\Service\ApiResponseServiceInterface;
 use Equed\EquedLms\Controller\Api\BaseApiController;
+use Equed\EquedLms\Domain\Service\ApiResponseServiceInterface;
+use Equed\EquedLms\Domain\Service\AuthenticationServiceInterface;
+use Equed\EquedLms\Service\GptTranslationServiceInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Http\JsonResponse;
 
@@ -51,12 +51,13 @@ final class AppLoginController extends BaseApiController
             return $this->jsonError('api.login.missingCredentials', JsonResponse::HTTP_BAD_REQUEST);
         }
 
-        $user = $this->authService->validateCredentials($email, $password);
-        if ($user === null) {
+        $result = $this->authService->login($email, $password);
+        if ($result === null) {
             return $this->jsonError('api.login.invalidCredentials', JsonResponse::HTTP_FORBIDDEN);
         }
 
-        $token = $this->authService->createToken($user);
+        $token = $result['token'];
+        $user  = $result['user'];
 
         return $this->jsonSuccess([
             'token'  => $token,

--- a/equed-lms/Classes/Controller/Api/AuthController.php
+++ b/equed-lms/Classes/Controller/Api/AuthController.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Equed\EquedLms\Controller\Api;
 
 use Equed\Core\Service\ConfigurationServiceInterface;
-use Equed\EquedLms\Service\GptTranslationServiceInterface;
-use Equed\EquedLms\Domain\Service\AuthenticationServiceInterface;
-use Equed\EquedLms\Domain\Service\ApiResponseServiceInterface;
 use Equed\EquedLms\Controller\Api\BaseApiController;
+use Equed\EquedLms\Domain\Service\ApiResponseServiceInterface;
+use Equed\EquedLms\Domain\Service\AuthenticationServiceInterface;
+use Equed\EquedLms\Service\GptTranslationServiceInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Http\JsonResponse;
 
@@ -51,12 +51,12 @@ final class AuthController extends BaseApiController
             return $this->jsonError('api.auth.missingCredentials', JsonResponse::HTTP_BAD_REQUEST);
         }
 
-        $user = $this->authService->validateCredentials($email, $password);
-        if ($user === null) {
+        $result = $this->authService->login($email, $password);
+        if ($result === null) {
             return $this->jsonError('api.auth.invalidCredentials', JsonResponse::HTTP_UNAUTHORIZED);
         }
-
-        $token = $this->authService->createToken($user);
+        $token = $result['token'];
+        $user  = $result['user'];
 
         return $this->jsonSuccess([
             'token'  => $token,
@@ -80,6 +80,8 @@ final class AuthController extends BaseApiController
         if (($check = $this->requireFeature('login_api')) !== null) {
             return $check;
         }
+
+        $this->authService->logout();
 
         return $this->jsonSuccess([
             'message' => $this->translationService->translate('api.auth.loggedOut'),

--- a/equed-lms/Classes/Domain/Service/AuthenticationServiceInterface.php
+++ b/equed-lms/Classes/Domain/Service/AuthenticationServiceInterface.php
@@ -19,4 +19,16 @@ interface AuthenticationServiceInterface
      * Create a JWT token for the given user.
      */
     public function createToken(FrontendUser $user): string;
+
+    /**
+     * Authenticate and issue a token for the user.
+     *
+     * @return array{token: string, user: FrontendUser}|null
+     */
+    public function login(string $email, string $password): ?array;
+
+    /**
+     * Perform logout housekeeping.
+     */
+    public function logout(): void;
 }

--- a/equed-lms/Classes/Service/AuthenticationService.php
+++ b/equed-lms/Classes/Service/AuthenticationService.php
@@ -49,4 +49,21 @@ final class AuthenticationService implements AuthenticationServiceInterface
 
         return $this->jwtService->generateToken($payload);
     }
+
+    public function login(string $email, string $password): ?array
+    {
+        $user = $this->validateCredentials($email, $password);
+        if ($user === null) {
+            return null;
+        }
+
+        $token = $this->createToken($user);
+
+        return ['token' => $token, 'user' => $user];
+    }
+
+    public function logout(): void
+    {
+        // Stateless JWT logout - no action required currently
+    }
 }


### PR DESCRIPTION
## Summary
- handle login and logout via `AuthenticationService`
- keep controllers slim using service methods
- follow PSR‑12 import order

## Testing
- `vendor/bin/phpunit -c equed-lms/phpunit.xml.dist` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f3ecdc3b88324a69ed6d091feb19e