### PR TITLE
Refactor Service Center API to use BaseApiController

### DIFF
--- a/equed-lms/Classes/Controller/Api/ServiceCenterController.php
+++ b/equed-lms/Classes/Controller/Api/ServiceCenterController.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace Equed\EquedLms\Controller\Api;
 
 use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Http\JsonResponse;
-use TYPO3\CMS\Core\Database\ConnectionPool;
-use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use Equed\Core\Service\ConfigurationServiceInterface;
+use Equed\EquedLms\Domain\Service\ApiResponseServiceInterface;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
+use Equed\EquedLms\Service\ServiceCenterCaseService;
+use Equed\EquedLms\Controller\Api\BaseApiController;
 
 /**
  * API controller for Service Center operations:
@@ -18,44 +18,33 @@ use Equed\EquedLms\Service\GptTranslationServiceInterface;
  * - Respond or close
  * - Trigger reports
  */
-final class ServiceCenterController extends ActionController
+final class ServiceCenterController extends BaseApiController
 {
     public function __construct(
-        private readonly ConnectionPool $connectionPool,
-        private readonly ConfigurationServiceInterface $configurationService,
-        private readonly GptTranslationServiceInterface $translationService,
+        private readonly ServiceCenterCaseService $caseService,
+        ConfigurationServiceInterface $configurationService,
+        ApiResponseServiceInterface $apiResponseService,
+        GptTranslationServiceInterface $translationService,
     ) {
-        parent::__construct();
+        parent::__construct($configurationService, $apiResponseService, $translationService);
     }
 
-    public function listQmsCasesAction(ServerRequestInterface $request): ResponseInterface
+    public function listQmsCasesAction(ServerRequestInterface $request): JsonResponse
     {
-        if (! $this->configurationService->isFeatureEnabled('service_center_api')) {
-            return new JsonResponse([
-                'error' => $this->translationService->translate('api.serviceCenter.disabled')
-            ], 403);
+        if (($check = $this->requireFeature('service_center_api')) !== null) {
+            return $check;
         }
 
         $user = $request->getAttribute('user');
-        $userGroups = is_array($user) ? $user['usergroup'] ?? [] : [];
+        $userGroups = is_array($user) ? ($user['usergroup'] ?? []) : [];
 
         if (!is_array($userGroups) || !in_array('service_center', $userGroups)) {
-            return new JsonResponse([
-                'error' => $this->translationService->translate('api.serviceCenter.unauthorized')
-            ], 401);
+            return $this->jsonError('api.serviceCenter.unauthorized', JsonResponse::HTTP_UNAUTHORIZED);
         }
 
-        $qb = $this->connectionPool->getQueryBuilderForTable('tx_equedlms_domain_model_qms');
-        $cases = $qb
-            ->select('*')
-            ->from('tx_equedlms_domain_model_qms')
-            ->where($qb->expr()->eq('deleted', 0))
-            ->orderBy('submitted_at', 'DESC')
-            ->executeQuery()
-            ->fetchAllAssociative();
+        $cases = $this->caseService->getQmsCases();
 
-        return new JsonResponse([
-            'status' => 'success',
+        return $this->jsonSuccess([
             'cases' => $cases,
         ]);
     }

--- a/equed-lms/Classes/Service/ServiceCenterCaseService.php
+++ b/equed-lms/Classes/Service/ServiceCenterCaseService.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Service;
+
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * Service to retrieve QMS cases for Service Center API operations.
+ */
+final class ServiceCenterCaseService
+{
+    public function __construct(private readonly ConnectionPool $connectionPool)
+    {
+    }
+
+    /**
+     * Fetch all QMS cases ordered by submission date.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function getQmsCases(): array
+    {
+        $qb = $this->connectionPool->getQueryBuilderForTable('tx_equedlms_domain_model_qms');
+
+        return $qb
+            ->select('*')
+            ->from('tx_equedlms_domain_model_qms')
+            ->where($qb->expr()->eq('deleted', 0))
+            ->orderBy('submitted_at', 'DESC')
+            ->executeQuery()
+            ->fetchAllAssociative();
+    }
+}
+
+// EOF


### PR DESCRIPTION
## Summary
- create `ServiceCenterCaseService` for retrieving QMS cases
- refactor `ServiceCenterController` to extend `BaseApiController`
- use feature flag checks and standard JSON responses

## Testing
- `composer install` *(fails: ext-dom missing)*

------
https://chatgpt.com/codex/tasks/task_e_684fcc07d4208324be6330b2b57af72c