### PR TITLE
Inject clock into instructor services

### DIFF
--- a/equed-lms/Classes/Service/CourseOverviewService.php
+++ b/equed-lms/Classes/Service/CourseOverviewService.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Equed\EquedLms\Service;
 
-use DateTimeImmutable;
+use Equed\EquedLms\Domain\Service\ClockInterface;
 use Equed\EquedLms\Domain\Repository\CourseProgramRepositoryInterface;
 use Equed\EquedLms\Domain\Repository\CourseInstanceRepositoryInterface;
 use Equed\EquedLms\Domain\Repository\UserCourseRecordRepositoryInterface;
@@ -19,6 +19,7 @@ final class CourseOverviewService implements CourseOverviewServiceInterface
         private readonly CourseProgramRepositoryInterface $programRepository,
         private readonly CourseInstanceRepositoryInterface $instanceRepository,
         private readonly UserCourseRecordRepositoryInterface $recordRepository,
+        private readonly ClockInterface                   $clock,
     ) {
     }
 
@@ -35,7 +36,7 @@ final class CourseOverviewService implements CourseOverviewServiceInterface
      */
     public function getActiveInstances(): array
     {
-        $now = new DateTimeImmutable();
+        $now = $this->clock->now();
 
         $query = $this->instanceRepository->createQuery();
         $query->matching(

--- a/equed-lms/Classes/Service/InstructorService.php
+++ b/equed-lms/Classes/Service/InstructorService.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Equed\EquedLms\Service;
 
-use DateTimeImmutable;
+use Equed\EquedLms\Domain\Service\ClockInterface;
 use Equed\EquedLms\Domain\Model\UserProfile;
 use Equed\EquedLms\Domain\Model\InstructorFeedback;
 use Equed\EquedLms\Domain\Repository\UserProfileRepositoryInterface;
@@ -23,6 +23,7 @@ final class InstructorService
         private readonly UserCourseRecordRepositoryInterface $recordRepository,
         private readonly InstructorFeedbackRepositoryInterface $feedbackRepository,
         private readonly PersistenceManagerInterface      $persistenceManager,
+        private readonly ClockInterface                   $clock,
     ) {
     }
 
@@ -67,7 +68,7 @@ final class InstructorService
 
         if (! $record->isCompleted()) {
             $record->setStatus(UserCourseStatus::Passed);
-            $record->setCompletedAt(new DateTimeImmutable());
+            $record->setCompletedAt($this->clock->now());
             $this->recordRepository->update($record);
             $this->persistenceManager->persistAll();
         }
@@ -94,8 +95,8 @@ final class InstructorService
         $feedback->setUserCourseRecord($record);
         $feedback->setInstructor($instanceInstructor);
         $feedback->setComment($note);
-        $feedback->setCreatedAt(new DateTimeImmutable());
-        $feedback->setUpdatedAt(new DateTimeImmutable());
+        $feedback->setCreatedAt($this->clock->now());
+        $feedback->setUpdatedAt($this->clock->now());
 
         $this->feedbackRepository->add($feedback);
         $this->persistenceManager->persistAll();

--- a/equed-lms/Configuration/Services/Services.yaml
+++ b/equed-lms/Configuration/Services/Services.yaml
@@ -208,6 +208,11 @@ services:
   Equed\EquedLms\Domain\Service\CourseBundleServiceInterface:
     class: Equed\EquedLms\Service\CourseBundleService
 
+  Equed\EquedLms\Service\InstructorService:
+    arguments:
+      $clock: '@Equed\EquedLms\Domain\Service\ClockInterface'
 
   Equed\EquedLms\Domain\Service\CourseOverviewServiceInterface:
     class: Equed\EquedLms\Service\CourseOverviewService
+    arguments:
+      $clock: '@Equed\EquedLms\Domain\Service\ClockInterface'


### PR DESCRIPTION
## Summary
- inject ClockInterface into InstructorService and CourseOverviewService
- use clock for all time generation
- wire the new dependency in the service container

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68504fa4ccec8324bbd8ca25c5c9dde6