### PR TITLE
Add validated DTOs for QMS API

### DIFF
--- a/equed-lms/Classes/Controller/Api/QmsController.php
+++ b/equed-lms/Classes/Controller/Api/QmsController.php
@@ -11,6 +11,9 @@ use Equed\EquedLms\Controller\Api\BaseApiController;
 use Equed\EquedLms\Domain\Service\ApiResponseServiceInterface;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 use Equed\EquedLms\Service\QmsApiService;
+use Equed\EquedLms\Dto\QmsSubmitRequest;
+use Equed\EquedLms\Dto\QmsRespondRequest;
+use Equed\EquedLms\Dto\QmsCloseRequest;
 
 /**
  * API controller for managing QMS cases.
@@ -58,17 +61,13 @@ final class QmsController extends BaseApiController
             return $check;
         }
 
-        $userId = $this->getCurrentUserId($request);
-        $body = (array)$request->getParsedBody();
-        $recordId = (int)($body['recordId'] ?? 0);
-        $message  = trim((string)($body['message'] ?? ''));
-        $type     = trim((string)($body['type'] ?? 'general'));
-
-        if ($userId === null || $recordId <= 0 || $message === '') {
+        try {
+            $dto = QmsSubmitRequest::fromRequest($request);
+        } catch (\InvalidArgumentException) {
             return $this->jsonError('api.qms.invalidInput', JsonResponse::HTTP_BAD_REQUEST);
         }
 
-        $this->qmsService->submitCase($userId, $recordId, $message, $type);
+        $this->qmsService->submitCase($dto);
 
         return $this->jsonSuccess([], 'api.qms.submitted');
     }
@@ -82,17 +81,13 @@ final class QmsController extends BaseApiController
             return $check;
         }
 
-        $userId = $this->getCurrentUserId($request);
-        $body = (array)$request->getParsedBody();
-        $qmsId    = (int)($body['qmsId'] ?? 0);
-        $response = trim((string)($body['response'] ?? ''));
-        $role     = trim((string)($body['role'] ?? 'certifier'));
-
-        if ($userId === null || $qmsId <= 0 || $response === '') {
+        try {
+            $dto = QmsRespondRequest::fromRequest($request);
+        } catch (\InvalidArgumentException) {
             return $this->jsonError('api.qms.invalidInput', JsonResponse::HTTP_BAD_REQUEST);
         }
 
-        $this->qmsService->respondToCase($userId, $qmsId, $response, $role);
+        $this->qmsService->respondToCase($dto);
 
         return $this->jsonSuccess([], 'api.qms.responded');
     }
@@ -106,15 +101,13 @@ final class QmsController extends BaseApiController
             return $check;
         }
 
-        $userId = $this->getCurrentUserId($request);
-        $body = (array)$request->getParsedBody();
-        $qmsId = (int)($body['qmsId'] ?? 0);
-
-        if ($userId === null || $qmsId <= 0) {
+        try {
+            $dto = QmsCloseRequest::fromRequest($request);
+        } catch (\InvalidArgumentException) {
             return $this->jsonError('api.qms.invalidInput', JsonResponse::HTTP_BAD_REQUEST);
         }
 
-        $this->qmsService->closeCase($userId, $qmsId);
+        $this->qmsService->closeCase($dto);
 
         return $this->jsonSuccess([], 'api.qms.closed');
     }

--- a/equed-lms/Classes/Dto/QmsCloseRequest.php
+++ b/equed-lms/Classes/Dto/QmsCloseRequest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Dto;
+
+use InvalidArgumentException;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class QmsCloseRequest
+{
+    public function __construct(
+        private readonly int $userId,
+        private readonly int $caseId,
+    ) {
+    }
+
+    public static function fromRequest(ServerRequestInterface $request): self
+    {
+        $user = $request->getAttribute('user');
+        $userId = is_array($user) && isset($user['uid']) ? (int)$user['uid'] : 0;
+        $body = (array) $request->getParsedBody();
+
+        $caseId = isset($body['qmsId']) ? (int)$body['qmsId'] : 0;
+
+        if ($userId <= 0 || $caseId <= 0) {
+            throw new InvalidArgumentException('Invalid QMS close input');
+        }
+
+        return new self($userId, $caseId);
+    }
+
+    public function getUserId(): int
+    {
+        return $this->userId;
+    }
+
+    public function getCaseId(): int
+    {
+        return $this->caseId;
+    }
+}

--- a/equed-lms/Classes/Dto/QmsRespondRequest.php
+++ b/equed-lms/Classes/Dto/QmsRespondRequest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Dto;
+
+use InvalidArgumentException;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class QmsRespondRequest
+{
+    public function __construct(
+        private readonly int $userId,
+        private readonly int $caseId,
+        private readonly string $response,
+        private readonly string $role = 'certifier',
+    ) {
+    }
+
+    public static function fromRequest(ServerRequestInterface $request): self
+    {
+        $user = $request->getAttribute('user');
+        $userId = is_array($user) && isset($user['uid']) ? (int)$user['uid'] : 0;
+        $body = (array) $request->getParsedBody();
+
+        $caseId   = isset($body['qmsId']) ? (int)$body['qmsId'] : 0;
+        $response = isset($body['response']) ? trim((string)$body['response']) : '';
+        $role     = isset($body['role']) ? trim((string)$body['role']) : 'certifier';
+
+        if ($userId <= 0 || $caseId <= 0 || $response === '') {
+            throw new InvalidArgumentException('Invalid QMS response input');
+        }
+
+        return new self($userId, $caseId, $response, $role);
+    }
+
+    public function getUserId(): int
+    {
+        return $this->userId;
+    }
+
+    public function getCaseId(): int
+    {
+        return $this->caseId;
+    }
+
+    public function getResponse(): string
+    {
+        return $this->response;
+    }
+
+    public function getRole(): string
+    {
+        return $this->role;
+    }
+}

--- a/equed-lms/Classes/Dto/QmsSubmitRequest.php
+++ b/equed-lms/Classes/Dto/QmsSubmitRequest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Dto;
+
+use InvalidArgumentException;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class QmsSubmitRequest
+{
+    public function __construct(
+        private readonly int $userId,
+        private readonly int $recordId,
+        private readonly string $message,
+        private readonly string $type = 'general',
+    ) {
+    }
+
+    public static function fromRequest(ServerRequestInterface $request): self
+    {
+        $user = $request->getAttribute('user');
+        $userId = is_array($user) && isset($user['uid']) ? (int)$user['uid'] : 0;
+        $body = (array) $request->getParsedBody();
+
+        $recordId = isset($body['recordId']) ? (int)$body['recordId'] : 0;
+        $message  = isset($body['message']) ? trim((string)$body['message']) : '';
+        $type     = isset($body['type']) ? trim((string)$body['type']) : 'general';
+
+        if ($userId <= 0 || $recordId <= 0 || $message === '') {
+            throw new InvalidArgumentException('Invalid QMS submit input');
+        }
+
+        return new self($userId, $recordId, $message, $type);
+    }
+
+    public function getUserId(): int
+    {
+        return $this->userId;
+    }
+
+    public function getRecordId(): int
+    {
+        return $this->recordId;
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+}

--- a/equed-lms/Classes/Service/QmsApiService.php
+++ b/equed-lms/Classes/Service/QmsApiService.php
@@ -7,6 +7,9 @@ namespace Equed\EquedLms\Service;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use Equed\EquedLms\Domain\Service\ClockInterface;
+use Equed\EquedLms\Dto\QmsSubmitRequest;
+use Equed\EquedLms\Dto\QmsRespondRequest;
+use Equed\EquedLms\Dto\QmsCloseRequest;
 
 /**
  * Simple DB-driven operations for QMS API endpoints.
@@ -38,17 +41,17 @@ final class QmsApiService
         return $qb->executeQuery()->fetchAllAssociative();
     }
 
-    public function submitCase(int $userId, int $recordId, string $message, string $type = 'general'): void
+    public function submitCase(QmsSubmitRequest $dto): void
     {
         $now = $this->clock->now()->getTimestamp();
         $this->connectionPool->getConnectionForTable('tx_equedlms_domain_model_qms')
             ->insert(
                 'tx_equedlms_domain_model_qms',
                 [
-                    'usercourserecord' => $recordId,
-                    'submitted_by'     => $userId,
-                    'type'             => $type,
-                    'message'          => $message,
+                    'usercourserecord' => $dto->getRecordId(),
+                    'submitted_by'     => $dto->getUserId(),
+                    'type'             => $dto->getType(),
+                    'message'          => $dto->getMessage(),
                     'status'           => 'open',
                     'submitted_at'     => $now,
                     'tstamp'           => $now,
@@ -57,25 +60,25 @@ final class QmsApiService
             );
     }
 
-    public function respondToCase(int $userId, int $caseId, string $response, string $role = 'certifier'): void
+    public function respondToCase(QmsRespondRequest $dto): void
     {
         $now = $this->clock->now()->getTimestamp();
         $this->connectionPool->getConnectionForTable('tx_equedlms_domain_model_qms')
             ->update(
                 'tx_equedlms_domain_model_qms',
                 [
-                    'response'       => $response,
-                    'responded_by'   => $userId,
-                    'responded_role' => $role,
+                    'response'       => $dto->getResponse(),
+                    'responded_by'   => $dto->getUserId(),
+                    'responded_role' => $dto->getRole(),
                     'responded_at'   => $now,
                     'status'         => 'responded',
                     'tstamp'         => $now,
                 ],
-                ['uid' => $caseId]
+                ['uid' => $dto->getCaseId()]
             );
     }
 
-    public function closeCase(int $userId, int $caseId): void
+    public function closeCase(QmsCloseRequest $dto): void
     {
         $now = $this->clock->now()->getTimestamp();
         $this->connectionPool->getConnectionForTable('tx_equedlms_domain_model_qms')
@@ -83,11 +86,11 @@ final class QmsApiService
                 'tx_equedlms_domain_model_qms',
                 [
                     'status'    => 'closed',
-                    'closed_by' => $userId,
+                    'closed_by' => $dto->getUserId(),
                     'closed_at' => $now,
                     'tstamp'    => $now,
                 ],
-                ['uid' => $caseId]
+                ['uid' => $dto->getCaseId()]
             );
     }
 


### PR DESCRIPTION
## Summary
- introduce `QmsSubmitRequest`, `QmsRespondRequest` and `QmsCloseRequest`
- inject these DTOs into `QmsApiService`
- parse DTOs in controller actions and handle validation errors

## Testing
- `composer phpstan` *(fails: Invalid escaping sequence in baseline)*
- `composer test` *(fails: missing PHP extensions)*

------
https://chatgpt.com/codex/tasks/task_e_685084f6c0548324980cb0f645c3f571