### PR TITLE
Refactor certifier API controller

### DIFF
--- a/equed-lms/Classes/Controller/Api/CertifierController.php
+++ b/equed-lms/Classes/Controller/Api/CertifierController.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace Equed\EquedLms\Controller\Api;
 
-use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Message\ResponseInterface;
-use TYPO3\CMS\Core\Http\JsonResponse;
 use Equed\Core\Service\ConfigurationServiceInterface;
-use Equed\EquedLms\Service\GptTranslationServiceInterface;
+use Equed\EquedLms\Controller\Api\BaseApiController;
+use Equed\EquedLms\Domain\Service\ApiResponseServiceInterface;
 use Equed\EquedLms\Domain\Service\CertifierServiceInterface;
+use Equed\EquedLms\Service\GptTranslationServiceInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Http\JsonResponse;
 
 /**
  * API controller for certifier actions: listing, approving and rejecting course validations.
@@ -18,13 +19,15 @@ use Equed\EquedLms\Domain\Service\CertifierServiceInterface;
  * with fallback chain (EN → DE → FR → ES → SW → EASY).
  * Execution is guarded by the <certifier_validation> feature toggle.
  */
-final class CertifierController
+final class CertifierController extends BaseApiController
 {
     public function __construct(
-        private readonly CertifierServiceInterface        $certifierService,
-        private readonly ConfigurationServiceInterface     $configurationService,
-        private readonly GptTranslationServiceInterface    $translationService,
+        private readonly CertifierServiceInterface $certifierService,
+        ConfigurationServiceInterface $configurationService,
+        ApiResponseServiceInterface $apiResponseService,
+        GptTranslationServiceInterface $translationService,
     ) {
+        parent::__construct($configurationService, $apiResponseService, $translationService);
     }
 
     /**
@@ -36,26 +39,18 @@ final class CertifierController
      */
     public function assignedValidationsAction(ServerRequestInterface $request): JsonResponse
     {
-        if (!$this->configurationService->isFeatureEnabled('certifier_validation')) {
-            return new JsonResponse(
-                ['error' => $this->translationService->translate('api.certifier.disabled')],
-                JsonResponse::HTTP_FORBIDDEN
-            );
+        if (($check = $this->requireFeature('certifier_validation')) !== null) {
+            return $check;
         }
 
-        $user = $request->getAttribute('user');
-        $certifierId = is_array($user) && isset($user['uid']) ? (int)$user['uid'] : null;
+        $certifierId = $this->getCurrentUserId($request);
         if ($certifierId === null) {
-            return new JsonResponse(
-                ['error' => $this->translationService->translate('api.certifier.unauthorized')],
-                JsonResponse::HTTP_UNAUTHORIZED
-            );
+            return $this->jsonError('api.certifier.unauthorized', JsonResponse::HTTP_UNAUTHORIZED);
         }
 
         $validations = $this->certifierService->getAssignedValidations($certifierId);
 
-        return new JsonResponse([
-            'status'      => 'success',
+        return $this->jsonSuccess([
             'validations' => $validations,
         ]);
     }
@@ -69,30 +64,22 @@ final class CertifierController
      */
     public function approveValidationAction(ServerRequestInterface $request): JsonResponse
     {
-        if (!$this->configurationService->isFeatureEnabled('certifier_validation')) {
-            return new JsonResponse(
-                ['error' => $this->translationService->translate('api.certifier.disabled')],
-                JsonResponse::HTTP_FORBIDDEN
-            );
+        if (($check = $this->requireFeature('certifier_validation')) !== null) {
+            return $check;
         }
 
         $body = (array)$request->getParsedBody();
         $recordId = isset($body['recordId']) ? (int)$body['recordId'] : 0;
 
-        $user = $request->getAttribute('user');
-        $certifierId = is_array($user) && isset($user['uid']) ? (int)$user['uid'] : null;
+        $certifierId = $this->getCurrentUserId($request);
 
         if ($certifierId === null || $recordId <= 0) {
-            return new JsonResponse(
-                ['error' => $this->translationService->translate('api.certifier.invalidParameters')],
-                JsonResponse::HTTP_BAD_REQUEST
-            );
+            return $this->jsonError('api.certifier.invalidParameters', JsonResponse::HTTP_BAD_REQUEST);
         }
 
         $this->certifierService->approveValidation($recordId, $certifierId);
 
-        return new JsonResponse([
-            'status'  => 'success',
+        return $this->jsonSuccess([
             'message' => $this->translationService->translate('api.certifier.approved'),
         ]);
     }
@@ -106,31 +93,23 @@ final class CertifierController
      */
     public function rejectValidationAction(ServerRequestInterface $request): JsonResponse
     {
-        if (!$this->configurationService->isFeatureEnabled('certifier_validation')) {
-            return new JsonResponse(
-                ['error' => $this->translationService->translate('api.certifier.disabled')],
-                JsonResponse::HTTP_FORBIDDEN
-            );
+        if (($check = $this->requireFeature('certifier_validation')) !== null) {
+            return $check;
         }
 
         $body = (array)$request->getParsedBody();
         $recordId = isset($body['recordId']) ? (int)$body['recordId'] : 0;
         $feedback = isset($body['feedback']) ? trim((string)$body['feedback']) : '';
 
-        $user = $request->getAttribute('user');
-        $certifierId = is_array($user) && isset($user['uid']) ? (int)$user['uid'] : null;
+        $certifierId = $this->getCurrentUserId($request);
 
         if ($certifierId === null || $recordId <= 0 || $feedback === '') {
-            return new JsonResponse(
-                ['error' => $this->translationService->translate('api.certifier.invalidParameters')],
-                JsonResponse::HTTP_BAD_REQUEST
-            );
+            return $this->jsonError('api.certifier.invalidParameters', JsonResponse::HTTP_BAD_REQUEST);
         }
 
         $this->certifierService->rejectValidation($recordId, $feedback, $certifierId);
 
-        return new JsonResponse([
-            'status'  => 'success',
+        return $this->jsonSuccess([
             'message' => $this->translationService->translate('api.certifier.rejected'),
         ]);
     }

--- a/equed-lms/Classes/Domain/Service/CertifierServiceInterface.php
+++ b/equed-lms/Classes/Domain/Service/CertifierServiceInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Domain\Service;
+
+interface CertifierServiceInterface
+{
+    /**
+     * Retrieve validations assigned to a certifier.
+     *
+     * @return array<int, mixed>
+     */
+    public function getAssignedValidations(int $certifierId): array;
+
+    /**
+     * Approve the specified validation record.
+     */
+    public function approveValidation(int $recordId, int $certifierId): void;
+
+    /**
+     * Reject the specified validation record with feedback.
+     */
+    public function rejectValidation(int $recordId, string $feedback, int $certifierId): void;
+}
+
+// EOF


### PR DESCRIPTION
## Summary
- make `CertifierController` use `BaseApiController`
- move validation methods to new `CertifierServiceInterface`
- use base controller helpers for feature flags and responses

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f41e456888324b88c5cf91050fb13