### PR TITLE
Fix PHP comment style and initializeObject

### DIFF
--- a/equed-core/Tests/Unit/Domain/Repository/AuditLogRepositoryTest.php
+++ b/equed-core/Tests/Unit/Domain/Repository/AuditLogRepositoryTest.php
@@ -44,6 +44,6 @@ class AuditLogRepositoryTest extends UnitTestCase
     }
 }
 
-/*
+/**
  * Mocked Services: AuthorizationService
  */

--- a/equed-core/Tests/Unit/Domain/Repository/CountryRepositoryTest.php
+++ b/equed-core/Tests/Unit/Domain/Repository/CountryRepositoryTest.php
@@ -33,6 +33,6 @@ class CountryRepositoryTest extends UnitTestCase
     }
 }
 
-/*
+/**
  * Mocked Services: AuthorizationService
  */

--- a/equed-core/Tests/Unit/Domain/Repository/DocumentUploadRepositoryTest.php
+++ b/equed-core/Tests/Unit/Domain/Repository/DocumentUploadRepositoryTest.php
@@ -56,6 +56,6 @@ class DocumentUploadRepositoryTest extends UnitTestCase
     }
 }
 
-/*
+/**
  * Mocked Services: AuthorizationService
  */

--- a/equed-core/Tests/Unit/Domain/Repository/ExternalCertificateRepositoryTest.php
+++ b/equed-core/Tests/Unit/Domain/Repository/ExternalCertificateRepositoryTest.php
@@ -33,6 +33,6 @@ class ExternalCertificateRepositoryTest extends UnitTestCase
     }
 }
 
-/*
+/**
  * Mocked Services: AuthorizationService
  */

--- a/equed-core/Tests/Unit/Domain/Repository/SearchLogRepositoryTest.php
+++ b/equed-core/Tests/Unit/Domain/Repository/SearchLogRepositoryTest.php
@@ -33,6 +33,6 @@ class SearchLogRepositoryTest extends UnitTestCase
     }
 }
 
-/*
+/**
  * Mocked Services: AuthorizationService
  */

--- a/equed-core/Tests/Unit/Domain/Repository/UserMetaRepositoryTest.php
+++ b/equed-core/Tests/Unit/Domain/Repository/UserMetaRepositoryTest.php
@@ -33,6 +33,6 @@ class UserMetaRepositoryTest extends UnitTestCase
     }
 }
 
-/*
+/**
  * Mocked Services: AuthorizationService
  */

--- a/equed-lms/Classes/Domain/Model/SearchLog.php
+++ b/equed-lms/Classes/Domain/Model/SearchLog.php
@@ -1,11 +1,14 @@
 <?php
 
 declare(strict_types=1);
+
 namespace Equed\EquedLms\Domain\Model;
-use Equed\EquedLms\Enum\LanguageCode;
+
 use DateTimeImmutable;
 use Ramsey\Uuid\Uuid;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
+use Equed\EquedLms\Enum\LanguageCode;
+
 /**
  * SearchLog
  *
@@ -14,49 +17,124 @@ use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 final class SearchLog extends AbstractEntity
 {
     protected string $uuid;
+
     /** Hash of the user identifier */
     protected string $userHash = '';
+
     /** Hash of the searched term */
     protected string $termHash = '';
+
     /** Language used for the search */
     protected LanguageCode $lang = LanguageCode::EN;
+
     protected DateTimeImmutable $createdAt;
     protected DateTimeImmutable $updatedAt;
+
     public function __construct()
     {
         $now = new DateTimeImmutable();
-        $this->uuid = \Ramsey\Uuid\Uuid::uuid4()->toString();
+        $this->uuid = Uuid::uuid4()->toString();
         $this->createdAt = $now;
         $this->updatedAt = $now;
     }
+
     public function initializeObject(): void
-        if (empty($this->uuid)) {
+    {
+        if ($this->uuid === '') {
             $this->uuid = Uuid::uuid4()->toString();
         }
         if (!isset($this->createdAt)) {
+            $now = new DateTimeImmutable();
             $this->createdAt = $now;
-        if (!isset($this->updatedAt)) {
             $this->updatedAt = $now;
+        }
+    }
+
+    /**
+     * Get the UUID.
+     */
     public function getUuid(): string
+    {
         return $this->uuid;
+    }
+
+    /**
+     * Hash of the user identifier.
+     */
     public function getUserHash(): string
+    {
         return $this->userHash;
+    }
+
+    /**
+     * Set the user identifier.
+     */
     public function setUserIdentifier(string|int $userIdentifier): void
+    {
         $this->userHash = hash('sha256', (string) $userIdentifier);
+    }
+
+    /**
+     * Hash of the searched term.
+     */
     public function getTermHash(): string
+    {
         return $this->termHash;
+    }
+
+    /**
+     * Set the search term.
+     */
     public function setSearchTerm(string $term): void
+    {
         $this->termHash = hash('sha256', $term);
+    }
+
+    /**
+     * Language used for the search.
+     */
     public function getLang(): LanguageCode
+    {
         return $this->lang;
+    }
+
+    /**
+     * Set language used for the search.
+     */
     public function setLang(LanguageCode $lang): void
+    {
         $this->lang = $lang;
+    }
+
+    /**
+     * Get the creation timestamp.
+     */
     public function getCreatedAt(): DateTimeImmutable
+    {
         return $this->createdAt;
+    }
+
+    /**
+     * Set the creation timestamp.
+     */
     public function setCreatedAt(DateTimeImmutable $createdAt): void
+    {
         $this->createdAt = $createdAt;
+    }
+
+    /**
+     * Get the last update timestamp.
+     */
     public function getUpdatedAt(): DateTimeImmutable
+    {
         return $this->updatedAt;
+    }
+
+    /**
+     * Set the last update timestamp.
+     */
     public function setUpdatedAt(DateTimeImmutable $updatedAt): void
+    {
         $this->updatedAt = $updatedAt;
+    }
 }


### PR DESCRIPTION
## Summary
- convert repository test comments to `/** ... */`
- reformat SearchLog and close `initializeObject()` properly
- add PHPDoc for SearchLog getters and setters

## Testing
- `git diff --cached --name-only`

------
https://chatgpt.com/codex/tasks/task_e_684ff49b56b4832494700be396f44f4b