### PR TITLE
Fix invalid minimal SARIF generation

### DIFF
--- a/.github/workflows/ci-matrix.yml
+++ b/.github/workflows/ci-matrix.yml
@@ -51,7 +51,7 @@ jobs:
             vendor/bin/phpstan analyse --error-format=sarif > "$REPORT_DIR/phpstan.sarif" || echo "⚠️ PHPStan failed – check baseline"
           else
             echo "ℹ️ PHPStan not installed"
-            echo '{}' > "$REPORT_DIR/phpstan.sarif"
+            echo '{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"phpstan"}},"results":[]}]}' > "$REPORT_DIR/phpstan.sarif"
           fi
         working-directory: ${{ matrix.extension }}
       - name: Validate SARIF
@@ -60,7 +60,7 @@ jobs:
           SARIF_FILE="${{ github.workspace }}/${{ matrix.extension }}/build/reports/phpstan.sarif"
           if [ ! -s "$SARIF_FILE" ] || ! jq empty "$SARIF_FILE" >/dev/null 2>&1; then
             echo "⚠️ SARIF report missing or invalid. Generating minimal report."
-            echo '{"version":"2.1.0","runs":[]}' > "$SARIF_FILE"
+            echo '{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"phpstan"}},"results":[]}]}' > "$SARIF_FILE"
           fi
       - name: Upload PHPStan report
         if: always()

--- a/.github/workflows/phpstan-sarif.yml
+++ b/.github/workflows/phpstan-sarif.yml
@@ -44,12 +44,12 @@ jobs:
             echo "PHPStan completed successfully"
           else
             echo "⚠️ PHPStan completed with issues"
-            echo '{"version":"2.1.0","runs":[]}' > build/reports/phpstan.sarif
+            echo '{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"phpstan"}},"results":[]}]}' > build/reports/phpstan.sarif
           fi
           # Validate generated SARIF and fallback to minimal file if corrupted
           if ! jq empty build/reports/phpstan.sarif >/dev/null 2>&1; then
             echo "⚠️ Invalid SARIF detected – generating minimal report"
-            echo '{"version":"2.1.0","runs":[]}' > build/reports/phpstan.sarif
+            echo '{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"phpstan"}},"results":[]}]}' > build/reports/phpstan.sarif
           fi
 
       - name: Validate SARIF


### PR DESCRIPTION
## Summary
- ensure fallback SARIF files contain a valid run object

## Testing
- `composer --version` *(fails: command not found)*
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fced20e788324b74a01ce5429bfb1