### PR TITLE
Add missing repository methods

### DIFF
--- a/equed-lms/Classes/Domain/Repository/UserCourseRecordRepositoryInterface.php
+++ b/equed-lms/Classes/Domain/Repository/UserCourseRecordRepositoryInterface.php
@@ -35,4 +35,12 @@ interface UserCourseRecordRepositoryInterface
     public function findCompletedWithoutBadge(): array;
 
     public function findOneByUserAndCourse(int $userId, int $courseUid): ?UserCourseRecord;
+
+    /**
+     * Find active course records for a user.
+     *
+     * @param \Equed\EquedLms\Domain\Model\FrontendUser $user
+     * @return UserCourseRecord[]
+     */
+    public function findActiveByUser(\Equed\EquedLms\Domain\Model\FrontendUser $user): array;
 }

--- a/equed-lms/Classes/Domain/Repository/UserSubmissionRepository.php
+++ b/equed-lms/Classes/Domain/Repository/UserSubmissionRepository.php
@@ -187,6 +187,24 @@ final class UserSubmissionRepository extends Repository implements UserSubmissio
     }
 
     /**
+     * Count all submissions with status "submitted".
+     */
+    public function countSubmitted(): int
+    {
+        $qb = $this->createQuery()->getQueryBuilder();
+        $qb
+            ->select($qb->expr()->count('*'))
+            ->from('tx_equedlms_domain_model_usersubmission')
+            ->where(
+                $qb->expr()->eq('status', $qb->createNamedParameter('submitted'))
+            );
+
+        $result = $qb->executeQuery()->fetchOne();
+
+        return $result === false ? 0 : (int) $result;
+    }
+
+    /**
      * Count pending submissions for a specific course instance.
      *
      * @param int $courseInstanceId

--- a/equed-lms/Classes/Domain/Repository/UserSubmissionRepositoryInterface.php
+++ b/equed-lms/Classes/Domain/Repository/UserSubmissionRepositoryInterface.php
@@ -89,6 +89,11 @@ interface UserSubmissionRepositoryInterface
     public function countSubmittedByLesson(Lesson $lesson): int;
 
     /**
+     * Count all submissions with status "submitted".
+     */
+    public function countSubmitted(): int;
+
+    /**
      * Count pending submissions for a specific course instance.
      *
      * @param int $courseInstanceId


### PR DESCRIPTION
## Summary
- expose `findActiveByUser()` in `UserCourseRecordRepositoryInterface`
- add `countSubmitted()` method for user submissions

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68501caaa45483249450d909290a1f8a