### PR TITLE
Introduce LoginRequest DTO for API login

### DIFF
--- a/equed-lms/Classes/Controller/Api/AppLoginController.php
+++ b/equed-lms/Classes/Controller/Api/AppLoginController.php
@@ -8,6 +8,7 @@ use Equed\Core\Service\ConfigurationServiceInterface;
 use Equed\EquedLms\Controller\Api\BaseApiController;
 use Equed\EquedLms\Domain\Service\ApiResponseServiceInterface;
 use Equed\EquedLms\Domain\Service\AuthenticationServiceInterface;
+use Equed\EquedLms\Dto\LoginRequest;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Http\JsonResponse;
@@ -43,15 +44,13 @@ final class AppLoginController extends BaseApiController
             return $check;
         }
 
-        $body     = (array)$request->getParsedBody();
-        $email    = trim($body['email'] ?? '');
-        $password = $body['password'] ?? '';
-
-        if ($email === '' || $password === '') {
+        try {
+            $dto = LoginRequest::fromRequest($request);
+        } catch (\InvalidArgumentException) {
             return $this->jsonError('api.login.missingCredentials', JsonResponse::HTTP_BAD_REQUEST);
         }
 
-        $result = $this->authService->login($email, $password);
+        $result = $this->authService->login($dto->getEmail(), $dto->getPassword());
         if ($result === null) {
             return $this->jsonError('api.login.invalidCredentials', JsonResponse::HTTP_FORBIDDEN);
         }

--- a/equed-lms/Classes/Controller/Api/AuthController.php
+++ b/equed-lms/Classes/Controller/Api/AuthController.php
@@ -8,6 +8,7 @@ use Equed\Core\Service\ConfigurationServiceInterface;
 use Equed\EquedLms\Controller\Api\BaseApiController;
 use Equed\EquedLms\Domain\Service\ApiResponseServiceInterface;
 use Equed\EquedLms\Domain\Service\AuthenticationServiceInterface;
+use Equed\EquedLms\Dto\LoginRequest;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Http\JsonResponse;
@@ -43,15 +44,13 @@ final class AuthController extends BaseApiController
             return $check;
         }
 
-        $data     = (array)$request->getParsedBody();
-        $email    = trim($data['email'] ?? '');
-        $password = $data['password'] ?? '';
-
-        if ($email === '' || $password === '') {
+        try {
+            $dto = LoginRequest::fromRequest($request);
+        } catch (\InvalidArgumentException) {
             return $this->jsonError('api.auth.missingCredentials', JsonResponse::HTTP_BAD_REQUEST);
         }
 
-        $result = $this->authService->login($email, $password);
+        $result = $this->authService->login($dto->getEmail(), $dto->getPassword());
         if ($result === null) {
             return $this->jsonError('api.auth.invalidCredentials', JsonResponse::HTTP_UNAUTHORIZED);
         }

--- a/equed-lms/Classes/Dto/LoginRequest.php
+++ b/equed-lms/Classes/Dto/LoginRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Dto;
+
+use InvalidArgumentException;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class LoginRequest
+{
+    public function __construct(
+        private readonly string $email,
+        private readonly string $password,
+    ) {
+    }
+
+    public static function fromRequest(ServerRequestInterface $request): self
+    {
+        $body = (array) $request->getParsedBody();
+        $email = isset($body['email']) ? trim((string) $body['email']) : '';
+        $password = isset($body['password']) ? (string) $body['password'] : '';
+
+        if ($email === '' || $password === '') {
+            throw new InvalidArgumentException('Missing credentials');
+        }
+
+        return new self($email, $password);
+    }
+
+    public function getEmail(): string
+    {
+        return $this->email;
+    }
+
+    public function getPassword(): string
+    {
+        return $this->password;
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `LoginRequest` DTO with validation
- refactor `AppLoginController` and `AuthController` to use the new DTO

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685078254fdc8324836c896b251976f2