### PR TITLE
Inject exam template path

### DIFF
--- a/equed-lms/Classes/Service/ExamService.php
+++ b/equed-lms/Classes/Service/ExamService.php
@@ -23,6 +23,7 @@ final class ExamService implements ExamServiceInterface
         private readonly ExamAttemptRepositoryInterface $examAttemptRepository,
         private readonly ExamAttemptFactoryInterface $examAttemptFactory,
         private readonly ClockInterface $clock,
+        private readonly string $templateBasePath,
         ?FileReaderInterface $fileReader = null
     ) {
         $this->fileReader = $fileReader ?? new LocalFileReader();
@@ -92,7 +93,7 @@ final class ExamService implements ExamServiceInterface
 
     public function loadTemplate(int $templateId): ?array
     {
-        $path = dirname(__DIR__, 2) . '/Resources/Private/ExamTemplates/' . $templateId . '.json';
+        $path = rtrim($this->templateBasePath, '/') . '/' . $templateId . '.json';
         if (!is_file($path)) {
             return null;
         }

--- a/equed-lms/Configuration/Services/Services.yaml
+++ b/equed-lms/Configuration/Services/Services.yaml
@@ -173,6 +173,10 @@ services:
   Equed\EquedLms\Domain\Service\ExamServiceInterface:
     class: Equed\EquedLms\Service\ExamService
 
+  Equed\EquedLms\Service\ExamService:
+    arguments:
+      $templateBasePath: '@=service("Equed\\\\EquedLms\\\\Service\\\\SettingsService").get("examTemplatePath")'
+
   Equed\EquedLms\Domain\Service\LessonProgressServiceInterface:
     class: Equed\EquedLms\Service\LessonProgressService
 

--- a/equed-lms/Tests/Unit/Service/ExamServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/ExamServiceTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Tests\Unit\Service;
+
+use Equed\EquedLms\Service\ExamService;
+use Equed\EquedLms\Domain\Repository\ExamAttemptRepositoryInterface;
+use Equed\EquedLms\Factory\ExamAttemptFactoryInterface;
+use Equed\EquedLms\Domain\Service\ClockInterface;
+use PHPUnit\Framework\TestCase;
+use Equed\EquedLms\Tests\Traits\ProphecyTrait;
+
+class ExamServiceTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testLoadTemplateUsesInjectedBasePath(): void
+    {
+        $base = sys_get_temp_dir() . '/exam_service_test';
+        if (!is_dir($base)) {
+            mkdir($base);
+        }
+        file_put_contents($base . '/5.json', json_encode(['foo' => 'bar']));
+
+        $repo = $this->prophesize(ExamAttemptRepositoryInterface::class);
+        $factory = $this->prophesize(ExamAttemptFactoryInterface::class);
+        $clock = $this->prophesize(ClockInterface::class);
+
+        $service = new ExamService(
+            $repo->reveal(),
+            $factory->reveal(),
+            $clock->reveal(),
+            $base
+        );
+
+        $data = $service->loadTemplate(5);
+
+        $this->assertSame(['foo' => 'bar'], $data);
+
+        unlink($base . '/5.json');
+        rmdir($base);
+    }
+}

--- a/equed-lms/phpunit.xml.dist
+++ b/equed-lms/phpunit.xml.dist
@@ -41,6 +41,7 @@
         <file>./Tests/Unit/Service/LessonContentServiceTest.php</file>
         <file>./Tests/Unit/Service/CourseStatusUpdaterServiceTest.php</file>
         <file>./Tests/Unit/Service/ExamNotificationServiceTest.php</file>
+        <file>./Tests/Unit/Service/ExamServiceTest.php</file>
         <file>./Tests/Unit/Service/TrainingRecordGeneratorServiceTest.php</file>
         <file>./Tests/Unit/Service/TabsBuilderTest.php</file>
         <file>./Tests/Unit/Service/FilterMetadataProviderTest.php</file>


### PR DESCRIPTION
## Summary
- inject template base path into `ExamService`
- compose template file path from injected base path
- configure DI to read base path from extension settings
- add unit test for loading templates via injected path

## Testing
- `./vendor/bin/phpunit -c phpunit.xml.dist` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685068c6bd8883248336e779fb01d90e