### PR TITLE
Add user profile DTOs and service mapping

### DIFF
--- a/equed-lms/Classes/Application/Assembler/UserProfileDtoAssembler.php
+++ b/equed-lms/Classes/Application/Assembler/UserProfileDtoAssembler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Application\Assembler;
+
+use Equed\EquedLms\Application\Dto\UserProfileDto;
+
+final class UserProfileDtoAssembler
+{
+    /**
+     * @param array<string,mixed> $data
+     */
+    public static function fromArray(array $data): UserProfileDto
+    {
+        $roles = array_filter(
+            array_map('intval', explode(',', (string)($data['usergroup'] ?? '')))
+        );
+
+        return new UserProfileDto(
+            (int)$data['uid'],
+            (string)($data['name'] ?? ''),
+            (string)($data['email'] ?? ''),
+            $roles,
+            trim((string)($data['name'] ?? '')) !== ''
+        );
+    }
+}
+

--- a/equed-lms/Classes/Application/Dto/UserProfileDto.php
+++ b/equed-lms/Classes/Application/Dto/UserProfileDto.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Application\Dto;
+
+/**
+ * Data Transfer Object representing a frontend user's profile.
+ */
+final class UserProfileDto implements \JsonSerializable
+{
+    /**
+     * @param int   $userId           FE user identifier
+     * @param string $name             Display name
+     * @param string $email            E-mail address
+     * @param int[]  $roles            Numeric role identifiers
+     * @param bool   $profileCompleted Whether the profile has been completed
+     */
+    public function __construct(
+        private readonly int $userId,
+        private readonly string $name,
+        private readonly string $email,
+        private readonly array $roles,
+        private readonly bool $profileCompleted,
+    ) {
+    }
+
+    public function getUserId(): int
+    {
+        return $this->userId;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getEmail(): string
+    {
+        return $this->email;
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getRoles(): array
+    {
+        return $this->roles;
+    }
+
+    public function isProfileCompleted(): bool
+    {
+        return $this->profileCompleted;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'userId' => $this->userId,
+            'name' => $this->name,
+            'email' => $this->email,
+            'roles' => $this->roles,
+            'profileCompleted' => $this->profileCompleted,
+        ];
+    }
+}
+

--- a/equed-lms/Classes/Controller/Api/AppUserController.php
+++ b/equed-lms/Classes/Controller/Api/AppUserController.php
@@ -53,15 +53,7 @@ final class AppUserController extends BaseApiController
             return $this->jsonError('api.userProfile.notFound', JsonResponse::HTTP_NOT_FOUND);
         }
 
-        $roles = array_filter(array_map('intval', explode(',', (string)($profile['usergroup'] ?? ''))));
-
-        return $this->jsonSuccess([
-            'userId'           => (int)$profile['uid'],
-            'name'             => (string)($profile['name'] ?? ''),
-            'email'            => (string)($profile['email'] ?? ''),
-            'roles'            => $roles,
-            'profileCompleted' => trim((string)($profile['name'] ?? '')) !== '',
-        ]);
+        return $this->jsonSuccess($profile->jsonSerialize());
     }
 }
 // End of file

--- a/equed-lms/Classes/Domain/Service/UserAccountServiceInterface.php
+++ b/equed-lms/Classes/Domain/Service/UserAccountServiceInterface.php
@@ -7,22 +7,25 @@ namespace Equed\EquedLms\Domain\Service;
 /**
  * Provides access to frontend user profile data.
  */
+use Equed\EquedLms\Application\Dto\UserProfileDto;
+use Equed\EquedLms\Dto\ProfileUpdateRequest;
+
 interface UserAccountServiceInterface
 {
     /**
      * Retrieve profile information for the given user.
      *
      * @param int $userId FE user identifier
-     * @return array<string,mixed>|null Profile data or null if not found
+     * @return UserProfileDto|null Profile data or null if not found
      */
-    public function getProfile(int $userId): ?array;
+    public function getProfile(int $userId): ?UserProfileDto;
 
     /**
      * Update profile fields for the given user.
      *
      * @param int $userId FE user identifier
-     * @param array<string,mixed> $fields Fields to update
+     * @param ProfileUpdateRequest $request DTO containing fields to update
      */
-    public function updateProfile(int $userId, array $fields): void;
+    public function updateProfile(int $userId, ProfileUpdateRequest $request): void;
 }
 

--- a/equed-lms/Classes/Dto/ProfileUpdateRequest.php
+++ b/equed-lms/Classes/Dto/ProfileUpdateRequest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Dto;
+
+use InvalidArgumentException;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Request DTO for updating user profiles.
+ */
+final class ProfileUpdateRequest
+{
+    /**
+     * Allowed fields that can be updated via the API.
+     */
+    private const ALLOWED_FIELDS = ['name', 'email'];
+
+    /**
+     * @param array<string,string> $fields
+     */
+    public function __construct(private readonly array $fields)
+    {
+    }
+
+    public static function fromRequest(ServerRequestInterface $request): self
+    {
+        $body   = (array) $request->getParsedBody();
+        $fields = [];
+        foreach (self::ALLOWED_FIELDS as $field) {
+            if (isset($body[$field]) && is_string($body[$field])) {
+                $value = trim($body[$field]);
+                if ($value !== '') {
+                    $fields[$field] = $value;
+                }
+            }
+        }
+
+        if ($fields === []) {
+            throw new InvalidArgumentException('No updateable fields provided');
+        }
+
+        return new self($fields);
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    public function getFields(): array
+    {
+        return $this->fields;
+    }
+}
+

--- a/equed-lms/Classes/Service/UserAccountService.php
+++ b/equed-lms/Classes/Service/UserAccountService.php
@@ -6,8 +6,11 @@ namespace Equed\EquedLms\Service;
 
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+use Equed\EquedLms\Application\Assembler\UserProfileDtoAssembler;
+use Equed\EquedLms\Application\Dto\UserProfileDto;
 use Equed\EquedLms\Domain\Service\UserAccountServiceInterface;
 use Equed\EquedLms\Domain\Service\ClockInterface;
+use Equed\EquedLms\Dto\ProfileUpdateRequest;
 
 /**
  * Default implementation for retrieving and updating frontend user profiles.
@@ -20,7 +23,7 @@ final class UserAccountService implements UserAccountServiceInterface
     ) {
     }
 
-    public function getProfile(int $userId): ?array
+    public function getProfile(int $userId): ?UserProfileDto
     {
         $qb = $this->getQueryBuilder('fe_users');
         $qb->select('uid', 'username', 'name', 'email', 'usergroup')
@@ -32,11 +35,12 @@ final class UserAccountService implements UserAccountServiceInterface
 
         $profile = $qb->executeQuery()->fetchAssociative();
 
-        return $profile === false ? null : $profile;
+        return $profile === false ? null : UserProfileDtoAssembler::fromArray($profile);
     }
 
-    public function updateProfile(int $userId, array $fields): void
+    public function updateProfile(int $userId, ProfileUpdateRequest $request): void
     {
+        $fields          = $request->getFields();
         $fields['tstamp'] = $this->clock->now()->getTimestamp();
         $connection = $this->connectionPool->getConnectionForTable('fe_users');
         $connection->update('fe_users', $fields, ['uid' => $userId]);


### PR DESCRIPTION
## Summary
- add `ProfileUpdateRequest` DTO for user profile updates
- introduce `UserProfileDto` and assembler
- map role data inside `UserAccountService`
- use new DTOs in API controllers

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68507d7386888324b1fc8ad4450e380f