### PR TITLE
Implement CourseBundle API refactor

### DIFF
--- a/equed-lms/Classes/Controller/Api/CourseBundleController.php
+++ b/equed-lms/Classes/Controller/Api/CourseBundleController.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace Equed\EquedLms\Controller\Api;
 
 use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Http\JsonResponse;
 use Equed\Core\Service\ConfigurationServiceInterface;
+use Equed\EquedLms\Controller\Api\BaseApiController;
+use Equed\EquedLms\Domain\Service\ApiResponseServiceInterface;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 use Equed\EquedLms\Domain\Service\CourseBundleServiceInterface;
 
@@ -18,46 +19,37 @@ use Equed\EquedLms\Domain\Service\CourseBundleServiceInterface;
  * with fallback chain (EN → DE → FR → ES → SW → EASY).
  * Execution is guarded by the <course_bundle_api> feature toggle.
  */
-final class CourseBundleController
+final class CourseBundleController extends BaseApiController
 {
     public function __construct(
         private readonly CourseBundleServiceInterface    $bundleService,
-        private readonly ConfigurationServiceInterface   $configurationService,
-        private readonly GptTranslationServiceInterface  $translationService,
+        ConfigurationServiceInterface $configurationService,
+        ApiResponseServiceInterface $apiResponseService,
+        GptTranslationServiceInterface $translationService,
     ) {
+        parent::__construct($configurationService, $apiResponseService, $translationService);
     }
 
     /**
      * Returns available course bundles for the authenticated user.
      *
      * @param ServerRequestInterface $request
-     * @return ResponseInterface
+     * @return JsonResponse
      * @throws \Throwable
      */
-    public function listAvailableAction(ServerRequestInterface $request): ResponseInterface
+    public function listAvailableAction(ServerRequestInterface $request): JsonResponse
     {
-        if (! $this->configurationService->isFeatureEnabled('course_bundle_api')) {
-            return new JsonResponse(
-                ['error' => $this->translationService->translate('api.courseBundle.disabled')],
-                JsonResponse::HTTP_FORBIDDEN
-            );
+        if (($check = $this->requireFeature('course_bundle_api')) !== null) {
+            return $check;
         }
-
-        $user = $request->getAttribute('user');
-        $userId = is_array($user) && isset($user['uid']) ? (int)$user['uid'] : null;
+        $userId = $this->getCurrentUserId($request);
         if ($userId === null) {
-            return new JsonResponse(
-                ['error' => $this->translationService->translate('api.courseBundle.unauthorized')],
-                JsonResponse::HTTP_UNAUTHORIZED
-            );
+            return $this->jsonError('api.courseBundle.unauthorized', JsonResponse::HTTP_UNAUTHORIZED);
         }
 
         $bundles = $this->bundleService->getAvailableBundles($userId);
 
-        return new JsonResponse([
-            'status'  => 'success',
-            'bundles' => $bundles,
-        ]);
+        return $this->jsonSuccess(['bundles' => $bundles]);
     }
 }
 // End of file

--- a/equed-lms/Classes/Domain/Service/CourseBundleServiceInterface.php
+++ b/equed-lms/Classes/Domain/Service/CourseBundleServiceInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Domain\Service;
+
+use Equed\EquedLms\Domain\Model\CourseBundle;
+
+/**
+ * Provides course bundle information for frontend users.
+ */
+interface CourseBundleServiceInterface
+{
+    /**
+     * Returns bundles available to the specified user.
+     *
+     * @param int $userId Frontend user UID
+     * @return CourseBundle[]
+     */
+    public function getAvailableBundles(int $userId): array;
+}
+

--- a/equed-lms/Classes/Service/CourseBundleService.php
+++ b/equed-lms/Classes/Service/CourseBundleService.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Service;
+
+use Equed\EquedLms\Domain\Model\CourseBundle;
+use Equed\EquedLms\Domain\Repository\CourseBundleRepository;
+use Equed\EquedLms\Domain\Service\CourseBundleServiceInterface;
+
+/**
+ * Retrieves course bundles for users.
+ */
+final class CourseBundleService implements CourseBundleServiceInterface
+{
+    public function __construct(
+        private readonly CourseBundleRepository $bundleRepository,
+    ) {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getAvailableBundles(int $userId): array
+    {
+        // For now, simply return all active bundles.
+        // Additional filtering logic can be implemented later.
+        return $this->bundleRepository->findAllActive();
+    }
+}
+

--- a/equed-lms/Configuration/Services/Services.yaml
+++ b/equed-lms/Configuration/Services/Services.yaml
@@ -162,3 +162,6 @@ services:
   Equed\EquedLms\Service\QuizManagerInterface:
     class: Equed\EquedLms\Service\QuizManager
 
+  Equed\EquedLms\Domain\Service\CourseBundleServiceInterface:
+    class: Equed\EquedLms\Service\CourseBundleService
+


### PR DESCRIPTION
## Summary
- extend BaseApiController for CourseBundleController
- add CourseBundleService and interface
- wire the service in the container
- use feature check and JSON helpers

## Testing
- `php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f47bc38788324a11c286be9a79961