### PR TITLE
Introduce interfaces for instructor and user access services

### DIFF
--- a/equed-lms/Classes/Controller/Api/InstructorActionController.php
+++ b/equed-lms/Classes/Controller/Api/InstructorActionController.php
@@ -9,7 +9,7 @@ use TYPO3\CMS\Core\Http\JsonResponse;
 use Equed\Core\Service\ConfigurationServiceInterface;
 use Equed\EquedLms\Domain\Service\ApiResponseServiceInterface;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
-use Equed\EquedLms\Service\InstructorService;
+use Equed\EquedLms\Domain\Service\InstructorServiceInterface;
 use Equed\EquedLms\Controller\Api\BaseApiController;
 
 /**
@@ -22,7 +22,7 @@ use Equed\EquedLms\Controller\Api\BaseApiController;
 final class InstructorActionController extends BaseApiController
 {
     public function __construct(
-        private readonly InstructorService      $instructorService,
+        private readonly InstructorServiceInterface $instructorService,
         ConfigurationServiceInterface           $configurationService,
         ApiResponseServiceInterface             $apiResponseService,
         GptTranslationServiceInterface          $translationService,

--- a/equed-lms/Classes/Domain/Service/InstructorServiceInterface.php
+++ b/equed-lms/Classes/Domain/Service/InstructorServiceInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Domain\Service;
+
+use Equed\EquedLms\Domain\Model\UserProfile;
+
+/**
+ * Provides instructor-related operations.
+ */
+interface InstructorServiceInterface
+{
+    /**
+     * Retrieve all user profiles marked as instructors.
+     *
+     * @return UserProfile[]
+     */
+    public function getInstructors(): array;
+
+    /**
+     * Check if a given instructor is assigned to a course instance.
+     */
+    public function isAssignedToCourse(int $instructorFeUserId, int $courseInstanceId): bool;
+
+    /**
+     * Mark a user course record as completed by the instructor if allowed.
+     */
+    public function completeCourse(int $recordId, int $instructorId): bool;
+
+    /**
+     * Store an evaluation note for a user course record.
+     */
+    public function uploadEvaluation(int $recordId, int $instructorId, string $note): bool;
+}

--- a/equed-lms/Classes/Domain/Service/UserAccessServiceInterface.php
+++ b/equed-lms/Classes/Domain/Service/UserAccessServiceInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Domain\Service;
+
+/**
+ * Provides access checks for users and instructors.
+ */
+interface UserAccessServiceInterface
+{
+    /**
+     * Check if a user has access to a specific course program.
+     */
+    public function canAccessCourse(int $userId, int $courseProgramId): bool;
+
+    /**
+     * Check if the given user is the instructor for a specific course record.
+     */
+    public function canValidateAsInstructor(int $instructorUserId, int $userCourseRecordId): bool;
+}

--- a/equed-lms/Classes/Service/InstructorService.php
+++ b/equed-lms/Classes/Service/InstructorService.php
@@ -16,7 +16,7 @@ use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 /**
  * Service to retrieve instructors and check instructor-course assignments.
  */
-final class InstructorService
+final class InstructorService implements \Equed\EquedLms\Domain\Service\InstructorServiceInterface
 {
     public function __construct(
         private readonly UserProfileRepositoryInterface   $userProfileRepository,

--- a/equed-lms/Classes/Service/UserAccessService.php
+++ b/equed-lms/Classes/Service/UserAccessService.php
@@ -9,7 +9,7 @@ use Equed\EquedLms\Domain\Repository\UserCourseRecordRepositoryInterface;
 /**
  * Service for checking user access and instructor validation.
  */
-final class UserAccessService
+final class UserAccessService implements \Equed\EquedLms\Domain\Service\UserAccessServiceInterface
 {
     public function __construct(
         private readonly UserCourseRecordRepositoryInterface $userCourseRecordRepository

--- a/equed-lms/Classes/Task/InstructorActivityTask.php
+++ b/equed-lms/Classes/Task/InstructorActivityTask.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Equed\EquedLms\Task;
 
-use Equed\EquedLms\Service\InstructorService;
+use Equed\EquedLms\Domain\Service\InstructorServiceInterface;
 use Equed\EquedLms\Service\LogService;
 use TYPO3\CMS\Scheduler\Task\AbstractTask;
 
@@ -16,7 +16,7 @@ final class InstructorActivityTask extends AbstractTask
     private const INACTIVITY_THRESHOLD_DAYS = 90;
 
     public function __construct(
-        private readonly InstructorService $instructorService,
+        private readonly InstructorServiceInterface $instructorService,
         private readonly LogService $logService
     ) {
     }

--- a/equed-lms/Configuration/Services/Services.yaml
+++ b/equed-lms/Configuration/Services/Services.yaml
@@ -148,6 +148,9 @@ services:
   Equed\EquedLms\Domain\Service\AuthenticationServiceInterface:
     class: Equed\EquedLms\Service\AuthenticationService
 
+  Equed\EquedLms\Domain\Service\UserAccessServiceInterface:
+    class: Equed\EquedLms\Service\UserAccessService
+
   Equed\EquedLms\Domain\Service\NotificationServiceInterface:
     class: Equed\EquedLms\Service\NotificationService
 
@@ -210,7 +213,8 @@ services:
   Equed\EquedLms\Domain\Service\CourseBundleServiceInterface:
     class: Equed\EquedLms\Service\CourseBundleService
 
-  Equed\EquedLms\Service\InstructorService:
+  Equed\EquedLms\Domain\Service\InstructorServiceInterface:
+    class: Equed\EquedLms\Service\InstructorService
     arguments:
       $clock: '@Equed\EquedLms\Domain\Service\ClockInterface'
 

--- a/equed-lms/Tests/Unit/Controller/InstructorControllerTest.php
+++ b/equed-lms/Tests/Unit/Controller/InstructorControllerTest.php
@@ -7,7 +7,7 @@ namespace Equed\EquedLms\Tests\Unit\Controller;
 use PHPUnit\Framework\TestCase;
 use Equed\EquedLms\Tests\Traits\ProphecyTrait;
 use Equed\EquedLms\Controller\InstructorController;
-use Equed\EquedLms\Service\InstructorServiceInterface;
+use Equed\EquedLms\Domain\Service\InstructorServiceInterface;
 use TYPO3\CMS\Core\View\ViewInterface;
 use Psr\Log\LoggerInterface;
 


### PR DESCRIPTION
## Summary
- add `InstructorServiceInterface` and `UserAccessServiceInterface`
- implement interfaces in existing service classes
- rely on the interfaces in controller, task and tests
- register the interfaces in `Services.yaml`

## Testing
- `composer test` *(fails: Cannot declare interface UuidGeneratorInterface)*

------
https://chatgpt.com/codex/tasks/task_e_685055561db4832487df18235221d2eb