### PR TITLE
Add GPT evaluation tests to PHPUnit config

### DIFF
--- a/equed-lms/phpunit.xml.dist
+++ b/equed-lms/phpunit.xml.dist
@@ -46,6 +46,8 @@
         <file>./Tests/Unit/Service/InstructorDashboardServiceTest.php</file>
         <file>./Tests/Unit/Service/NotificationAggregatorTest.php</file>
         <file>./Tests/Unit/Service/CacheManagerTest.php</file>
+        <file>./Tests/Unit/Service/GptEvaluationServiceTest.php</file>
+        <file>./Tests/Unit/Service/FeedbackAnalysisServiceTest.php</file>
         </testsuite>
         <testsuite name="functional">
             <directory>./Tests/Functional/</directory>


### PR DESCRIPTION
## Summary
- include GptEvaluationServiceTest and FeedbackAnalysisServiceTest in PHPUnit config

## Testing
- `./vendor/bin/phpunit --version`
- `./vendor/bin/phpunit -c phpunit.xml.dist Tests/Unit/Service/GptEvaluationServiceTest.php --testdox` *(fails: Cannot mix bracketed namespace declarations with unbracketed namespace declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68505275c20083249590dc67c4a01023