### PR TITLE
Add SARIF validation in CI

### DIFF
--- a/.github/workflows/ci-matrix.yml
+++ b/.github/workflows/ci-matrix.yml
@@ -40,25 +40,33 @@ jobs:
       - name: Install dependencies
         run: composer install --no-interaction --prefer-dist
         working-directory: ${{ matrix.extension }}
-      - name: Run PHPStan
-        continue-on-error: true
-        shell: bash
-        run: |
-          REPORT_DIR="${{ github.workspace }}/${{ matrix.extension }}/build/reports"
-          mkdir -p "$REPORT_DIR"
-          if [ -f vendor/bin/phpstan ]; then
-            echo "🔍 Running PHPStan..."
-            vendor/bin/phpstan analyse --error-format=sarif > "$REPORT_DIR/phpstan.sarif" || echo "⚠️ PHPStan failed – check baseline"
-          else
-            echo "ℹ️ PHPStan not installed"
-            echo '{}' > "$REPORT_DIR/phpstan.sarif"
-          fi
-        working-directory: ${{ matrix.extension }}
-      - name: Upload PHPStan report
-        if: always()
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: "${{ github.workspace }}/${{ matrix.extension }}/build/reports/phpstan.sarif"
+        - name: Run PHPStan
+          continue-on-error: true
+          shell: bash
+          run: |
+            REPORT_DIR="${{ github.workspace }}/${{ matrix.extension }}/build/reports"
+            mkdir -p "$REPORT_DIR"
+            if [ -f vendor/bin/phpstan ]; then
+              echo "🔍 Running PHPStan..."
+              vendor/bin/phpstan analyse --error-format=sarif > "$REPORT_DIR/phpstan.sarif" || echo "⚠️ PHPStan failed – check baseline"
+            else
+              echo "ℹ️ PHPStan not installed"
+              echo '{}' > "$REPORT_DIR/phpstan.sarif"
+            fi
+          working-directory: ${{ matrix.extension }}
+        - name: Validate SARIF
+          shell: bash
+          run: |
+            SARIF_FILE="${{ github.workspace }}/${{ matrix.extension }}/build/reports/phpstan.sarif"
+            if [ ! -s "$SARIF_FILE" ] || ! jq empty "$SARIF_FILE" >/dev/null 2>&1; then
+              echo "⚠️ SARIF report missing or invalid. Generating minimal report."
+              echo '{"version":"2.1.0","runs":[]}' > "$SARIF_FILE"
+            fi
+        - name: Upload PHPStan report
+          if: always()
+          uses: github/codeql-action/upload-sarif@v3
+          with:
+            sarif_file: "${{ github.workspace }}/${{ matrix.extension }}/build/reports/phpstan.sarif"
       - name: Run PHPUnit
         continue-on-error: true
         run: |


### PR DESCRIPTION
## Summary
- validate generated SARIF file in the matrix workflow

## Testing
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fcad776648324a14290c6b033d100