### PR TITLE
Use repository interfaces in LMS services

### DIFF
--- a/equed-lms/Classes/Middleware/CourseAccessMiddleware.php
+++ b/equed-lms/Classes/Middleware/CourseAccessMiddleware.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Equed\EquedLms\Middleware;
 
-use Equed\EquedLms\Domain\Repository\CourseAccessMapRepository;
+use Equed\EquedLms\Domain\Repository\CourseAccessMapRepositoryInterface;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 use Equed\EquedLms\Helper\LanguageHelper;
 use Psr\Http\Message\ResponseInterface;
@@ -19,7 +19,7 @@ use Laminas\Diactoros\Response\JsonResponse;
 final class CourseAccessMiddleware implements MiddlewareInterface
 {
     public function __construct(
-        private readonly CourseAccessMapRepository $accessMapRepository,
+        private readonly CourseAccessMapRepositoryInterface $accessMapRepository,
         private readonly GptTranslationServiceInterface $translationService
     ) {
     }

--- a/equed-lms/Classes/Service/CourseBundleService.php
+++ b/equed-lms/Classes/Service/CourseBundleService.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Equed\EquedLms\Service;
 
 use Equed\EquedLms\Domain\Model\CourseBundle;
-use Equed\EquedLms\Domain\Repository\CourseBundleRepository;
+use Equed\EquedLms\Domain\Repository\CourseBundleRepositoryInterface;
 use Equed\EquedLms\Domain\Service\CourseBundleServiceInterface;
 
 /**
@@ -14,7 +14,7 @@ use Equed\EquedLms\Domain\Service\CourseBundleServiceInterface;
 final class CourseBundleService implements CourseBundleServiceInterface
 {
     public function __construct(
-        private readonly CourseBundleRepository $bundleRepository,
+        private readonly CourseBundleRepositoryInterface $bundleRepository,
     ) {
     }
 

--- a/equed-lms/Classes/Service/CourseOverviewService.php
+++ b/equed-lms/Classes/Service/CourseOverviewService.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Equed\EquedLms\Service;
 
 use DateTimeImmutable;
-use Equed\EquedLms\Domain\Repository\CourseProgramRepository;
+use Equed\EquedLms\Domain\Repository\CourseProgramRepositoryInterface;
 use Equed\EquedLms\Domain\Repository\CourseInstanceRepositoryInterface;
 use Equed\EquedLms\Domain\Repository\UserCourseRecordRepositoryInterface;
 use Equed\EquedLms\Domain\Service\CourseOverviewServiceInterface;
@@ -16,7 +16,7 @@ use Equed\EquedLms\Domain\Service\CourseOverviewServiceInterface;
 final class CourseOverviewService implements CourseOverviewServiceInterface
 {
     public function __construct(
-        private readonly CourseProgramRepository $programRepository,
+        private readonly CourseProgramRepositoryInterface $programRepository,
         private readonly CourseInstanceRepositoryInterface $instanceRepository,
         private readonly UserCourseRecordRepositoryInterface $recordRepository,
     ) {

--- a/equed-lms/Classes/Service/GlossaryService.php
+++ b/equed-lms/Classes/Service/GlossaryService.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Equed\EquedLms\Service;
 
-use Equed\EquedLms\Domain\Repository\GlossaryEntryRepository;
+use Equed\EquedLms\Domain\Repository\GlossaryEntryRepositoryInterface;
 use TYPO3\CMS\Core\Context\Context;
 
 final class GlossaryService implements GlossaryServiceInterface
 {
     public function __construct(
-        private readonly GlossaryEntryRepository $glossaryEntryRepository,
+        private readonly GlossaryEntryRepositoryInterface $glossaryEntryRepository,
         private readonly Context $context
     ) {
     }

--- a/equed-lms/Classes/Service/InstructorService.php
+++ b/equed-lms/Classes/Service/InstructorService.php
@@ -9,7 +9,7 @@ use Equed\EquedLms\Domain\Model\UserProfile;
 use Equed\EquedLms\Domain\Model\InstructorFeedback;
 use Equed\EquedLms\Domain\Repository\UserProfileRepositoryInterface;
 use Equed\EquedLms\Domain\Repository\UserCourseRecordRepositoryInterface;
-use Equed\EquedLms\Domain\Repository\InstructorFeedbackRepository;
+use Equed\EquedLms\Domain\Repository\InstructorFeedbackRepositoryInterface;
 use Equed\EquedLms\Enum\UserCourseStatus;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 
@@ -21,7 +21,7 @@ final class InstructorService
     public function __construct(
         private readonly UserProfileRepositoryInterface   $userProfileRepository,
         private readonly UserCourseRecordRepositoryInterface $recordRepository,
-        private readonly InstructorFeedbackRepository     $feedbackRepository,
+        private readonly InstructorFeedbackRepositoryInterface $feedbackRepository,
         private readonly PersistenceManagerInterface      $persistenceManager,
     ) {
     }

--- a/equed-lms/Configuration/Services/Services.yaml
+++ b/equed-lms/Configuration/Services/Services.yaml
@@ -111,6 +111,21 @@ services:
   Equed\EquedLms\Domain\Repository\SubmissionRepositoryInterface:
     class: Equed\EquedLms\Domain\Repository\SubmissionRepository
 
+  Equed\EquedLms\Domain\Repository\InstructorFeedbackRepositoryInterface:
+    class: Equed\EquedLms\Domain\Repository\InstructorFeedbackRepository
+
+  Equed\EquedLms\Domain\Repository\GlossaryEntryRepositoryInterface:
+    class: Equed\EquedLms\Domain\Repository\GlossaryEntryRepository
+
+  Equed\EquedLms\Domain\Repository\CourseProgramRepositoryInterface:
+    class: Equed\EquedLms\Domain\Repository\CourseProgramRepository
+
+  Equed\EquedLms\Domain\Repository\CourseBundleRepositoryInterface:
+    class: Equed\EquedLms\Domain\Repository\CourseBundleRepository
+
+  Equed\EquedLms\Domain\Repository\CourseAccessMapRepositoryInterface:
+    class: Equed\EquedLms\Domain\Repository\CourseAccessMapRepository
+
   Equed\EquedLms\Factory\FrontendUserFactoryInterface:
     class: Equed\EquedLms\Factory\DefaultFrontendUserFactory
 


### PR DESCRIPTION
## Summary
- favor repository interfaces when injecting dependencies
- wire interface implementations in Services.yaml

## Testing
- `composer lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68501b321edc8324a268c719a000d41b