### PR TITLE
Add translation key fields to models and DTOs

### DIFF
--- a/equed-lms/Classes/Application/Assembler/CourseDtoAssembler.php
+++ b/equed-lms/Classes/Application/Assembler/CourseDtoAssembler.php
@@ -14,7 +14,9 @@ final class CourseDtoAssembler
         return new CourseDto(
             (int)$course->getUid(),
             $course->getTitle(),
+            $course->getTitleKey(),
             $course->getDescription(),
+            $course->getDescriptionKey(),
             $course->getStartDate()?->format(DATE_ATOM),
             $course->getLocation()
         );

--- a/equed-lms/Classes/Application/Assembler/LessonDtoAssembler.php
+++ b/equed-lms/Classes/Application/Assembler/LessonDtoAssembler.php
@@ -25,6 +25,7 @@ final class LessonDtoAssembler
             static fn (LessonContentPage $p): array => [
                 'type' => $p->getPageType(),
                 'value' => $p->getContent(),
+                'titleKey' => $p->getTitleKey(),
             ],
             $lesson->getPages()->toArray()
         );
@@ -32,6 +33,7 @@ final class LessonDtoAssembler
         return new LessonDto(
             (int)$lesson->getUid(),
             $lesson->getTitle(),
+            $lesson->getTitleKey(),
             $lesson->getUpdatedAt()?->format(DATE_ATOM),
             $lesson->getModule()?->getCourseProgram()?->getUid(),
             $assets,

--- a/equed-lms/Classes/Application/Dto/CourseDto.php
+++ b/equed-lms/Classes/Application/Dto/CourseDto.php
@@ -12,7 +12,9 @@ final class CourseDto implements \JsonSerializable
     public function __construct(
         private readonly int $id,
         private readonly string $title,
+        private readonly ?string $titleKey,
         private readonly ?string $description,
+        private readonly ?string $descriptionKey,
         private readonly ?string $startDate,
         private readonly string $location
     ) {
@@ -28,9 +30,19 @@ final class CourseDto implements \JsonSerializable
         return $this->title;
     }
 
+    public function getTitleKey(): ?string
+    {
+        return $this->titleKey;
+    }
+
     public function getDescription(): ?string
     {
         return $this->description;
+    }
+
+    public function getDescriptionKey(): ?string
+    {
+        return $this->descriptionKey;
     }
 
     public function getStartDate(): ?string
@@ -48,7 +60,9 @@ final class CourseDto implements \JsonSerializable
         return [
             'id' => $this->id,
             'title' => $this->title,
+            'titleKey' => $this->titleKey,
             'description' => $this->description,
+            'descriptionKey' => $this->descriptionKey,
             'startDate' => $this->startDate,
             'location' => $this->location,
         ];

--- a/equed-lms/Classes/Application/Dto/LessonDto.php
+++ b/equed-lms/Classes/Application/Dto/LessonDto.php
@@ -16,6 +16,7 @@ final class LessonDto implements \JsonSerializable
     public function __construct(
         private readonly int $id,
         private readonly string $title,
+        private readonly ?string $titleKey,
         private readonly ?string $updatedAt,
         private readonly ?int $courseId,
         private readonly array $assets,
@@ -31,6 +32,11 @@ final class LessonDto implements \JsonSerializable
     public function getTitle(): string
     {
         return $this->title;
+    }
+
+    public function getTitleKey(): ?string
+    {
+        return $this->titleKey;
     }
 
     public function getUpdatedAt(): ?string
@@ -60,6 +66,7 @@ final class LessonDto implements \JsonSerializable
         return [
             'id' => $this->id,
             'title' => $this->title,
+            'titleKey' => $this->titleKey,
             'updatedAt' => $this->updatedAt,
             'courseId' => $this->courseId,
             'assets' => $this->assets,

--- a/equed-lms/Classes/Domain/Model/Course.php
+++ b/equed-lms/Classes/Domain/Model/Course.php
@@ -23,7 +23,11 @@ final class Course extends AbstractEntity
 
     protected string $title = '';
 
+    protected ?string $titleKey = null;
+
     protected string $description = '';
+
+    protected ?string $descriptionKey = null;
 
     #[Extbase\ORM\ManyToOne]
     #[Extbase\ORM\Lazy]
@@ -53,6 +57,16 @@ final class Course extends AbstractEntity
         $this->title = $title;
     }
 
+    public function getTitleKey(): ?string
+    {
+        return $this->titleKey;
+    }
+
+    public function setTitleKey(?string $titleKey): void
+    {
+        $this->titleKey = $titleKey;
+    }
+
     public function getDescription(): string
     {
         return $this->description;
@@ -61,6 +75,16 @@ final class Course extends AbstractEntity
     public function setDescription(string $description): void
     {
         $this->description = $description;
+    }
+
+    public function getDescriptionKey(): ?string
+    {
+        return $this->descriptionKey;
+    }
+
+    public function setDescriptionKey(?string $descriptionKey): void
+    {
+        $this->descriptionKey = $descriptionKey;
     }
 
     public function getCourseProgram(): ?CourseProgram

--- a/equed-lms/Classes/Domain/Model/Lesson.php
+++ b/equed-lms/Classes/Domain/Model/Lesson.php
@@ -27,6 +27,8 @@ final class Lesson extends AbstractEntity
 
     protected ?string $introduction = null;
 
+    protected ?string $introductionKey = null;
+
     protected int $expectedDuration = 0;
 
     protected string $category = '';
@@ -103,6 +105,16 @@ final class Lesson extends AbstractEntity
     public function setIntroduction(?string $introduction): void
     {
         $this->introduction = $introduction;
+    }
+
+    public function getIntroductionKey(): ?string
+    {
+        return $this->introductionKey;
+    }
+
+    public function setIntroductionKey(?string $introductionKey): void
+    {
+        $this->introductionKey = $introductionKey;
     }
 
     public function getExpectedDuration(): int

--- a/equed-lms/Classes/Domain/Model/LessonContentPage.php
+++ b/equed-lms/Classes/Domain/Model/LessonContentPage.php
@@ -24,6 +24,8 @@ final class LessonContentPage extends AbstractEntity
 
     protected string $title = '';
 
+    protected ?string $titleKey = null;
+
     protected string $content = '';
 
     protected int $sorting = 0;
@@ -84,6 +86,16 @@ final class LessonContentPage extends AbstractEntity
     public function setTitle(string $title): void
     {
         $this->title = $title;
+    }
+
+    public function getTitleKey(): ?string
+    {
+        return $this->titleKey;
+    }
+
+    public function setTitleKey(?string $titleKey): void
+    {
+        $this->titleKey = $titleKey;
     }
 
     /**

--- a/equed-lms/Classes/Service/LessonService.php
+++ b/equed-lms/Classes/Service/LessonService.php
@@ -48,6 +48,7 @@ final class LessonService implements LessonServiceInterface
         $data = [
             'id' => $lesson->getUid(),
             'title' => $lesson->getTitle(),
+            'titleKey' => $lesson->getTitleKey(),
             'updatedAt' => $lesson->getLastModified()?->format('c'),
             'courseId' => $lesson->getCourse()?->getUid(),
             'assets' => array_map(
@@ -61,6 +62,7 @@ final class LessonService implements LessonServiceInterface
                 fn (Page $page): array => [
                     'type' => $page->getType(),
                     'value' => $page->getContent(),
+                    'titleKey' => $page->getTitleKey(),
                 ],
                 $lesson->getPages()->toArray()
             ),

--- a/equed-lms/Documentation/PersistedProperties.md
+++ b/equed-lms/Documentation/PersistedProperties.md
@@ -388,6 +388,7 @@
 - title
 - titleKey
 - introduction
+- introductionKey
 - expectedDuration
 - category
 - pages
@@ -427,6 +428,7 @@
 - uuid
 - lesson
 - title
+- titleKey
 - content
 - sorting
 - media


### PR DESCRIPTION
## Summary
- add `titleKey` and `introductionKey` fields to Lesson
- add `titleKey` field to LessonContentPage
- add `titleKey` and `descriptionKey` to Course
- expose translation keys in LessonService and DTO assemblers
- document new fields in PersistedProperties

## Testing
- `php -l Classes/Domain/Model/Lesson.php`
- `php -l Classes/Domain/Model/LessonContentPage.php`
- `php -l Classes/Domain/Model/Course.php`
- `php -l Classes/Application/Dto/CourseDto.php`
- `php -l Classes/Application/Dto/LessonDto.php`
- `php -l Classes/Application/Assembler/CourseDtoAssembler.php`
- `php -l Classes/Application/Assembler/LessonDtoAssembler.php`
- `php -l Classes/Service/LessonService.php`


------
https://chatgpt.com/codex/tasks/task_e_685007b5ad208324a1cedd5d5a11d213