### PR TITLE
feat(lms): move submission validation to services

### DIFF
--- a/equed-lms/Classes/Controller/Api/SubmissionRestController.php
+++ b/equed-lms/Classes/Controller/Api/SubmissionRestController.php
@@ -37,10 +37,6 @@ final class SubmissionRestController extends BaseApiController
         $params  = $request->getQueryParams();
         $userId  = isset($params['userId']) ? (int) $params['userId'] : $currentUserId;
 
-        if ($userId === null || $userId <= 0) {
-            return $this->jsonError('api.submission.invalidUser', JsonResponse::HTTP_BAD_REQUEST);
-        }
-
         try {
             $data = $this->submissionService->exportForApp($userId);
 
@@ -64,13 +60,8 @@ final class SubmissionRestController extends BaseApiController
         }
 
         $payload = (array) $request->getParsedBody();
-
         if (!isset($payload['userId']) || (int) $payload['userId'] <= 0) {
             $payload['userId'] = $currentUserId;
-        }
-
-        if (empty($payload['userId']) || !isset($payload['submission'])) {
-            return $this->jsonError('api.submission.invalidPayload', JsonResponse::HTTP_BAD_REQUEST);
         }
 
         try {

--- a/equed-lms/Classes/Dto/SubmissionCreateRequest.php
+++ b/equed-lms/Classes/Dto/SubmissionCreateRequest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Dto;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+final class SubmissionCreateRequest
+{
+    public function __construct(
+        private readonly int $userId,
+        private readonly int $recordId,
+        private readonly string $note,
+        private readonly string $file,
+        private readonly string $type,
+    ) {
+    }
+
+    public static function fromRequest(ServerRequestInterface $request): self
+    {
+        $user = $request->getAttribute('user');
+        $userId = is_array($user) && isset($user['uid']) ? (int)$user['uid'] : 0;
+        $body = (array) $request->getParsedBody();
+
+        $recordId = isset($body['userCourseRecord']) ? (int)$body['userCourseRecord'] : 0;
+        $note = isset($body['note']) ? trim((string)$body['note']) : '';
+        $file = isset($body['file']) ? trim((string)$body['file']) : '';
+        $type = isset($body['type']) ? trim((string)$body['type']) : 'general';
+
+        return new self($userId, $recordId, $note, $file, $type);
+    }
+
+    public function getUserId(): int
+    {
+        return $this->userId;
+    }
+
+    public function getRecordId(): int
+    {
+        return $this->recordId;
+    }
+
+    public function getNote(): string
+    {
+        return $this->note;
+    }
+
+    public function getFile(): string
+    {
+        return $this->file;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+}

--- a/equed-lms/Classes/Dto/SubmissionEvaluateRequest.php
+++ b/equed-lms/Classes/Dto/SubmissionEvaluateRequest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Dto;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+final class SubmissionEvaluateRequest
+{
+    public function __construct(
+        private readonly int $submissionId,
+        private readonly int $evaluatorId,
+        private readonly string $evaluationNote,
+        private readonly string $evaluationFile,
+        private readonly string $comment,
+    ) {
+    }
+
+    public static function fromRequest(ServerRequestInterface $request): self
+    {
+        $user = $request->getAttribute('user');
+        $evaluatorId = is_array($user) && isset($user['uid']) ? (int)$user['uid'] : 0;
+        $body = (array) $request->getParsedBody();
+
+        $submissionId = isset($body['submissionId']) ? (int)$body['submissionId'] : 0;
+        $evaluationNote = isset($body['evaluationNote']) ? trim((string)$body['evaluationNote']) : '';
+        $evaluationFile = isset($body['evaluationFile']) ? trim((string)$body['evaluationFile']) : '';
+        $comment = isset($body['instructorComment']) ? trim((string)$body['instructorComment']) : '';
+
+        return new self($submissionId, $evaluatorId, $evaluationNote, $evaluationFile, $comment);
+    }
+
+    public function getSubmissionId(): int
+    {
+        return $this->submissionId;
+    }
+
+    public function getEvaluatorId(): int
+    {
+        return $this->evaluatorId;
+    }
+
+    public function getEvaluationNote(): string
+    {
+        return $this->evaluationNote;
+    }
+
+    public function getEvaluationFile(): string
+    {
+        return $this->evaluationFile;
+    }
+
+    public function getComment(): string
+    {
+        return $this->comment;
+    }
+}

--- a/equed-lms/Classes/Service/SubmissionSyncService.php
+++ b/equed-lms/Classes/Service/SubmissionSyncService.php
@@ -9,6 +9,7 @@ use Equed\EquedLms\Domain\Repository\UserSubmissionRepositoryInterface;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 use Ramsey\Uuid\Uuid;
 use Equed\EquedLms\Domain\Service\ClockInterface;
+use InvalidArgumentException;
 
 final class SubmissionSyncService
 {
@@ -27,6 +28,10 @@ final class SubmissionSyncService
      */
     public function exportForApp(int $userId): array
     {
+        if ($userId <= 0) {
+            throw new InvalidArgumentException('Invalid userId');
+        }
+
         $submissions = $this->submissionRepository->findByFeUser($userId);
         $result      = [];
 
@@ -44,9 +49,13 @@ final class SubmissionSyncService
      */
     public function importFromApp(array $payload): UserSubmission
     {
-        $data = $payload['submission'] ?? $payload;
+        if (empty($payload['userId']) || !isset($payload['submission'])) {
+            throw new InvalidArgumentException('Invalid payload');
+        }
 
-        if (!isset($data['userId']) && isset($payload['userId'])) {
+        $data = $payload['submission'];
+
+        if (!isset($data['userId'])) {
             $data['userId'] = (int) $payload['userId'];
         }
 

--- a/equed-lms/Tests/Unit/Service/SubmissionServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/SubmissionServiceTest.php
@@ -6,6 +6,8 @@ namespace Equed\EquedLms\Tests\Unit\Service;
 
 use Equed\EquedLms\Domain\Repository\UserSubmissionRepositoryInterface;
 use Equed\EquedLms\Service\SubmissionService;
+use Equed\EquedLms\Dto\SubmissionCreateRequest;
+use Equed\EquedLms\Dto\SubmissionEvaluateRequest;
 use Equed\EquedLms\Domain\Service\ClockInterface;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 use Psr\EventDispatcher\EventDispatcherInterface;
@@ -70,7 +72,8 @@ class SubmissionServiceTest extends TestCase
         $this->repository->createSubmission(1, 2, 'n', 'f', 't', $timestamp)->shouldBeCalled();
         $this->persistence->persistAll()->shouldBeCalled();
 
-        $this->subject->createSubmission(1, 2, 'n', 'f', 't');
+        $dto = new SubmissionCreateRequest(1, 2, 'n', 'f', 't');
+        $this->subject->createSubmission($dto);
     }
 
     public function testEvaluateSubmissionUpdatesAndDispatches(): void
@@ -85,6 +88,7 @@ class SubmissionServiceTest extends TestCase
         $this->repository->findByUid(5)->willReturn($submission);
         $this->eventDispatcher->dispatch(new SubmissionReviewedEvent($submission))->shouldBeCalled();
 
-        $this->subject->evaluateSubmission(5, 'e', 'f', 'c', 9);
+        $dto = new SubmissionEvaluateRequest(5, 9, 'e', 'f', 'c');
+        $this->subject->evaluateSubmission($dto);
     }
 }


### PR DESCRIPTION
## Summary
- add submission request DTOs
- validate submission operations inside services
- rely on services from controllers only

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_68507aee37d88324b9d664602ca7a4f9