### PR TITLE
Inject clock into DB services

### DIFF
--- a/equed-lms/Classes/Service/QmsApiService.php
+++ b/equed-lms/Classes/Service/QmsApiService.php
@@ -6,14 +6,17 @@ namespace Equed\EquedLms\Service;
 
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+use Equed\EquedLms\Domain\Service\ClockInterface;
 
 /**
  * Simple DB-driven operations for QMS API endpoints.
  */
 final class QmsApiService
 {
-    public function __construct(private readonly ConnectionPool $connectionPool)
-    {
+    public function __construct(
+        private readonly ConnectionPool $connectionPool,
+        private readonly ClockInterface $clock
+    ) {
     }
 
     /**
@@ -37,7 +40,7 @@ final class QmsApiService
 
     public function submitCase(int $userId, int $recordId, string $message, string $type = 'general'): void
     {
-        $now = time();
+        $now = $this->clock->now()->getTimestamp();
         $this->connectionPool->getConnectionForTable('tx_equedlms_domain_model_qms')
             ->insert(
                 'tx_equedlms_domain_model_qms',
@@ -56,7 +59,7 @@ final class QmsApiService
 
     public function respondToCase(int $userId, int $caseId, string $response, string $role = 'certifier'): void
     {
-        $now = time();
+        $now = $this->clock->now()->getTimestamp();
         $this->connectionPool->getConnectionForTable('tx_equedlms_domain_model_qms')
             ->update(
                 'tx_equedlms_domain_model_qms',
@@ -74,7 +77,7 @@ final class QmsApiService
 
     public function closeCase(int $userId, int $caseId): void
     {
-        $now = time();
+        $now = $this->clock->now()->getTimestamp();
         $this->connectionPool->getConnectionForTable('tx_equedlms_domain_model_qms')
             ->update(
                 'tx_equedlms_domain_model_qms',

--- a/equed-lms/Classes/Service/SubmissionService.php
+++ b/equed-lms/Classes/Service/SubmissionService.php
@@ -10,6 +10,7 @@ use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Equed\EquedLms\Event\Submission\SubmissionReviewedEvent;
+use Equed\EquedLms\Domain\Service\ClockInterface;
 
 /**
  * Service for managing user submissions.
@@ -20,6 +21,7 @@ final class SubmissionService
         private readonly UserSubmissionRepositoryInterface $submissionRepository,
         private readonly ConnectionPool $connectionPool,
         private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly ClockInterface $clock,
     ) {
     }
 
@@ -58,7 +60,7 @@ final class SubmissionService
 
     public function createSubmission(int $userId, int $recordId, string $note, string $file, string $type): void
     {
-        $now = time();
+        $now = $this->clock->now()->getTimestamp();
         $this->getConnection()->insert(
             'tx_equedlms_domain_model_usersubmission',
             [
@@ -77,7 +79,7 @@ final class SubmissionService
 
     public function evaluateSubmission(int $submissionId, string $evaluationNote, string $evaluationFile, string $comment, int $evaluatorId): void
     {
-        $now = time();
+        $now = $this->clock->now()->getTimestamp();
         $this->getConnection()->update(
             'tx_equedlms_domain_model_usersubmission',
             [

--- a/equed-lms/Classes/Service/UserAccountService.php
+++ b/equed-lms/Classes/Service/UserAccountService.php
@@ -7,14 +7,17 @@ namespace Equed\EquedLms\Service;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use Equed\EquedLms\Domain\Service\UserAccountServiceInterface;
+use Equed\EquedLms\Domain\Service\ClockInterface;
 
 /**
  * Default implementation for retrieving and updating frontend user profiles.
  */
 final class UserAccountService implements UserAccountServiceInterface
 {
-    public function __construct(private readonly ConnectionPool $connectionPool)
-    {
+    public function __construct(
+        private readonly ConnectionPool $connectionPool,
+        private readonly ClockInterface $clock
+    ) {
     }
 
     public function getProfile(int $userId): ?array
@@ -34,7 +37,7 @@ final class UserAccountService implements UserAccountServiceInterface
 
     public function updateProfile(int $userId, array $fields): void
     {
-        $fields['tstamp'] = time();
+        $fields['tstamp'] = $this->clock->now()->getTimestamp();
         $connection = $this->connectionPool->getConnectionForTable('fe_users');
         $connection->update('fe_users', $fields, ['uid' => $userId]);
     }

--- a/equed-lms/Classes/Service/UserCourseRecordCrudService.php
+++ b/equed-lms/Classes/Service/UserCourseRecordCrudService.php
@@ -7,14 +7,17 @@ namespace Equed\EquedLms\Service;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use Equed\EquedLms\Domain\Service\UserCourseRecordCrudServiceInterface;
+use Equed\EquedLms\Domain\Service\ClockInterface;
 
 /**
  * DB-backed implementation for managing user course records.
  */
 final class UserCourseRecordCrudService implements UserCourseRecordCrudServiceInterface
 {
-    public function __construct(private readonly ConnectionPool $connectionPool)
-    {
+    public function __construct(
+        private readonly ConnectionPool $connectionPool,
+        private readonly ClockInterface $clock
+    ) {
     }
 
     public function listForUser(int $userId): array
@@ -49,7 +52,7 @@ final class UserCourseRecordCrudService implements UserCourseRecordCrudServiceIn
 
     public function updateRecord(int $userId, int $recordId, array $fields): void
     {
-        $fields['tstamp'] = time();
+        $fields['tstamp'] = $this->clock->now()->getTimestamp();
         $this->connectionPool
             ->getConnectionForTable('tx_equedlms_domain_model_usercourserecord')
             ->update(

--- a/equed-lms/Configuration/Services/Services.yaml
+++ b/equed-lms/Configuration/Services/Services.yaml
@@ -177,6 +177,22 @@ services:
   Equed\EquedLms\Domain\Service\UserCourseRecordCrudServiceInterface:
     class: Equed\EquedLms\Service\UserCourseRecordCrudService
 
+  Equed\EquedLms\Service\SubmissionService:
+    arguments:
+      $clock: '@Equed\EquedLms\Domain\Service\ClockInterface'
+
+  Equed\EquedLms\Service\QmsApiService:
+    arguments:
+      $clock: '@Equed\EquedLms\Domain\Service\ClockInterface'
+
+  Equed\EquedLms\Service\UserAccountService:
+    arguments:
+      $clock: '@Equed\EquedLms\Domain\Service\ClockInterface'
+
+  Equed\EquedLms\Service\UserCourseRecordCrudService:
+    arguments:
+      $clock: '@Equed\EquedLms\Domain\Service\ClockInterface'
+
   Equed\EquedLms\Service\MailServiceInterface:
     class: Equed\EquedLms\Service\Email\MailService
 

--- a/equed-lms/Tests/Unit/Service/SubmissionServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/SubmissionServiceTest.php
@@ -6,6 +6,9 @@ namespace Equed\EquedLms\Tests\Unit\Service;
 
 use Equed\EquedLms\Domain\Repository\UserSubmissionRepositoryInterface;
 use Equed\EquedLms\Service\SubmissionService;
+use Equed\EquedLms\Domain\Service\ClockInterface;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Equed\EquedLms\Tests\Traits\ProphecyTrait;
 use PHPUnit\Framework\TestCase;
 
@@ -15,11 +18,23 @@ class SubmissionServiceTest extends TestCase
 
     private SubmissionService $subject;
     private $repository;
+    private $connectionPool;
+    private $eventDispatcher;
+    private $clock;
 
     protected function setUp(): void
     {
-        $this->repository = $this->prophesize(UserSubmissionRepositoryInterface::class);
-        $this->subject = new SubmissionService($this->repository->reveal());
+        $this->repository      = $this->prophesize(UserSubmissionRepositoryInterface::class);
+        $this->connectionPool  = $this->prophesize(ConnectionPool::class);
+        $this->eventDispatcher = $this->prophesize(EventDispatcherInterface::class);
+        $this->clock           = $this->prophesize(ClockInterface::class);
+
+        $this->subject = new SubmissionService(
+            $this->repository->reveal(),
+            $this->connectionPool->reveal(),
+            $this->eventDispatcher->reveal(),
+            $this->clock->reveal()
+        );
     }
 
     public function testGetPendingSubmissionsDelegatesToRepository(): void


### PR DESCRIPTION
## Summary
- add ClockInterface injection into database-related services
- replace `time()` calls with injected clock
- register clock arguments for affected services
- adjust `SubmissionServiceTest` to provide a mock clock

## Testing
- `phpunit -c equed-lms/phpunit.xml.dist` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68502500ebc48324ab28c3220a50ec29