### PR TITLE
Refactor AppUserController to reuse base API logic

### DIFF
--- a/equed-lms/Classes/Controller/Api/AppUserController.php
+++ b/equed-lms/Classes/Controller/Api/AppUserController.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Equed\EquedLms\Controller\Api;
 
 use Equed\Core\Service\ConfigurationServiceInterface;
+use Equed\EquedLms\Controller\Api\BaseApiController;
+use Equed\EquedLms\Domain\Service\ApiResponseServiceInterface;
+use Equed\EquedLms\Domain\Service\UserAccountServiceInterface;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
-use Equed\EquedLms\Domain\Repository\UserRepositoryInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Http\JsonResponse;
 
@@ -17,13 +19,15 @@ use TYPO3\CMS\Core\Http\JsonResponse;
  * with fallback chain (EN → DE → FR → ES → SW → EASY).
  * Execution is guarded by the <user_profile_api> feature toggle.
  */
-final class AppUserController
+final class AppUserController extends BaseApiController
 {
     public function __construct(
-        private readonly UserRepositoryInterface         $userRepository,
-        private readonly ConfigurationServiceInterface   $configurationService,
-        private readonly GptTranslationServiceInterface  $translationService,
+        private readonly UserAccountServiceInterface     $accountService,
+        ConfigurationServiceInterface                    $configurationService,
+        ApiResponseServiceInterface                      $apiResponseService,
+        GptTranslationServiceInterface                   $translationService,
     ) {
+        parent::__construct($configurationService, $apiResponseService, $translationService);
     }
 
     /**
@@ -35,43 +39,28 @@ final class AppUserController
      */
     public function profileAction(ServerRequestInterface $request): JsonResponse
     {
-        if (!$this->configurationService->isFeatureEnabled('user_profile_api')) {
-            return new JsonResponse(
-                ['error' => $this->translationService->translate('api.userProfile.disabled')],
-                JsonResponse::HTTP_FORBIDDEN
-            );
+        if (($check = $this->requireFeature('user_profile_api')) !== null) {
+            return $check;
         }
 
-        $userContext = $request->getAttribute('user');
-        if (!is_array($userContext) || !isset($userContext['uid'])) {
-            return new JsonResponse(
-                ['error' => $this->translationService->translate('api.userProfile.unauthorized')],
-                JsonResponse::HTTP_UNAUTHORIZED
-            );
+        $userId = $this->getCurrentUserId($request);
+        if ($userId === null) {
+            return $this->jsonError('api.userProfile.unauthorized', JsonResponse::HTTP_UNAUTHORIZED);
         }
 
-        $userId = (int)$userContext['uid'];
-        $user = $this->userRepository->findByUid($userId);
-
-        if ($user === null) {
-            return new JsonResponse(
-                ['error' => $this->translationService->translate('api.userProfile.notFound')],
-                JsonResponse::HTTP_NOT_FOUND
-            );
+        $profile = $this->accountService->getProfile($userId);
+        if ($profile === null) {
+            return $this->jsonError('api.userProfile.notFound', JsonResponse::HTTP_NOT_FOUND);
         }
 
-        $roles = array_map(
-            static fn ($group) => $group->getUid(),
-            $user->getUserGroups()->toArray()
-        );
+        $roles = array_filter(array_map('intval', explode(',', (string)($profile['usergroup'] ?? ''))));
 
-        return new JsonResponse([
-            'status'           => 'success',
-            'userId'           => $user->getUid(),
-            'name'             => $user->getName(),
-            'email'            => $user->getEmail(),
+        return $this->jsonSuccess([
+            'userId'           => (int)$profile['uid'],
+            'name'             => (string)($profile['name'] ?? ''),
+            'email'            => (string)($profile['email'] ?? ''),
             'roles'            => $roles,
-            'profileCompleted' => !empty($user->getName()),
+            'profileCompleted' => trim((string)($profile['name'] ?? '')) !== '',
         ]);
     }
 }

--- a/equed-lms/Configuration/Services/Services.yaml
+++ b/equed-lms/Configuration/Services/Services.yaml
@@ -117,6 +117,9 @@ services:
   Equed\EquedLms\Factory\UserCourseRecordFactoryInterface:
     class: Equed\EquedLms\Factory\DefaultUserCourseRecordFactory
 
+  Equed\EquedLms\Domain\Service\UserAccountServiceInterface:
+    class: Equed\EquedLms\Service\UserAccountService
+
   Equed\EquedLms\Domain\Service\JwtServiceInterface:
     class: Equed\EquedLms\Service\JwtService
     arguments:
@@ -152,6 +155,9 @@ services:
 
   Equed\EquedLms\Service\ProgressServiceInterface:
     class: Equed\EquedLms\Service\ProgressService
+
+  Equed\EquedLms\Domain\Service\UserCourseRecordCrudServiceInterface:
+    class: Equed\EquedLms\Service\UserCourseRecordCrudService
 
   Equed\EquedLms\Service\MailServiceInterface:
     class: Equed\EquedLms\Service\Email\MailService


### PR DESCRIPTION
## Summary
- refactor `AppUserController` to extend `BaseApiController`
- use `UserAccountService` to fetch profile data
- map new service implementations in DI configuration

## Testing
- `composer --version` *(fails: command not found)*
- `./vendor/bin/phpunit --version` *(fails: no such file)*

------
https://chatgpt.com/codex/tasks/task_e_684fd905e7e08324b8fe38ff7ba3f68b