### PR TITLE
Implement instructor dashboard API controller

### DIFF
--- a/equed-lms/Classes/Domain/Service/InstructorDashboardServiceInterface.php
+++ b/equed-lms/Classes/Domain/Service/InstructorDashboardServiceInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Domain\Service;
+
+/**
+ * Provides instructor specific dashboard data.
+ */
+interface InstructorDashboardServiceInterface
+{
+    /**
+     * Check whether the given user is an instructor.
+     */
+    public function isInstructor(int $userId): bool;
+
+    /**
+     * Get course instances assigned to the instructor.
+     *
+     * @return array<int, mixed>
+     */
+    public function getInstructorInstances(int $instructorId): array;
+
+    /**
+     * Get participants (user course records) for the instructor.
+     *
+     * @return array<int, mixed>
+     */
+    public function getInstructorParticipants(int $instructorId): array;
+}

--- a/equed-lms/Classes/Service/InstructorDashboardService.php
+++ b/equed-lms/Classes/Service/InstructorDashboardService.php
@@ -6,17 +6,20 @@ namespace Equed\EquedLms\Service;
 
 use Equed\EquedLms\Domain\Repository\CourseInstanceRepositoryInterface;
 use Equed\EquedLms\Domain\Repository\UserCourseRecordRepositoryInterface;
+use Equed\EquedLms\Domain\Repository\UserProfileRepositoryInterface;
+use Equed\EquedLms\Domain\Service\InstructorDashboardServiceInterface;
 use Equed\EquedLms\Domain\Model\FrontendUser;
 use Equed\EquedLms\Dto\InstructorDashboardData;
 
 /**
  * Provides instructor-specific dashboard statistics and metrics.
  */
-final class InstructorDashboardService
+final class InstructorDashboardService implements InstructorDashboardServiceInterface
 {
     public function __construct(
         private readonly CourseInstanceRepositoryInterface $courseInstanceRepository,
-        private readonly UserCourseRecordRepositoryInterface $userCourseRecordRepository
+        private readonly UserCourseRecordRepositoryInterface $userCourseRecordRepository,
+        private readonly UserProfileRepositoryInterface $userProfileRepository,
     ) {
     }
 
@@ -48,5 +51,20 @@ final class InstructorDashboardService
             count($validatedRecords),
             count($openTasks),
         );
+    }
+
+    public function isInstructor(int $userId): bool
+    {
+        return $this->userProfileRepository->findByUserId($userId)?->isInstructor() ?? false;
+    }
+
+    public function getInstructorInstances(int $instructorId): array
+    {
+        return $this->courseInstanceRepository->findByInstructor($instructorId);
+    }
+
+    public function getInstructorParticipants(int $instructorId): array
+    {
+        return $this->userCourseRecordRepository->findByInstructor($instructorId);
     }
 }


### PR DESCRIPTION
## Summary
- add `InstructorDashboardServiceInterface`
- implement `InstructorDashboardService` interface with instructor helper methods
- refactor `InstructorDashboardController` to extend `BaseApiController`
- use `requireFeature()` and `jsonSuccess()` responses

## Testing
- `composer test` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fbd5945d4832481da505ceeed008f