### PR TITLE
Use repository in SubmissionController

### DIFF
--- a/equed-lms/Classes/Domain/Repository/UserSubmissionRepository.php
+++ b/equed-lms/Classes/Domain/Repository/UserSubmissionRepository.php
@@ -440,4 +440,46 @@ final class UserSubmissionRepository extends Repository implements UserSubmissio
             ['uid' => $submissionId]
         );
     }
+
+    /**
+     * Fetch submissions for a frontend user as associative arrays.
+     *
+     * @param int $feUserId
+     * @return array<int, array<string, mixed>>
+     */
+    public function fetchAllByFeUser(int $feUserId): array
+    {
+        $qb = $this->connection->createQueryBuilder();
+        $qb
+            ->select('uid', 'usercourserecord', 'type', 'note', 'file', 'status', 'submitted_at', 'evaluated_at', 'evaluation_note')
+            ->from('tx_equedlms_domain_model_usersubmission')
+            ->where(
+                $qb->expr()->eq('fe_user', $qb->createNamedParameter($feUserId, \PDO::PARAM_INT)),
+                $qb->expr()->eq('deleted', 0)
+            )
+            ->orderBy('submitted_at', 'DESC');
+
+        return $qb->executeQuery()->fetchAllAssociative();
+    }
+
+    /**
+     * Fetch submissions for a user course record as associative arrays.
+     *
+     * @param int $recordId
+     * @return array<int, array<string, mixed>>
+     */
+    public function fetchAllByRecord(int $recordId): array
+    {
+        $qb = $this->connection->createQueryBuilder();
+        $qb
+            ->select('*')
+            ->from('tx_equedlms_domain_model_usersubmission')
+            ->where(
+                $qb->expr()->eq('usercourserecord', $qb->createNamedParameter($recordId, \PDO::PARAM_INT)),
+                $qb->expr()->eq('deleted', 0)
+            )
+            ->orderBy('submitted_at', 'DESC');
+
+        return $qb->executeQuery()->fetchAllAssociative();
+    }
 }

--- a/equed-lms/Classes/Domain/Repository/UserSubmissionRepositoryInterface.php
+++ b/equed-lms/Classes/Domain/Repository/UserSubmissionRepositoryInterface.php
@@ -29,9 +29,25 @@ interface UserSubmissionRepositoryInterface
     public function findByFeUser(int $feUserId): array;
 
     /**
+     * Fetch submissions for a frontend user as associative arrays.
+     *
+     * @param int $feUserId
+     * @return array<int, array<string, mixed>>
+     */
+    public function fetchAllByFeUser(int $feUserId): array;
+
+    /**
      * @return UserSubmission[]
      */
     public function findByCourseInstance(int $courseInstanceId): array;
+
+    /**
+     * Fetch submissions for a user course record as associative arrays.
+     *
+     * @param int $recordId
+     * @return array<int, array<string, mixed>>
+     */
+    public function fetchAllByRecord(int $recordId): array;
 
     /**
      * @param int $uid


### PR DESCRIPTION
## Summary
- centralize data logic in `UserSubmissionRepository`
- remove SQL from `SubmissionController`
- inject the repository for listing methods

## Testing
- `composer lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68506f849d0c83248b186fedac20b44a