### PR TITLE
Use repository for submission persistence

### DIFF
--- a/equed-lms/Classes/Domain/Repository/UserSubmissionRepositoryInterface.php
+++ b/equed-lms/Classes/Domain/Repository/UserSubmissionRepositoryInterface.php
@@ -126,6 +126,24 @@ interface UserSubmissionRepositoryInterface
      */
     public function findLatestByUserCourseRecord(int $userCourseRecordUid): ?UserSubmission;
 
+    public function createSubmission(
+        int $userId,
+        int $recordId,
+        string $note,
+        string $file,
+        string $type,
+        int $timestamp
+    ): void;
+
+    public function updateSubmission(
+        int $submissionId,
+        string $evaluationNote,
+        string $evaluationFile,
+        string $comment,
+        int $evaluatorId,
+        int $timestamp
+    ): void;
+
     /**
      * @return QueryInterface<UserSubmission>
      */


### PR DESCRIPTION
## Summary
- add write methods to `UserSubmissionRepositoryInterface`
- implement DB inserts/updates in `UserSubmissionRepository`
- refactor `SubmissionService` to delegate to repository and persist changes
- update unit tests for new repository interactions

## Testing
- `vendor/bin/phpunit -c equed-lms/phpunit.xml --testsuite Unit` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_685048db8df48324bd3a10faf7642492