### PR TITLE
Refactor progress API controllers

### DIFF
--- a/equed-lms/Classes/Controller/Api/UserProgressController.php
+++ b/equed-lms/Classes/Controller/Api/UserProgressController.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Equed\EquedLms\Controller\Api;
 
-use Equed\EquedLms\Service\ProgressService;
-use Equed\EquedLms\Trait\ErrorResponseTrait;
+use Equed\EquedLms\Service\ProgressServiceInterface;
+use Equed\EquedLms\Controller\Api\BaseApiController;
+use Equed\EquedLms\Domain\Service\ApiResponseServiceInterface;
+use Equed\Core\Service\ConfigurationServiceInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Http\JsonResponse;
-use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 
 /**
@@ -17,66 +17,57 @@ use Equed\EquedLms\Service\GptTranslationServiceInterface;
  *
  * Provides endpoints to retrieve a user's progress across courses and lessons.
  */
-final class UserProgressController extends ActionController
+final class UserProgressController extends BaseApiController
 {
-    use ErrorResponseTrait;
 
     public function __construct(
-        private readonly ProgressService $progressService,
-        private readonly GptTranslationServiceInterface $translationService,
-
+        private readonly ProgressServiceInterface $progressService,
+        ConfigurationServiceInterface $configurationService,
+        ApiResponseServiceInterface $apiResponseService,
+        GptTranslationServiceInterface $translationService,
     ) {
+        parent::__construct($configurationService, $apiResponseService, $translationService);
     }
 
     /**
      * GET /api/user/progress
-     *
-     * @return ResponseInterface
      */
-    public function showAction(ServerRequestInterface $request): ResponseInterface
+    public function showAction(ServerRequestInterface $request): JsonResponse
     {
-        $userContext = $request->getAttribute('user');
-        $user = is_array($userContext) ? $userContext : null;
-        if ($user === null) {
-            return new JsonResponse([
-                'error' => $this->translationService->translate('api.userProgress.unauthorized'),
-            ], 401);
+        if (($check = $this->requireFeature('progress_api')) !== null) {
+            return $check;
         }
 
-        $userId = (int)$user['uid'];
-        $data = $this->progressService->getOverallProgressForUser($userId);
+        $userId = $this->getCurrentUserId($request);
+        if ($userId === null) {
+            return $this->jsonError('api.userProgress.unauthorized', JsonResponse::HTTP_UNAUTHORIZED);
+        }
 
-        return new JsonResponse([
-            'status'   => 'success',
-            'progress' => $data,
-        ]);
+        $data = $this->progressService->getProgressDataForUser($userId);
+
+        return $this->jsonSuccess(['progress' => $data]);
     }
 
     /**
      * GET /api/user/progress/course?recordId={id}
-     *
-     * @return ResponseInterface
      */
-    public function courseAction(ServerRequestInterface $request): ResponseInterface
+    public function courseAction(ServerRequestInterface $request): JsonResponse
     {
-        $userContext = $request->getAttribute('user');
-        $user = is_array($userContext) ? $userContext : null;
+        if (($check = $this->requireFeature('progress_api')) !== null) {
+            return $check;
+        }
+
+        $userId = $this->getCurrentUserId($request);
         $params = $request->getQueryParams();
         $recordId = (int)($params['recordId'] ?? 0);
 
-        if ($user === null || $recordId <= 0) {
-            return new JsonResponse([
-                'error' => $this->translationService->translate('api.userProgress.invalidParameters'),
-            ], 400);
+        if ($userId === null || $recordId <= 0) {
+            return $this->jsonError('api.userProgress.invalidParameters', JsonResponse::HTTP_BAD_REQUEST);
         }
 
-        $userId = (int)$user['uid'];
         $data = $this->progressService->getCourseProgress($userId, $recordId);
 
-        return new JsonResponse([
-            'status'   => 'success',
-            'progress' => $data,
-        ]);
+        return $this->jsonSuccess(['progress' => $data]);
     }
 }
 // EOF

--- a/equed-lms/Classes/Service/ProgressService.php
+++ b/equed-lms/Classes/Service/ProgressService.php
@@ -82,6 +82,16 @@ final class ProgressService implements ProgressServiceInterface
         ];
     }
 
+    public function getCourseProgress(int $userId, int $recordId): float
+    {
+        $record = $this->userCourseRecordRepository->findByUid($recordId);
+        if ($record === null || (int)$record->getUser()->getUid() !== $userId) {
+            return 0.0;
+        }
+
+        return (float)$record->getProgressPercent();
+    }
+
     public function cleanupAbandonedCourseProgress(int $days): void
     {
         $cutoff = $this->clock->now()

--- a/equed-lms/Classes/Service/ProgressServiceInterface.php
+++ b/equed-lms/Classes/Service/ProgressServiceInterface.php
@@ -15,6 +15,11 @@ interface ProgressServiceInterface
     public function getProgressDataForUser(int|\Equed\EquedLms\Domain\Model\FrontendUser $user): array;
 
     /**
+     * Returns progress percent for a specific user course record.
+     */
+    public function getCourseProgress(int $userId, int $recordId): float;
+
+    /**
      * Cleanup progress records older than the given threshold.
      */
     public function cleanupAbandonedCourseProgress(int $days): void;


### PR DESCRIPTION
## Summary
- extend `ProgressController` and `UserProgressController` from `BaseApiController`
- delegate course record progress lookup to `ProgressService`
- expose `getCourseProgress()` in `ProgressService`

## Testing
- `php` lint *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fdb41c4a483248a5c346bc348375c