### PR TITLE
Add DTOs for certifier validation actions

### DIFF
--- a/equed-lms/Classes/Domain/Service/CertifierServiceInterface.php
+++ b/equed-lms/Classes/Domain/Service/CertifierServiceInterface.php
@@ -16,12 +16,12 @@ interface CertifierServiceInterface
     /**
      * Approve the specified validation record.
      */
-    public function approveValidation(int $recordId, int $certifierId): void;
+    public function approveValidation(\Equed\EquedLms\Dto\ValidationApproveRequest $request): void;
 
     /**
      * Reject the specified validation record with feedback.
      */
-    public function rejectValidation(int $recordId, string $feedback, int $certifierId): void;
+    public function rejectValidation(\Equed\EquedLms\Dto\ValidationRejectRequest $request): void;
 }
 
 // EOF

--- a/equed-lms/Classes/Dto/ValidationApproveRequest.php
+++ b/equed-lms/Classes/Dto/ValidationApproveRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Dto;
+
+use InvalidArgumentException;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class ValidationApproveRequest
+{
+    public function __construct(
+        private readonly int $recordId,
+        private readonly int $certifierId,
+    ) {
+    }
+
+    public static function fromRequest(ServerRequestInterface $request): self
+    {
+        $user = $request->getAttribute('user');
+        $certifierId = is_array($user) && isset($user['uid']) ? (int)$user['uid'] : 0;
+        $body = (array) $request->getParsedBody();
+        $recordId = isset($body['recordId']) ? (int) $body['recordId'] : 0;
+
+        if ($certifierId <= 0 || $recordId <= 0) {
+            throw new InvalidArgumentException('Invalid approval input');
+        }
+
+        return new self($recordId, $certifierId);
+    }
+
+    public function getRecordId(): int
+    {
+        return $this->recordId;
+    }
+
+    public function getCertifierId(): int
+    {
+        return $this->certifierId;
+    }
+}

--- a/equed-lms/Classes/Dto/ValidationRejectRequest.php
+++ b/equed-lms/Classes/Dto/ValidationRejectRequest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Dto;
+
+use InvalidArgumentException;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class ValidationRejectRequest
+{
+    public function __construct(
+        private readonly int $recordId,
+        private readonly string $feedback,
+        private readonly int $certifierId,
+    ) {
+    }
+
+    public static function fromRequest(ServerRequestInterface $request): self
+    {
+        $user = $request->getAttribute('user');
+        $certifierId = is_array($user) && isset($user['uid']) ? (int)$user['uid'] : 0;
+        $body = (array) $request->getParsedBody();
+        $recordId = isset($body['recordId']) ? (int) $body['recordId'] : 0;
+        $feedback = isset($body['feedback']) ? trim((string) $body['feedback']) : '';
+
+        if ($certifierId <= 0 || $recordId <= 0 || $feedback === '') {
+            throw new InvalidArgumentException('Invalid rejection input');
+        }
+
+        return new self($recordId, $feedback, $certifierId);
+    }
+
+    public function getRecordId(): int
+    {
+        return $this->recordId;
+    }
+
+    public function getFeedback(): string
+    {
+        return $this->feedback;
+    }
+
+    public function getCertifierId(): int
+    {
+        return $this->certifierId;
+    }
+}


### PR DESCRIPTION
## Summary
- create `ValidationApproveRequest` and `ValidationRejectRequest` DTOs
- change `CertifierServiceInterface` to accept those DTOs
- update `CertifierController` to use the new DTOs

## Testing
- `composer test` *(fails: Cannot declare interface UuidGeneratorInterface)*
- `composer test` in `equed-core` *(fails: vendor/bin/phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_685080616d1c8324b20f4555e86df8c2