### PR TITLE
Refactor Feedback API controller

### DIFF
--- a/equed-lms/Classes/Controller/Api/FeedbackController.php
+++ b/equed-lms/Classes/Controller/Api/FeedbackController.php
@@ -7,9 +7,10 @@ namespace Equed\EquedLms\Controller\Api;
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Http\JsonResponse;
 use Equed\Core\Service\ConfigurationServiceInterface;
+use Equed\EquedLms\Domain\Service\ApiResponseServiceInterface;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 use Equed\EquedLms\Domain\Service\FeedbackServiceInterface;
-use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
+use Equed\EquedLms\Controller\Api\BaseApiController;
 
 /**
  * API controller for submitting and checking feedback on course records.
@@ -18,14 +19,15 @@ use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
  * with fallback chain (EN → DE → FR → ES → SW → EASY).
  * Execution is guarded by the <feedback_api> feature toggle.
  */
-final class FeedbackController extends ActionController
+final class FeedbackController extends BaseApiController
 {
     public function __construct(
-        private readonly FeedbackServiceInterface        $feedbackService,
-        private readonly ConfigurationServiceInterface   $configurationService,
-        private readonly GptTranslationServiceInterface  $translationService,
+        private readonly FeedbackServiceInterface $feedbackService,
+        ConfigurationServiceInterface $configurationService,
+        ApiResponseServiceInterface $apiResponseService,
+        GptTranslationServiceInterface $translationService,
     ) {
-        parent::__construct();
+        parent::__construct($configurationService, $apiResponseService, $translationService);
     }
 
     /**
@@ -36,20 +38,13 @@ final class FeedbackController extends ActionController
      */
     public function submitAction(ServerRequestInterface $request): JsonResponse
     {
-        if (! $this->configurationService->isFeatureEnabled('feedback_api')) {
-            return new JsonResponse(
-                ['error' => $this->translationService->translate('api.feedback.disabled')],
-                JsonResponse::HTTP_FORBIDDEN
-            );
+        if (($check = $this->requireFeature('feedback_api')) !== null) {
+            return $check;
         }
 
-        $user = $request->getAttribute('user');
-        $userId = is_array($user) && isset($user['uid']) ? (int)$user['uid'] : null;
+        $userId = $this->getCurrentUserId($request);
         if ($userId === null) {
-            return new JsonResponse(
-                ['error' => $this->translationService->translate('api.feedback.unauthorized')],
-                JsonResponse::HTTP_UNAUTHORIZED
-            );
+            return $this->jsonError('api.feedback.unauthorized', JsonResponse::HTTP_UNAUTHORIZED);
         }
 
         $body = (array)$request->getParsedBody();
@@ -61,10 +56,7 @@ final class FeedbackController extends ActionController
         $ratingLocation = isset($body['ratingLocation']) ? (int)$body['ratingLocation'] : 0;
 
         if ($recordId <= 0 || $feedback === '') {
-            return new JsonResponse(
-                ['error' => $this->translationService->translate('api.feedback.invalidInput')],
-                JsonResponse::HTTP_BAD_REQUEST
-            );
+            return $this->jsonError('api.feedback.invalidInput', JsonResponse::HTTP_BAD_REQUEST);
         }
 
         $this->feedbackService->submitFeedback(
@@ -77,8 +69,7 @@ final class FeedbackController extends ActionController
             ratingLocation: $ratingLocation
         );
 
-        return new JsonResponse([
-            'status'  => 'success',
+        return $this->jsonSuccess([
             'message' => $this->translationService->translate('api.feedback.submitted'),
         ]);
     }
@@ -91,35 +82,24 @@ final class FeedbackController extends ActionController
      */
     public function checkAction(ServerRequestInterface $request): JsonResponse
     {
-        if (! $this->configurationService->isFeatureEnabled('feedback_api')) {
-            return new JsonResponse(
-                ['error' => $this->translationService->translate('api.feedback.disabled')],
-                JsonResponse::HTTP_FORBIDDEN
-            );
+        if (($check = $this->requireFeature('feedback_api')) !== null) {
+            return $check;
         }
 
-        $user = $request->getAttribute('user');
-        $userId = is_array($user) && isset($user['uid']) ? (int)$user['uid'] : null;
+        $userId = $this->getCurrentUserId($request);
         if ($userId === null) {
-            return new JsonResponse(
-                ['error' => $this->translationService->translate('api.feedback.unauthorized')],
-                JsonResponse::HTTP_UNAUTHORIZED
-            );
+            return $this->jsonError('api.feedback.unauthorized', JsonResponse::HTTP_UNAUTHORIZED);
         }
 
         $params = $request->getQueryParams();
         $recordId = isset($params['recordId']) ? (int)$params['recordId'] : 0;
         if ($recordId <= 0) {
-            return new JsonResponse(
-                ['error' => $this->translationService->translate('api.feedback.invalidRecordId')],
-                JsonResponse::HTTP_BAD_REQUEST
-            );
+            return $this->jsonError('api.feedback.invalidRecordId', JsonResponse::HTTP_BAD_REQUEST);
         }
 
         $submitted = $this->feedbackService->isFeedbackSubmitted($userId, $recordId);
 
-        return new JsonResponse([
-            'status'            => 'success',
+        return $this->jsonSuccess([
             'feedbackSubmitted' => $submitted,
         ]);
     }


### PR DESCRIPTION
## Summary
- extend `BaseApiController` in `FeedbackController`
- inject API response service
- use `jsonSuccess`/`jsonError` helpers for feedback API responses

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684fb9e4809883249d4f4d46c93bef0f