### PR TITLE
Add CourseViewModel DTO

### DIFF
--- a/equed-lms/Classes/Controller/CourseController.php
+++ b/equed-lms/Classes/Controller/CourseController.php
@@ -32,18 +32,21 @@ final class CourseController extends ActionController
         $userAttr = $request->getAttribute('user');
         $userId   = is_array($userAttr) && isset($userAttr['uid']) ? (int)$userAttr['uid'] : 0;
 
-        $data = $this->courseProgressService->getCourseViewModel($courseUid, $userId);
+        $viewModel = $this->courseProgressService->getCourseViewModel($courseUid, $userId);
 
-        if (isset($data['error'])) {
+        if ($viewModel->hasError()) {
             $this->addFlashMessage(
-                $data['error'],
+                $viewModel->getError() ?? '',
                 '',
                 \TYPO3\CMS\Core\Messaging\AbstractMessage::ERROR
             );
             return $this->redirect('list');
         }
 
-        $this->view->assignMultiple($data);
+        $this->view->assignMultiple([
+            'course'   => $viewModel->getCourse(),
+            'progress' => $viewModel->getProgress(),
+        ]);
 
         return $this->htmlResponse();
     }

--- a/equed-lms/Classes/Dto/CourseViewModel.php
+++ b/equed-lms/Classes/Dto/CourseViewModel.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Dto;
+
+use Equed\EquedLms\Domain\Model\Course;
+
+final class CourseViewModel implements \JsonSerializable
+{
+    public function __construct(
+        private readonly ?Course $course = null,
+        private readonly int $progress = 0,
+        private readonly ?string $error = null,
+    ) {
+    }
+
+    public function getCourse(): ?Course
+    {
+        return $this->course;
+    }
+
+    public function getProgress(): int
+    {
+        return $this->progress;
+    }
+
+    public function getError(): ?string
+    {
+        return $this->error;
+    }
+
+    public function hasError(): bool
+    {
+        return $this->error !== null;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'course' => $this->course,
+            'progress' => $this->progress,
+            'error' => $this->error,
+        ];
+    }
+}

--- a/equed-lms/Classes/Service/CourseProgressService.php
+++ b/equed-lms/Classes/Service/CourseProgressService.php
@@ -7,6 +7,7 @@ namespace Equed\EquedLms\Service;
 use Equed\EquedLms\Domain\Repository\CourseRepositoryInterface;
 use Equed\EquedLms\Domain\Repository\LessonProgressRepositoryInterface;
 use Equed\EquedLms\Domain\Service\CourseCompletionServiceInterface;
+use Equed\EquedLms\Dto\CourseViewModel;
 
 /**
  * Service responsible for preparing the view model for course progress pages.
@@ -21,15 +22,15 @@ final class CourseProgressService implements CourseProgressServiceInterface
     ) {
     }
 
-    public function getCourseViewModel(int $courseUid, int $userId): array
+    public function getCourseViewModel(int $courseUid, int $userId): CourseViewModel
     {
         if ($courseUid <= 0) {
-            return ['error' => $this->translationService->translate('error.noCourseSelected')];
+            return new CourseViewModel(error: $this->translationService->translate('error.noCourseSelected'));
         }
 
         $course = $this->courseRepository->findByUid($courseUid);
         if ($course === null) {
-            return ['error' => $this->translationService->translate('error.courseNotFound')];
+            return new CourseViewModel(error: $this->translationService->translate('error.courseNotFound'));
         }
 
         $lessons = $course->getLessons();
@@ -46,11 +47,9 @@ final class CourseProgressService implements CourseProgressServiceInterface
             }
         }
 
-        return [
-            'course' => $course,
-            'lessons' => $lessons,
-            'progressPercent' => $progressPercent,
-            'userId' => $userId,
-        ];
+        return new CourseViewModel(
+            course: $course,
+            progress: $progressPercent,
+        );
     }
 }

--- a/equed-lms/Classes/Service/CourseProgressServiceInterface.php
+++ b/equed-lms/Classes/Service/CourseProgressServiceInterface.php
@@ -4,17 +4,15 @@ declare(strict_types=1);
 
 namespace Equed\EquedLms\Service;
 
+use Equed\EquedLms\Dto\CourseViewModel;
+
 interface CourseProgressServiceInterface
 {
     /**
      * Build the view model for a course progress page.
      *
-     * The returned array either contains an 'error' key with a localized
-     * message or the keys 'course', 'lessons', 'progressPercent' and 'userId'.
-     *
-     * @param int $courseUid Course identifier
-     * @param int $userId    Frontend user identifier
-     * @return array<string,mixed>
+     * Returns a {@see CourseViewModel} containing either the course data with
+     * progress information or an error message.
      */
-    public function getCourseViewModel(int $courseUid, int $userId): array;
+    public function getCourseViewModel(int $courseUid, int $userId): CourseViewModel;
 }

--- a/equed-lms/Resources/Private/Partials/Course/ListItem.html
+++ b/equed-lms/Resources/Private/Partials/Course/ListItem.html
@@ -13,5 +13,5 @@
     {course.status}
   </p>
 
-  <f:render partial="User/ProgressBar" arguments="{percent: course.progress}" />
+  <f:render partial="User/ProgressBar" arguments="{percent: progress}" />
 </div>

--- a/equed-lms/Resources/Private/Templates/Course/Detail.html
+++ b/equed-lms/Resources/Private/Templates/Course/Detail.html
@@ -4,7 +4,7 @@
   <p><f:translate key="course.level" />: {course.level}</p>
   <p><f:translate key="course.description" /></p>
 
-  <f:render partial="User/ProgressBar" arguments="{percent: course.progress}" />
+  <f:render partial="User/ProgressBar" arguments="{percent: progress}" />
   <f:link.action action="start" controller="Lesson" arguments="{course: course}" class="btn btn-primary">
     <f:translate key="course.action.start" />
   </f:link.action>

--- a/equed-lms/Resources/Private/Templates/Course/Index.html
+++ b/equed-lms/Resources/Private/Templates/Course/Index.html
@@ -23,16 +23,16 @@
 
         <div class="progress-bar"
              role="progressbar"
-             aria-valuenow="{progressPercent}"
+             aria-valuenow="{progress}"
              aria-valuemin="0"
              aria-valuemax="100"
              aria-label="{f:translate(key: 'course.progress')}">
-          <div class="progress-fill" style="width: {progressPercent}%;">
-            <span class="sr-only">{progressPercent}%</span>
+          <div class="progress-fill" style="width: {progress}%;">
+            <span class="sr-only">{progress}%</span>
           </div>
         </div>
 
-        <f:if condition="{progressPercent} == 100">
+        <f:if condition="{progress} == 100">
           <div class="course-complete" role="status" aria-live="polite">
             <span aria-hidden="true">✔</span>
             <span><f:translate key="course.completed" /></span>

--- a/equed-lms/Resources/Private/Templates/Course/Show.html
+++ b/equed-lms/Resources/Private/Templates/Course/Show.html
@@ -13,7 +13,7 @@
       <f:translate key="course.description" />
     </p>
 
-    <f:render partial="User/ProgressBar" arguments="{percent: course.progress}" />
+    <f:render partial="User/ProgressBar" arguments="{percent: progress}" />
 
     <f:link.action action="start"
                    controller="Lesson"

--- a/equed-lms/Tests/Unit/Service/CourseProgressServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/CourseProgressServiceTest.php
@@ -6,6 +6,7 @@ namespace Equed\EquedLms\Tests\Unit\Service;
 
 use Equed\EquedLms\Service\CourseProgressService;
 use Equed\EquedLms\Service\CourseProgressServiceInterface;
+use Equed\EquedLms\Dto\CourseViewModel;
 use Equed\EquedLms\Domain\Repository\CourseRepositoryInterface;
 use Equed\EquedLms\Domain\Repository\LessonProgressRepositoryInterface;
 use Equed\EquedLms\Domain\Service\CourseCompletionServiceInterface;
@@ -48,7 +49,9 @@ final class CourseProgressServiceTest extends TestCase
         $this->courseRepo->findByUid(5)->willReturn(null);
 
         $result = $this->subject->getCourseViewModel(5, 3);
-        $this->assertSame(['error' => 'err'], $result);
+        $this->assertInstanceOf(CourseViewModel::class, $result);
+        $this->assertTrue($result->hasError());
+        $this->assertSame('err', $result->getError());
     }
 
     public function testCalculatesProgressAndMarksCompletion(): void
@@ -64,7 +67,9 @@ final class CourseProgressServiceTest extends TestCase
         $this->completion->markCompletedIfNotYet(3, 7)->shouldBeCalled();
 
         $result = $this->subject->getCourseViewModel(7, 3);
-        $this->assertSame(100, $result['progressPercent']);
-        $this->assertSame($course->reveal(), $result['course']);
+        $this->assertInstanceOf(CourseViewModel::class, $result);
+        $this->assertFalse($result->hasError());
+        $this->assertSame(100, $result->getProgress());
+        $this->assertSame($course->reveal(), $result->getCourse());
     }
 }


### PR DESCRIPTION
## Summary
- implement `CourseViewModel` DTO
- return the DTO from `CourseProgressServiceInterface`
- refactor `CourseProgressService` and controller to use the DTO
- adjust templates and tests for new `progress` field

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850769968b4832494332e0cdd72c492