### PR TITLE
Add accessibility fields to lessons

### DIFF
--- a/equed-lms/Classes/Application/Assembler/LessonDtoAssembler.php
+++ b/equed-lms/Classes/Application/Assembler/LessonDtoAssembler.php
@@ -26,6 +26,9 @@ final class LessonDtoAssembler
                 'type' => $p->getPageType(),
                 'value' => $p->getContent(),
                 'titleKey' => $p->getTitleKey(),
+                'accessibilityNotes' => $p->getAccessibilityNotes(),
+                'mediaAltText' => $p->getMediaAltText(),
+                'transcript' => $p->getTranscript(),
             ],
             $lesson->getPages()->toArray()
         );
@@ -38,6 +41,9 @@ final class LessonDtoAssembler
             $lesson->getModule()?->getCourseProgram()?->getUid(),
             $assets,
             $content,
+            $lesson->getAccessibilityNotes(),
+            $lesson->getMediaAltText(),
+            $lesson->getTranscript(),
         );
     }
 }

--- a/equed-lms/Classes/Application/Dto/LessonDto.php
+++ b/equed-lms/Classes/Application/Dto/LessonDto.php
@@ -21,6 +21,9 @@ final class LessonDto implements \JsonSerializable
         private readonly ?int $courseId,
         private readonly array $assets,
         private readonly array $content,
+        private readonly ?string $accessibilityNotes,
+        private readonly ?string $mediaAltText,
+        private readonly ?string $transcript,
     ) {
     }
 
@@ -49,6 +52,21 @@ final class LessonDto implements \JsonSerializable
         return $this->courseId;
     }
 
+    public function getAccessibilityNotes(): ?string
+    {
+        return $this->accessibilityNotes;
+    }
+
+    public function getMediaAltText(): ?string
+    {
+        return $this->mediaAltText;
+    }
+
+    public function getTranscript(): ?string
+    {
+        return $this->transcript;
+    }
+
     /** @return array<int,array<string,mixed>> */
     public function getAssets(): array
     {
@@ -71,6 +89,9 @@ final class LessonDto implements \JsonSerializable
             'courseId' => $this->courseId,
             'assets' => $this->assets,
             'content' => $this->content,
+            'accessibilityNotes' => $this->accessibilityNotes,
+            'mediaAltText' => $this->mediaAltText,
+            'transcript' => $this->transcript,
         ];
     }
 }

--- a/equed-lms/Classes/Domain/Model/Lesson.php
+++ b/equed-lms/Classes/Domain/Model/Lesson.php
@@ -56,6 +56,12 @@ final class Lesson extends AbstractEntity
     #[Extbase\ORM\OneToMany(mappedBy: 'lesson', cascade: ['remove'])]
     protected ObjectStorage $materials;
 
+    protected ?string $accessibilityNotes = null;
+
+    protected ?string $mediaAltText = null;
+
+    protected ?string $transcript = null;
+
     protected DateTimeImmutable $createdAt;
 
     protected DateTimeImmutable $updatedAt;
@@ -221,6 +227,36 @@ final class Lesson extends AbstractEntity
         if ($this->materials->contains($material)) {
             $this->materials->detach($material);
         }
+    }
+
+    public function getAccessibilityNotes(): ?string
+    {
+        return $this->accessibilityNotes;
+    }
+
+    public function setAccessibilityNotes(?string $accessibilityNotes): void
+    {
+        $this->accessibilityNotes = $accessibilityNotes;
+    }
+
+    public function getMediaAltText(): ?string
+    {
+        return $this->mediaAltText;
+    }
+
+    public function setMediaAltText(?string $mediaAltText): void
+    {
+        $this->mediaAltText = $mediaAltText;
+    }
+
+    public function getTranscript(): ?string
+    {
+        return $this->transcript;
+    }
+
+    public function setTranscript(?string $transcript): void
+    {
+        $this->transcript = $transcript;
     }
 
     public function getCreatedAt(): DateTimeImmutable

--- a/equed-lms/Classes/Domain/Model/LessonContentPage.php
+++ b/equed-lms/Classes/Domain/Model/LessonContentPage.php
@@ -36,6 +36,12 @@ final class LessonContentPage extends AbstractEntity
 
     protected string $pageType = 'text'; // e.g. text, video, quiz
 
+    protected ?string $accessibilityNotes = null;
+
+    protected ?string $mediaAltText = null;
+
+    protected ?string $transcript = null;
+
     protected DateTimeImmutable $createdAt;
 
     protected DateTimeImmutable $updatedAt;
@@ -160,6 +166,36 @@ final class LessonContentPage extends AbstractEntity
     public function setPageType(string $pageType): void
     {
         $this->pageType = $pageType;
+    }
+
+    public function getAccessibilityNotes(): ?string
+    {
+        return $this->accessibilityNotes;
+    }
+
+    public function setAccessibilityNotes(?string $accessibilityNotes): void
+    {
+        $this->accessibilityNotes = $accessibilityNotes;
+    }
+
+    public function getMediaAltText(): ?string
+    {
+        return $this->mediaAltText;
+    }
+
+    public function setMediaAltText(?string $mediaAltText): void
+    {
+        $this->mediaAltText = $mediaAltText;
+    }
+
+    public function getTranscript(): ?string
+    {
+        return $this->transcript;
+    }
+
+    public function setTranscript(?string $transcript): void
+    {
+        $this->transcript = $transcript;
     }
 
     /**

--- a/equed-lms/Documentation/PersistedProperties.md
+++ b/equed-lms/Documentation/PersistedProperties.md
@@ -394,6 +394,9 @@
 - pages
 - quiz
 - materials
+- accessibilityNotes
+- mediaAltText
+- transcript
 - createdAt
 - updatedAt
 
@@ -432,6 +435,9 @@
 - content
 - sorting
 - media
+- accessibilityNotes
+- mediaAltText
+- transcript
 - pageType
 - createdAt
 - updatedAt

--- a/equed-lms/Migrations/Version20250801018000.php
+++ b/equed-lms/Migrations/Version20250801018000.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250801018000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add accessibility notes, media alt text and transcript columns';
+    }
+
+    public function up(Schema $schema): void
+    {
+        if ($schema->hasTable('tx_equedlms_domain_model_lesson')) {
+            $table = $schema->getTable('tx_equedlms_domain_model_lesson');
+            if (!$table->hasColumn('accessibility_notes')) {
+                $table->addColumn('accessibility_notes', 'text', ['notnull' => false]);
+            }
+            if (!$table->hasColumn('media_alt_text')) {
+                $table->addColumn('media_alt_text', 'string', ['notnull' => false]);
+            }
+            if (!$table->hasColumn('transcript')) {
+                $table->addColumn('transcript', 'text', ['notnull' => false]);
+            }
+        }
+        if ($schema->hasTable('tx_equedlms_domain_model_lessoncontentpage')) {
+            $table = $schema->getTable('tx_equedlms_domain_model_lessoncontentpage');
+            if (!$table->hasColumn('accessibility_notes')) {
+                $table->addColumn('accessibility_notes', 'text', ['notnull' => false]);
+            }
+            if (!$table->hasColumn('media_alt_text')) {
+                $table->addColumn('media_alt_text', 'string', ['notnull' => false]);
+            }
+            if (!$table->hasColumn('transcript')) {
+                $table->addColumn('transcript', 'text', ['notnull' => false]);
+            }
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        if ($schema->hasTable('tx_equedlms_domain_model_lesson')) {
+            $table = $schema->getTable('tx_equedlms_domain_model_lesson');
+            foreach (['accessibility_notes', 'media_alt_text', 'transcript'] as $col) {
+                if ($table->hasColumn($col)) {
+                    $table->dropColumn($col);
+                }
+            }
+        }
+        if ($schema->hasTable('tx_equedlms_domain_model_lessoncontentpage')) {
+            $table = $schema->getTable('tx_equedlms_domain_model_lessoncontentpage');
+            foreach (['accessibility_notes', 'media_alt_text', 'transcript'] as $col) {
+                if ($table->hasColumn($col)) {
+                    $table->dropColumn($col);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extend `Lesson` and `LessonContentPage` entities with accessibility fields
- expose new fields in `LessonDto` and assembler
- document new persisted properties
- add migration for new columns

## Testing
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68500a5eb03c8324bb531e5d9f2582d8