### PR TITLE
Add enums for status fields

### DIFF
--- a/equed-lms/Classes/Domain/Model/CourseFeedback.php
+++ b/equed-lms/Classes/Domain/Model/CourseFeedback.php
@@ -13,6 +13,7 @@ use TYPO3\CMS\Extbase\Domain\Model\FileReference;
 use Equed\EquedLms\Domain\Model\FrontendUser;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 use Equed\EquedLms\Enum\LanguageCode;
+use Equed\EquedLms\Enum\FeedbackStatus;
 
 final class CourseFeedback extends AbstractEntity
 {
@@ -60,7 +61,7 @@ final class CourseFeedback extends AbstractEntity
     protected ?string $comment = null;
 
     /** Submission status */
-    protected string $status = 'submitted';
+    protected FeedbackStatus $status = FeedbackStatus::Submitted;
 
     /** Creation timestamp */
     protected DateTimeImmutable $createdAt;
@@ -201,13 +202,17 @@ final class CourseFeedback extends AbstractEntity
         $this->comment = $comment;
     }
 
-    public function getStatus(): string
+    public function getStatus(): FeedbackStatus
     {
         return $this->status;
     }
 
-    public function setStatus(string $status): void
+    public function setStatus(FeedbackStatus|string $status): void
     {
+        if (is_string($status)) {
+            $status = FeedbackStatus::from($status);
+        }
+
         $this->status = $status;
     }
 

--- a/equed-lms/Classes/Domain/Model/ExternalSystemSync.php
+++ b/equed-lms/Classes/Domain/Model/ExternalSystemSync.php
@@ -8,6 +8,7 @@ use Equed\EquedLms\Enum\LanguageCode;
 use DateTimeImmutable;
 use Ramsey\Uuid\Uuid;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
+use Equed\EquedLms\Enum\ExternalSyncStatus;
 
 /**
  * ExternalSystemSync
@@ -37,10 +38,8 @@ final class ExternalSystemSync extends AbstractEntity
 
     /**
      * Current status (pending | success | failed)
-     *
-     * @var string
      */
-    protected string $status = 'pending';
+    protected ExternalSyncStatus $status = ExternalSyncStatus::Pending;
 
     /**
      * Optional JSON payload
@@ -124,13 +123,17 @@ final class ExternalSystemSync extends AbstractEntity
         $this->action = $action;
     }
 
-    public function getStatus(): string
+    public function getStatus(): ExternalSyncStatus
     {
         return $this->status;
     }
 
-    public function setStatus(string $status): void
+    public function setStatus(ExternalSyncStatus|string $status): void
     {
+        if (is_string($status)) {
+            $status = ExternalSyncStatus::from($status);
+        }
+
         $this->status = $status;
     }
 

--- a/equed-lms/Classes/Domain/Model/GlossarySuggestion.php
+++ b/equed-lms/Classes/Domain/Model/GlossarySuggestion.php
@@ -10,6 +10,7 @@ use TYPO3\CMS\Extbase\Annotation\ORM\ManyToOne;
 use TYPO3\CMS\Extbase\Annotation\ORM\Lazy;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 use Equed\EquedLms\Enum\LanguageCode;
+use Equed\EquedLms\Enum\GlossarySuggestionStatus;
 
 /**
  * GlossarySuggestion
@@ -67,10 +68,8 @@ final class GlossarySuggestion extends AbstractEntity
 
     /**
      * Current review status (pending | approved | rejected)
-     *
-     * @var string
      */
-    protected string $status = 'pending'; // pending | approved | rejected
+    protected GlossarySuggestionStatus $status = GlossarySuggestionStatus::Pending;
 
     /**
      * Optional admin review comment
@@ -173,13 +172,17 @@ final class GlossarySuggestion extends AbstractEntity
         $this->language = $language;
     }
 
-    public function getStatus(): string
+    public function getStatus(): GlossarySuggestionStatus
     {
         return $this->status;
     }
 
-    public function setStatus(string $status): void
+    public function setStatus(GlossarySuggestionStatus|string $status): void
     {
+        if (is_string($status)) {
+            $status = GlossarySuggestionStatus::from($status);
+        }
+
         $this->status = $status;
     }
 

--- a/equed-lms/Classes/Domain/Model/IncidentReport.php
+++ b/equed-lms/Classes/Domain/Model/IncidentReport.php
@@ -9,6 +9,7 @@ use Ramsey\Uuid\Uuid;
 use TYPO3\CMS\Extbase\Annotation\ORM\Lazy;
 use TYPO3\CMS\Extbase\Annotation\ORM\ManyToOne;
 use Equed\EquedLms\Domain\Model\FrontendUser;
+use Equed\EquedLms\Enum\IncidentReportStatus;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 
 /**
@@ -48,7 +49,7 @@ final class IncidentReport extends AbstractEntity
     protected string $severityKey = '';
 
     /** Current processing status */
-    protected string $status = 'open';
+    protected IncidentReportStatus $status = IncidentReportStatus::Open;
 
     /** Optional comment by instructor */
     protected ?string $commentInstructor = null;
@@ -167,13 +168,17 @@ final class IncidentReport extends AbstractEntity
         $this->severityKey = $key;
     }
 
-    public function getStatus(): string
+    public function getStatus(): IncidentReportStatus
     {
         return $this->status;
     }
 
-    public function setStatus(string $status): void
+    public function setStatus(IncidentReportStatus|string $status): void
     {
+        if (is_string($status)) {
+            $status = IncidentReportStatus::from($status);
+        }
+
         $this->status = $status;
     }
 

--- a/equed-lms/Classes/Domain/Model/InstructorFeedback.php
+++ b/equed-lms/Classes/Domain/Model/InstructorFeedback.php
@@ -12,6 +12,7 @@ use TYPO3\CMS\Extbase\Annotation\ORM\ManyToOne;
 use Equed\EquedLms\Domain\Model\FrontendUser;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 use Equed\EquedLms\Enum\LanguageCode;
+use Equed\EquedLms\Enum\FeedbackStatus;
 
 /**
  * InstructorFeedback
@@ -38,7 +39,7 @@ final class InstructorFeedback extends AbstractEntity
 
     protected int $rating = 0;
 
-    protected string $status = 'submitted';
+    protected FeedbackStatus $status = FeedbackStatus::Submitted;
 
     protected bool $visibleToParticipant = false;
 
@@ -121,13 +122,17 @@ final class InstructorFeedback extends AbstractEntity
         $this->rating = $rating;
     }
 
-    public function getStatus(): string
+    public function getStatus(): FeedbackStatus
     {
         return $this->status;
     }
 
-    public function setStatus(string $status): void
+    public function setStatus(FeedbackStatus|string $status): void
     {
+        if (is_string($status)) {
+            $status = FeedbackStatus::from($status);
+        }
+
         $this->status = $status;
     }
 

--- a/equed-lms/Classes/Domain/Model/TrainingCenter.php
+++ b/equed-lms/Classes/Domain/Model/TrainingCenter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Equed\EquedLms\Domain\Model;
 use Equed\EquedLms\Enum\LanguageCode;
+use Equed\EquedLms\Enum\TrainingCenterStatus;
 
 use DateTimeImmutable;
 use Equed\Core\Service\ClockInterface;
@@ -54,7 +55,7 @@ final class TrainingCenter extends AbstractEntity
 
     protected ?DateTimeImmutable $certifiedUntil = null;
 
-    protected string $status = 'active';
+    protected TrainingCenterStatus $status = TrainingCenterStatus::Active;
 
     protected string $country = '';
 
@@ -286,13 +287,17 @@ final class TrainingCenter extends AbstractEntity
         $this->certifiedUntil = $certifiedUntil;
     }
 
-    public function getStatus(): string
+    public function getStatus(): TrainingCenterStatus
     {
         return $this->status;
     }
 
-    public function setStatus(string $status): void
+    public function setStatus(TrainingCenterStatus|string $status): void
     {
+        if (is_string($status)) {
+            $status = TrainingCenterStatus::from($status);
+        }
+
         $this->status = $status;
     }
 

--- a/equed-lms/Classes/Domain/Model/TrainingCenterFeedback.php
+++ b/equed-lms/Classes/Domain/Model/TrainingCenterFeedback.php
@@ -12,6 +12,7 @@ use TYPO3\CMS\Extbase\Annotation\ORM\Lazy;
 use TYPO3\CMS\Extbase\Annotation\ORM\ManyToOne;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 use Equed\EquedLms\Enum\LanguageCode;
+use Equed\EquedLms\Enum\FeedbackStatus;
 
 /**
  * Domain model for training center feedback.
@@ -44,7 +45,7 @@ final class TrainingCenterFeedback extends AbstractEntity
 
     protected ?string $comment = null;
 
-    protected string $status = 'submitted';
+    protected FeedbackStatus $status = FeedbackStatus::Submitted;
 
     protected bool $visibleToCenter = true;
 
@@ -188,7 +189,7 @@ final class TrainingCenterFeedback extends AbstractEntity
     /**
      * Gets the feedback status.
      */
-    public function getStatus(): string
+    public function getStatus(): FeedbackStatus
     {
         return $this->status;
     }
@@ -196,8 +197,12 @@ final class TrainingCenterFeedback extends AbstractEntity
     /**
      * Sets the feedback status.
      */
-    public function setStatus(string $status): void
+    public function setStatus(FeedbackStatus|string $status): void
     {
+        if (is_string($status)) {
+            $status = FeedbackStatus::from($status);
+        }
+
         $this->status = $status;
     }
 

--- a/equed-lms/Classes/Domain/Model/UserProfile.php
+++ b/equed-lms/Classes/Domain/Model/UserProfile.php
@@ -13,6 +13,7 @@ use TYPO3\CMS\Extbase\Annotation\ORM\OneToOne;
 use Equed\EquedLms\Domain\Model\FrontendUser;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 use Equed\EquedLms\Enum\BadgeLevel;
+use Equed\EquedLms\Enum\UserProfileStatus;
 use Equed\EquedLms\Enum\LanguageCode;
 
 /**
@@ -45,7 +46,7 @@ final class UserProfile extends AbstractEntity
     protected BadgeLevel $badgeLevel = BadgeLevel::None;
     protected ?string $badgeLevelKey = null;
 
-    protected string $profileStatus = 'active';
+    protected UserProfileStatus $profileStatus = UserProfileStatus::Active;
     protected ?string $profileStatusKey = null;
 
     protected bool $isVisibleInSearch = false;
@@ -198,13 +199,17 @@ final class UserProfile extends AbstractEntity
         $this->badgeLevelKey = $badgeLevelKey;
     }
 
-    public function getProfileStatus(): string
+    public function getProfileStatus(): UserProfileStatus
     {
         return $this->profileStatus;
     }
 
-    public function setProfileStatus(string $status): void
+    public function setProfileStatus(UserProfileStatus|string $status): void
     {
+        if (is_string($status)) {
+            $status = UserProfileStatus::from($status);
+        }
+
         $this->profileStatus = $status;
     }
 

--- a/equed-lms/Classes/Domain/Model/UserProgressRecord.php
+++ b/equed-lms/Classes/Domain/Model/UserProgressRecord.php
@@ -11,6 +11,7 @@ use TYPO3\CMS\Extbase\Annotation\Inject;
 use TYPO3\CMS\Extbase\Annotation\ORM\Lazy;
 use TYPO3\CMS\Extbase\Annotation\ORM\ManyToOne;
 use Equed\EquedLms\Domain\Model\FrontendUser;
+use Equed\EquedLms\Enum\ProgressRecordStatus;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 
 /**
@@ -34,7 +35,7 @@ final class UserProgressRecord extends AbstractEntity
     #[Lazy]
     protected ?Lesson $lesson = null;
 
-    protected string $status = 'incomplete';
+    protected ProgressRecordStatus $status = ProgressRecordStatus::Incomplete;
     protected ?string $statusKey = null;
 
     protected string $lessonPage = '';
@@ -122,18 +123,20 @@ final class UserProgressRecord extends AbstractEntity
     /**
      * Gets the progress status.
      */
-    public function getStatus(): string
+    public function getStatus(): ProgressRecordStatus
     {
         return $this->status;
     }
 
     /**
      * Sets the progress status.
-     *
-     * @param string $status
      */
-    public function setStatus(string $status): void
+    public function setStatus(ProgressRecordStatus|string $status): void
     {
+        if (is_string($status)) {
+            $status = ProgressRecordStatus::from($status);
+        }
+
         $this->status = $status;
     }
 

--- a/equed-lms/Classes/Domain/Repository/IncidentReportRepository.php
+++ b/equed-lms/Classes/Domain/Repository/IncidentReportRepository.php
@@ -8,6 +8,7 @@ use Equed\EquedLms\Domain\Model\IncidentReport;
 use Equed\EquedLms\Domain\Model\CourseInstance;
 use Equed\EquedLms\Domain\Model\FrontendUser;
 use TYPO3\CMS\Extbase\Persistence\Repository;
+use Equed\EquedLms\Enum\IncidentReportStatus;
 
 /**
  * Repository for IncidentReport entities.
@@ -72,11 +73,14 @@ final class IncidentReportRepository extends Repository
      * @param string $status
      * @return IncidentReport[]
      */
-    public function findByStatus(string $status): array
+    public function findByStatus(IncidentReportStatus|string $status): array
     {
+        if (is_string($status)) {
+            $status = IncidentReportStatus::from($status);
+        }
         $query = $this->createQuery();
         $query->matching(
-            $query->equals('status', $status)
+            $query->equals('status', $status->value)
         );
 
         return $query->execute()->toArray();

--- a/equed-lms/Classes/Domain/Repository/UserProfileRepository.php
+++ b/equed-lms/Classes/Domain/Repository/UserProfileRepository.php
@@ -10,6 +10,7 @@ use Equed\EquedLms\Enum\BadgeLevel;
 use TYPO3\CMS\Extbase\Persistence\QueryInterface;
 use TYPO3\CMS\Extbase\Persistence\Repository;
 use Equed\EquedLms\Domain\Repository\UserProfileRepositoryInterface;
+use Equed\EquedLms\Enum\UserProfileStatus;
 
 /**
  * Repository for UserProfile entities.
@@ -104,13 +105,17 @@ final class UserProfileRepository extends Repository implements UserProfileRepos
      * @param string $status Enum: active, paused, review
      * @return UserProfile[]
      */
-    public function findByStatus(string $status): array
+    public function findByStatus(UserProfileStatus|string $status): array
     {
+        if (is_string($status)) {
+            $status = UserProfileStatus::from($status);
+        }
+
         $query = $this->createQuery();
 
         return $query
             ->matching(
-                $query->equals('profileStatus', $status)
+                $query->equals('profileStatus', $status->value)
             )
             ->execute()
             ->toArray();

--- a/equed-lms/Classes/Domain/Repository/UserProgressRecordRepository.php
+++ b/equed-lms/Classes/Domain/Repository/UserProgressRecordRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Equed\EquedLms\Domain\Repository;
 
 use Equed\EquedLms\Domain\Model\UserProgressRecord;
+use Equed\EquedLms\Enum\ProgressRecordStatus;
 use TYPO3\CMS\Extbase\Persistence\QueryInterface;
 use TYPO3\CMS\Extbase\Persistence\Repository;
 
@@ -62,11 +63,14 @@ final class UserProgressRecordRepository extends Repository
      * @param string $status One of 'incomplete', 'complete', 'passed'
      * @return UserProgressRecord[]
      */
-    public function findByStatus(string $status): array
+    public function findByStatus(ProgressRecordStatus|string $status): array
     {
+        if (is_string($status)) {
+            $status = ProgressRecordStatus::from($status);
+        }
         $query = $this->createQuery();
         $query->matching(
-            $query->equals('status', $status)
+            $query->equals('status', $status->value)
         );
 
         return $query->execute()->toArray();

--- a/equed-lms/Classes/Enum/ExternalSyncStatus.php
+++ b/equed-lms/Classes/Enum/ExternalSyncStatus.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Enum;
+
+/**
+ * Status values for external system sync operations.
+ */
+enum ExternalSyncStatus: string
+{
+    case Ok = 'ok';
+    case Failed = 'failed';
+    case Pending = 'pending';
+}
+

--- a/equed-lms/Classes/Enum/FeedbackStatus.php
+++ b/equed-lms/Classes/Enum/FeedbackStatus.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Enum;
+
+/**
+ * Status values for feedback entities.
+ */
+enum FeedbackStatus: string
+{
+    case Submitted = 'submitted';
+    case Reviewed = 'reviewed';
+}
+

--- a/equed-lms/Classes/Enum/GlossarySuggestionStatus.php
+++ b/equed-lms/Classes/Enum/GlossarySuggestionStatus.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Enum;
+
+/**
+ * Status values for glossary suggestions.
+ */
+enum GlossarySuggestionStatus: string
+{
+    case Pending = 'pending';
+    case Approved = 'approved';
+    case Rejected = 'rejected';
+}
+

--- a/equed-lms/Classes/Enum/IncidentReportStatus.php
+++ b/equed-lms/Classes/Enum/IncidentReportStatus.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Enum;
+
+/**
+ * Status values for incident reports.
+ */
+enum IncidentReportStatus: string
+{
+    case Open = 'open';
+    case Review = 'review';
+    case Closed = 'closed';
+    case Escalated = 'escalated';
+}
+

--- a/equed-lms/Classes/Enum/ProgressRecordStatus.php
+++ b/equed-lms/Classes/Enum/ProgressRecordStatus.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Enum;
+
+/**
+ * Status values for user progress records.
+ */
+enum ProgressRecordStatus: string
+{
+    case Incomplete = 'incomplete';
+    case Complete = 'complete';
+    case Passed = 'passed';
+}
+

--- a/equed-lms/Classes/Enum/TrainingCenterStatus.php
+++ b/equed-lms/Classes/Enum/TrainingCenterStatus.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Enum;
+
+/**
+ * Status values for training centers.
+ */
+enum TrainingCenterStatus: string
+{
+    case Active = 'active';
+    case Inactive = 'inactive';
+    case Suspended = 'suspended';
+}
+

--- a/equed-lms/Classes/Enum/UserProfileStatus.php
+++ b/equed-lms/Classes/Enum/UserProfileStatus.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Enum;
+
+/**
+ * Possible status values for user profiles.
+ */
+enum UserProfileStatus: string
+{
+    case Active = 'active';
+    case Paused = 'paused';
+    case Review = 'review';
+}
+

--- a/equed-lms/Configuration/TCA/tx_equedlms_domain_model_coursefeedback.php
+++ b/equed-lms/Configuration/TCA/tx_equedlms_domain_model_coursefeedback.php
@@ -113,8 +113,12 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_coursefeedback.status',
             'config' => [
-                'type' => 'input',
-                'eval' => 'trim'
+                'type' => 'select',
+                'items' => [
+                    ['Submitted', 'submitted'],
+                    ['Reviewed', 'reviewed'],
+                ],
+                'default' => 'submitted',
             ]
         ],
         'created_at' => [

--- a/equed-lms/Configuration/TCA/tx_equedlms_domain_model_externalsystemsync.php
+++ b/equed-lms/Configuration/TCA/tx_equedlms_domain_model_externalsystemsync.php
@@ -62,8 +62,13 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_externalsystemsync.sync_status',
             'config' => [
-                'type' => 'input',
-                'eval' => 'int'
+                'type' => 'select',
+                'items' => [
+                    ['OK', 'ok'],
+                    ['Failed', 'failed'],
+                    ['Pending', 'pending'],
+                ],
+                'default' => 'pending',
             ]
         ],
         'is_active' => [

--- a/equed-lms/Configuration/TCA/tx_equedlms_domain_model_glossarysuggestion.php
+++ b/equed-lms/Configuration/TCA/tx_equedlms_domain_model_glossarysuggestion.php
@@ -84,8 +84,13 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_glossarysuggestion.status',
             'config' => [
-                'type' => 'input',
-                'eval' => 'int'
+                'type' => 'select',
+                'items' => [
+                    ['Pending', 'pending'],
+                    ['Approved', 'approved'],
+                    ['Rejected', 'rejected'],
+                ],
+                'default' => 'pending',
             ]
         ],
         'admin_comment' => [

--- a/equed-lms/Configuration/TCA/tx_equedlms_domain_model_incidentreport.php
+++ b/equed-lms/Configuration/TCA/tx_equedlms_domain_model_incidentreport.php
@@ -79,8 +79,14 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_incidentreport.status',
             'config' => [
-                'type' => 'input',
-                'eval' => 'trim'
+                'type' => 'select',
+                'items' => [
+                    ['Open', 'open'],
+                    ['Under Review', 'review'],
+                    ['Closed', 'closed'],
+                    ['Escalated', 'escalated'],
+                ],
+                'default' => 'open',
             ]
         ],
         'comment_instructor' => [

--- a/equed-lms/Configuration/TCA/tx_equedlms_domain_model_trainingcenter.php
+++ b/equed-lms/Configuration/TCA/tx_equedlms_domain_model_trainingcenter.php
@@ -93,8 +93,13 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_trainingcenter.status',
             'config' => [
-                'type' => 'input',
-                'eval' => 'trim'
+                'type' => 'select',
+                'items' => [
+                    ['Aktiv', 'active'],
+                    ['Inaktiv', 'inactive'],
+                    ['Gesperrt', 'suspended'],
+                ],
+                'default' => 'active',
             ]
         ],
         'allowed_programs' => [

--- a/equed-lms/Configuration/TCA/tx_equedlms_domain_model_trainingcenterfeedback.php
+++ b/equed-lms/Configuration/TCA/tx_equedlms_domain_model_trainingcenterfeedback.php
@@ -115,8 +115,12 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_trainingcenterfeedback.status',
             'config' => [
-                'type' => 'input',
-                'eval' => 'trim'
+                'type' => 'select',
+                'items' => [
+                    ['Submitted', 'submitted'],
+                    ['Reviewed', 'reviewed'],
+                ],
+                'default' => 'submitted',
             ]
         ],
         'is_internal' => [

--- a/equed-lms/Configuration/TCA/tx_equedlms_domain_model_userprofile.php
+++ b/equed-lms/Configuration/TCA/tx_equedlms_domain_model_userprofile.php
@@ -95,8 +95,13 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_userprofile.profile_status',
             'config' => [
-                'type' => 'input',
-                'eval' => 'trim'
+                'type' => 'select',
+                'items' => [
+                    ['Active', 'active'],
+                    ['Paused', 'paused'],
+                    ['Under Review', 'review'],
+                ],
+                'default' => 'active',
             ]
         ],
         'profile_status_key' => [


### PR DESCRIPTION
## Summary
- introduce enums for feedback, sync, incident and other statuses
- type-hint status fields in models and repositories
- update TCA configs to use select lists

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fe36eec888324947973dac2743cd4