### PR TITLE
Refactor lesson progress API

### DIFF
--- a/equed-lms/Classes/Domain/Service/LessonProgressServiceInterface.php
+++ b/equed-lms/Classes/Domain/Service/LessonProgressServiceInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Domain\Service;
+
+use Equed\EquedLms\Domain\Model\LessonProgress;
+
+interface LessonProgressServiceInterface
+{
+    /**
+     * Retrieve progress entry for given user and lesson.
+     */
+    public function getProgress(int $userId, int $lessonId): ?LessonProgress;
+
+    /**
+     * Update or create progress entry for given user and lesson.
+     */
+    public function setProgress(int $userId, int $lessonId, bool $completed): LessonProgress;
+}

--- a/equed-lms/Configuration/Services/Services.yaml
+++ b/equed-lms/Configuration/Services/Services.yaml
@@ -144,6 +144,9 @@ services:
   Equed\EquedLms\Domain\Service\ExamServiceInterface:
     class: Equed\EquedLms\Service\ExamService
 
+  Equed\EquedLms\Domain\Service\LessonProgressServiceInterface:
+    class: Equed\EquedLms\Service\LessonProgressService
+
   Equed\EquedLms\Service\CourseProgressServiceInterface:
     class: Equed\EquedLms\Service\CourseProgressService
 

--- a/equed-lms/Tests/Unit/Service/LessonProgressServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/LessonProgressServiceTest.php
@@ -8,6 +8,8 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Equed\EquedLms\Service\LessonProgressService;
 use Equed\EquedLms\Domain\Repository\LessonProgressRepositoryInterface;
+use Equed\EquedLms\Domain\Repository\LessonRepositoryInterface;
+use Equed\EquedLms\Domain\Service\ClockInterface;
 use Equed\EquedLms\Domain\Model\LessonProgress;
 use Equed\EquedLms\Domain\Model\Lesson;
 use TYPO3\CMS\Extbase\Domain\Model\FrontendUser;
@@ -19,11 +21,20 @@ class LessonProgressServiceTest extends TestCase
 
     private LessonProgressService $subject;
     private $repo;
+    private $lessonRepo;
+    private $clock;
 
     protected function setUp(): void
     {
         $this->repo = $this->prophesize(LessonProgressRepositoryInterface::class);
-        $this->subject = new LessonProgressService($this->repo->reveal());
+        $this->lessonRepo = $this->prophesize(LessonRepositoryInterface::class);
+        $this->clock = $this->prophesize(ClockInterface::class);
+
+        $this->subject = new LessonProgressService(
+            $this->repo->reveal(),
+            $this->lessonRepo->reveal(),
+            $this->clock->reveal(),
+        );
     }
 
     public function testSetProgressCompletedCreatesNewEntry(): void
@@ -34,9 +45,11 @@ class LessonProgressServiceTest extends TestCase
         $lesson->getUid()->willReturn(2);
 
         $this->repo->findByUserAndLesson(1, 2)->willReturn(null);
+        $this->lessonRepo->findByUid(2)->willReturn($lesson->reveal());
+        $this->clock->now()->willReturn(new \DateTimeImmutable('2024-01-01 00:00:00'));
         $this->repo->updateOrAdd(\Prophecy\Argument::type(LessonProgress::class))->shouldBeCalled();
 
-        $progress = $this->subject->setProgressCompleted($user->reveal(), $lesson->reveal());
+        $progress = $this->subject->setProgress(1, 2, true);
         $this->assertSame(ProgressStatus::Completed, $progress->getStatus());
         $this->assertTrue($progress->isCompleted());
     }


### PR DESCRIPTION
## Summary
- create `LessonProgressServiceInterface`
- implement new interface in `LessonProgressService`
- refactor `LessonProgressController` to extend `BaseApiController`
- wire interface in service container
- update unit test for new service

## Testing
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fc0efa9288324865fa039184fda9e