### PR TITLE
Add DTOs for lesson progress and submission reviews

### DIFF
--- a/equed-lms/Classes/Application/Assembler/LessonProgressDtoAssembler.php
+++ b/equed-lms/Classes/Application/Assembler/LessonProgressDtoAssembler.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Application\Assembler;
+
+use Equed\EquedLms\Application\Dto\LessonProgressDto;
+use Equed\EquedLms\Domain\Model\LessonProgress;
+
+final class LessonProgressDtoAssembler
+{
+    public static function fromEntity(LessonProgress $progress): LessonProgressDto
+    {
+        return new LessonProgressDto(
+            $progress->getUuid(),
+            $progress->getUserCourseRecord()?->getUser()?->getUid() ?? $progress->getFeUser() ?: null,
+            $progress->getLesson()->getUid(),
+            $progress->getProgress(),
+            $progress->getStatus()->value,
+            $progress->isCompleted(),
+            $progress->getCompletedAt()?->format(DATE_ATOM),
+            $progress->getUpdatedAt()->format(DATE_ATOM),
+        );
+    }
+}

--- a/equed-lms/Classes/Application/Assembler/SubmissionReviewDtoAssembler.php
+++ b/equed-lms/Classes/Application/Assembler/SubmissionReviewDtoAssembler.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Application\Assembler;
+
+use Equed\EquedLms\Application\Dto\SubmissionReviewDto;
+use Equed\EquedLms\Domain\Model\SubmissionReview;
+use Equed\EquedLms\Domain\Model\UserSubmission;
+
+final class SubmissionReviewDtoAssembler
+{
+    public static function fromEntity(SubmissionReview $review): SubmissionReviewDto
+    {
+        return new SubmissionReviewDto(
+            $review->getUuid(),
+            $review->getSubmission()?->getUid(),
+            $review->getReviewedBy()?->getUid(),
+            $review->getStatus(),
+            $review->getComment(),
+            $review->getEvaluationDocument()?->getPublicUrl(),
+            $review->isVisibleForUser(),
+            $review->isGeneratedByGpt(),
+            $review->getLang(),
+            $review->getCreatedAt()->format(DATE_ATOM),
+            $review->getUpdatedAt()->format(DATE_ATOM),
+        );
+    }
+
+    public static function fromSubmission(UserSubmission $submission): SubmissionReviewDto
+    {
+        return new SubmissionReviewDto(
+            $submission->getUuid(),
+            $submission->getUid(),
+            null,
+            $submission->getStatus()->value,
+            $submission->getInstructorComment(),
+            $submission->getInstructorFeedbackFile()?->getPublicUrl(),
+            true,
+            false,
+            'en',
+            $submission->getCreatedAt()->format(DATE_ATOM),
+            $submission->getUpdatedAt()->format(DATE_ATOM),
+        );
+    }
+}

--- a/equed-lms/Classes/Application/Dto/LessonProgressDto.php
+++ b/equed-lms/Classes/Application/Dto/LessonProgressDto.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Application\Dto;
+
+/**
+ * DTO representing progress information for a lesson.
+ */
+final class LessonProgressDto implements \JsonSerializable
+{
+    public function __construct(
+        private readonly string $uuid,
+        private readonly ?int $userId,
+        private readonly int $lessonId,
+        private readonly int $progress,
+        private readonly string $status,
+        private readonly bool $completed,
+        private readonly ?string $completedAt,
+        private readonly string $updatedAt,
+    ) {
+    }
+
+    public function getUuid(): string
+    {
+        return $this->uuid;
+    }
+
+    public function getUserId(): ?int
+    {
+        return $this->userId;
+    }
+
+    public function getLessonId(): int
+    {
+        return $this->lessonId;
+    }
+
+    public function getProgress(): int
+    {
+        return $this->progress;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function isCompleted(): bool
+    {
+        return $this->completed;
+    }
+
+    public function getCompletedAt(): ?string
+    {
+        return $this->completedAt;
+    }
+
+    public function getUpdatedAt(): string
+    {
+        return $this->updatedAt;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'uuid' => $this->uuid,
+            'userId' => $this->userId,
+            'lessonId' => $this->lessonId,
+            'progress' => $this->progress,
+            'status' => $this->status,
+            'completed' => $this->completed,
+            'completedAt' => $this->completedAt,
+            'updatedAt' => $this->updatedAt,
+        ];
+    }
+}

--- a/equed-lms/Classes/Application/Dto/SubmissionReviewDto.php
+++ b/equed-lms/Classes/Application/Dto/SubmissionReviewDto.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Application\Dto;
+
+/**
+ * DTO representing a review of a user submission.
+ */
+final class SubmissionReviewDto implements \JsonSerializable
+{
+    public function __construct(
+        private readonly string $uuid,
+        private readonly ?int $submissionId,
+        private readonly ?int $reviewedBy,
+        private readonly string $status,
+        private readonly ?string $comment,
+        private readonly ?string $evaluationDocumentUrl,
+        private readonly bool $visibleForUser,
+        private readonly bool $generatedByGpt,
+        private readonly string $lang,
+        private readonly string $createdAt,
+        private readonly string $updatedAt,
+    ) {
+    }
+
+    public function getUuid(): string
+    {
+        return $this->uuid;
+    }
+
+    public function getSubmissionId(): ?int
+    {
+        return $this->submissionId;
+    }
+
+    public function getReviewedBy(): ?int
+    {
+        return $this->reviewedBy;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function getComment(): ?string
+    {
+        return $this->comment;
+    }
+
+    public function getEvaluationDocumentUrl(): ?string
+    {
+        return $this->evaluationDocumentUrl;
+    }
+
+    public function isVisibleForUser(): bool
+    {
+        return $this->visibleForUser;
+    }
+
+    public function isGeneratedByGpt(): bool
+    {
+        return $this->generatedByGpt;
+    }
+
+    public function getLang(): string
+    {
+        return $this->lang;
+    }
+
+    public function getCreatedAt(): string
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): string
+    {
+        return $this->updatedAt;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'uuid' => $this->uuid,
+            'submissionId' => $this->submissionId,
+            'reviewedBy' => $this->reviewedBy,
+            'status' => $this->status,
+            'comment' => $this->comment,
+            'evaluationDocumentUrl' => $this->evaluationDocumentUrl,
+            'visibleForUser' => $this->visibleForUser,
+            'generatedByGpt' => $this->generatedByGpt,
+            'lang' => $this->lang,
+            'createdAt' => $this->createdAt,
+            'updatedAt' => $this->updatedAt,
+        ];
+    }
+}

--- a/equed-lms/Classes/Controller/Api/LessonProgressController.php
+++ b/equed-lms/Classes/Controller/Api/LessonProgressController.php
@@ -11,6 +11,7 @@ use Equed\EquedLms\Service\GptTranslationServiceInterface;
 use Equed\EquedLms\Domain\Service\ApiResponseServiceInterface;
 use Equed\EquedLms\Domain\Service\LessonProgressServiceInterface;
 use Equed\EquedLms\Controller\Api\BaseApiController;
+use Equed\EquedLms\Application\Assembler\LessonProgressDtoAssembler;
 
 /**
  * API controller for lesson progress: get and set progress for lessons.
@@ -54,8 +55,9 @@ final class LessonProgressController extends BaseApiController
         }
 
         $progress = $this->lessonProgressService->getProgress($userId, $lessonId);
+        $dto = $progress !== null ? LessonProgressDtoAssembler::fromEntity($progress) : null;
 
-        return $this->jsonSuccess(['progress' => $progress]);
+        return $this->jsonSuccess(['progress' => $dto]);
     }
 
     /**

--- a/equed-lms/Classes/EventListener/ProgressUpdateListener.php
+++ b/equed-lms/Classes/EventListener/ProgressUpdateListener.php
@@ -7,6 +7,7 @@ namespace Equed\EquedLms\EventListener;
 use Equed\EquedLms\Event\Progress\LessonProgressUpdatedEvent;
 use Equed\EquedLms\Event\Progress\UserCourseProgressUpdatedEvent;
 use Equed\EquedLms\Service\LogService;
+use Equed\EquedLms\Application\Assembler\LessonProgressDtoAssembler;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use TYPO3\CMS\Core\SingletonInterface;
 
@@ -30,10 +31,9 @@ final class ProgressUpdateListener implements EventSubscriberInterface, Singleto
     public function onLessonProgressUpdated(LessonProgressUpdatedEvent $event): void
     {
         $progress = $event->getLessonProgress();
+        $dto = LessonProgressDtoAssembler::fromEntity($progress);
         $this->logService->logInfo('Lesson progress updated', [
-            'lesson'   => $progress->getLesson()->getUid(),
-            'user'     => $progress->getUserCourseRecord()?->getUser()?->getUid(),
-            'progress' => $progress->getProgress(),
+            'progress' => $dto->jsonSerialize(),
         ]);
     }
 

--- a/equed-lms/Classes/EventListener/SubmissionNotificationListener.php
+++ b/equed-lms/Classes/EventListener/SubmissionNotificationListener.php
@@ -8,6 +8,7 @@ use Equed\EquedLms\Event\Submission\SubmissionUploadedEvent;
 use Equed\EquedLms\Event\Submission\SubmissionReviewedEvent;
 use Equed\EquedLms\Service\NotificationService;
 use Equed\EquedLms\Service\LogService;
+use Equed\EquedLms\Application\Assembler\SubmissionReviewDtoAssembler;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use TYPO3\CMS\Core\SingletonInterface;
 
@@ -79,6 +80,8 @@ final class SubmissionNotificationListener implements EventSubscriberInterface, 
     {
         $submission = $event->getSubmission();
         $user = $submission->getUserCourseRecord()?->getUser();
+        $dto = SubmissionReviewDtoAssembler::fromSubmission($submission);
+
         if ($user !== null) {
             $this->notificationService->notify(
                 $user,
@@ -90,8 +93,7 @@ final class SubmissionNotificationListener implements EventSubscriberInterface, 
         $this->logService->logInfo(
             'Submission reviewed',
             [
-                'submission' => $submission->getUid(),
-                'user'       => $user?->getUid(),
+                'submissionReview' => $dto->jsonSerialize(),
             ]
         );
     }


### PR DESCRIPTION
## Summary
- add `LessonProgressDto` and `SubmissionReviewDto`
- create assemblers for the new DTOs
- use `LessonProgressDto` in `LessonProgressController` and progress listener
- log submission reviews via `SubmissionReviewDto`

## Testing
- `composer` and `phpunit` unavailable in container

------
https://chatgpt.com/codex/tasks/task_e_68500bcfcc008324b515a24e7cff7c77