### PR TITLE
Remove parent constructors in controllers

### DIFF
--- a/equed-lms/Classes/Controller/Api/AppCertificateController.php
+++ b/equed-lms/Classes/Controller/Api/AppCertificateController.php
@@ -30,7 +30,6 @@ final class AppCertificateController extends BaseApiController
         ApiResponseServiceInterface $apiResponseService,
         GptTranslationServiceInterface $translationService,
     ) {
-        parent::__construct($configurationService, $apiResponseService, $translationService);
     }
 
     /**
@@ -71,4 +70,3 @@ final class AppCertificateController extends BaseApiController
         return $this->jsonSuccess(['file_path' => $filePath]);
     }
 }
-// End of file

--- a/equed-lms/Classes/Controller/Api/AppLessonController.php
+++ b/equed-lms/Classes/Controller/Api/AppLessonController.php
@@ -27,7 +27,6 @@ final class AppLessonController extends BaseApiController
         ApiResponseServiceInterface                   $apiResponseService,
         GptTranslationServiceInterface                $translationService,
     ) {
-        parent::__construct($configurationService, $apiResponseService, $translationService);
     }
 
     /**
@@ -56,4 +55,3 @@ final class AppLessonController extends BaseApiController
         return $this->jsonSuccess(['lesson' => $data]);
     }
 }
-// EOF

--- a/equed-lms/Classes/Controller/Api/AppLoginController.php
+++ b/equed-lms/Classes/Controller/Api/AppLoginController.php
@@ -28,7 +28,6 @@ final class AppLoginController extends BaseApiController
         ApiResponseServiceInterface                    $apiResponseService,
         GptTranslationServiceInterface                 $translationService
     ) {
-        parent::__construct($configurationService, $apiResponseService, $translationService);
     }
 
     /**
@@ -69,4 +68,3 @@ final class AppLoginController extends BaseApiController
         ]);
     }
 }
-// End of file

--- a/equed-lms/Classes/Controller/Api/AppMaterialController.php
+++ b/equed-lms/Classes/Controller/Api/AppMaterialController.php
@@ -27,7 +27,6 @@ final class AppMaterialController extends BaseApiController
         ApiResponseServiceInterface              $apiResponseService,
         GptTranslationServiceInterface           $translationService,
     ) {
-        parent::__construct($configurationService, $apiResponseService, $translationService);
     }
 
     /**
@@ -58,4 +57,3 @@ final class AppMaterialController extends BaseApiController
         ]);
     }
 }
-// EOF

--- a/equed-lms/Classes/Controller/Api/AppSyncController.php
+++ b/equed-lms/Classes/Controller/Api/AppSyncController.php
@@ -27,7 +27,6 @@ final class AppSyncController extends BaseApiController
         ApiResponseServiceInterface $apiResponseService,
         GptTranslationServiceInterface $translationService,
     ) {
-        parent::__construct($configurationService, $apiResponseService, $translationService);
     }
 
     /**
@@ -86,4 +85,3 @@ final class AppSyncController extends BaseApiController
         ]);
     }
 }
-// EOF

--- a/equed-lms/Classes/Controller/Api/AppUploadController.php
+++ b/equed-lms/Classes/Controller/Api/AppUploadController.php
@@ -28,7 +28,6 @@ final class AppUploadController extends BaseApiController
         ApiResponseServiceInterface $apiResponseService,
         GptTranslationServiceInterface $translationService,
     ) {
-        parent::__construct($configurationService, $apiResponseService, $translationService);
     }
 
     /**
@@ -65,4 +64,3 @@ final class AppUploadController extends BaseApiController
         ]);
     }
 }
-// End of file

--- a/equed-lms/Classes/Controller/Api/AppUserController.php
+++ b/equed-lms/Classes/Controller/Api/AppUserController.php
@@ -27,7 +27,6 @@ final class AppUserController extends BaseApiController
         ApiResponseServiceInterface                      $apiResponseService,
         GptTranslationServiceInterface                   $translationService,
     ) {
-        parent::__construct($configurationService, $apiResponseService, $translationService);
     }
 
     /**
@@ -56,4 +55,3 @@ final class AppUserController extends BaseApiController
         return $this->jsonSuccess($profile->jsonSerialize());
     }
 }
-// End of file

--- a/equed-lms/Classes/Controller/Api/AuditController.php
+++ b/equed-lms/Classes/Controller/Api/AuditController.php
@@ -22,7 +22,6 @@ final class AuditController extends ActionController
         private readonly AuditLogRepositoryInterface     $auditLogRepository,
         private readonly GptTranslationServiceInterface  $translationService,
     ) {
-        parent::__construct();
     }
 
     /**
@@ -45,4 +44,3 @@ final class AuditController extends ActionController
         return $this->htmlResponse();
     }
 }
-// EOF

--- a/equed-lms/Classes/Controller/Api/AuthController.php
+++ b/equed-lms/Classes/Controller/Api/AuthController.php
@@ -28,7 +28,6 @@ final class AuthController extends BaseApiController
         ApiResponseServiceInterface                    $apiResponseService,
         GptTranslationServiceInterface                 $translationService,
     ) {
-        parent::__construct($configurationService, $apiResponseService, $translationService);
     }
 
     /**
@@ -120,4 +119,3 @@ final class AuthController extends BaseApiController
         ]);
     }
 }
-// End of file

--- a/equed-lms/Classes/Controller/Api/BadgeController.php
+++ b/equed-lms/Classes/Controller/Api/BadgeController.php
@@ -20,9 +20,7 @@ final class BadgeController extends ActionController
     public function __construct(
         private readonly BadgeAwardRepositoryInterface  $awardRepository,
         private readonly GptTranslationServiceInterface $translationService,
-
     ) {
-        parent::__construct();
     }
 
     /**
@@ -47,4 +45,3 @@ final class BadgeController extends ActionController
         return $this->htmlResponse();
     }
 }
-// End of file

--- a/equed-lms/Classes/Controller/Api/BaseApiController.php
+++ b/equed-lms/Classes/Controller/Api/BaseApiController.php
@@ -21,7 +21,6 @@ abstract class BaseApiController extends ActionController
         protected readonly ApiResponseServiceInterface $apiResponseService,
         protected readonly GptTranslationServiceInterface $translationService
     ) {
-        parent::__construct();
     }
 
     /**
@@ -72,5 +71,3 @@ abstract class BaseApiController extends ActionController
         return new JsonResponse($payload, $status);
     }
 }
-
-// EOF

--- a/equed-lms/Classes/Controller/Api/CertificateController.php
+++ b/equed-lms/Classes/Controller/Api/CertificateController.php
@@ -33,7 +33,6 @@ final class CertificateController extends BaseApiController
         ApiResponseServiceInterface                    $apiResponseService,
         GptTranslationServiceInterface                 $translationService,
     ) {
-        parent::__construct($configurationService, $apiResponseService, $translationService);
     }
 
     /**
@@ -131,5 +130,3 @@ final class CertificateController extends BaseApiController
         ]);
     }
 }
-// End of file
-

--- a/equed-lms/Classes/Controller/Api/CertifierController.php
+++ b/equed-lms/Classes/Controller/Api/CertifierController.php
@@ -29,7 +29,6 @@ final class CertifierController extends BaseApiController
         ApiResponseServiceInterface $apiResponseService,
         GptTranslationServiceInterface $translationService,
     ) {
-        parent::__construct($configurationService, $apiResponseService, $translationService);
     }
 
     /**
@@ -109,4 +108,3 @@ final class CertifierController extends BaseApiController
         ]);
     }
 }
-// EOF

--- a/equed-lms/Classes/Controller/Api/CourseAccessController.php
+++ b/equed-lms/Classes/Controller/Api/CourseAccessController.php
@@ -30,7 +30,6 @@ final class CourseAccessController extends BaseApiController
         GptTranslationServiceInterface $translationService,
         private readonly Context $context,
     ) {
-        parent::__construct($configurationService, $apiResponseService, $translationService);
     }
 
     /**
@@ -63,4 +62,3 @@ final class CourseAccessController extends BaseApiController
         ]);
     }
 }
-// End of file

--- a/equed-lms/Classes/Controller/Api/CourseAccessMapController.php
+++ b/equed-lms/Classes/Controller/Api/CourseAccessMapController.php
@@ -27,7 +27,6 @@ final class CourseAccessMapController extends BaseApiController
         ApiResponseServiceInterface $apiResponseService,
         GptTranslationServiceInterface $translationService,
     ) {
-        parent::__construct($configurationService, $apiResponseService, $translationService);
     }
 
     /**
@@ -50,4 +49,3 @@ final class CourseAccessMapController extends BaseApiController
         ]);
     }
 }
-// EOF

--- a/equed-lms/Classes/Controller/Api/CourseBookingController.php
+++ b/equed-lms/Classes/Controller/Api/CourseBookingController.php
@@ -26,7 +26,6 @@ final class CourseBookingController extends BaseApiController
         ApiResponseServiceInterface $apiResponseService,
         GptTranslationServiceInterface $translationService,
     ) {
-        parent::__construct($configurationService, $apiResponseService, $translationService);
     }
 
     /**
@@ -60,4 +59,3 @@ final class CourseBookingController extends BaseApiController
         return $this->jsonSuccess([], 'api.courseBooking.success');
     }
 }
-// End of file

--- a/equed-lms/Classes/Controller/Api/CourseBundleController.php
+++ b/equed-lms/Classes/Controller/Api/CourseBundleController.php
@@ -27,7 +27,6 @@ final class CourseBundleController extends BaseApiController
         ApiResponseServiceInterface $apiResponseService,
         GptTranslationServiceInterface $translationService,
     ) {
-        parent::__construct($configurationService, $apiResponseService, $translationService);
     }
 
     /**
@@ -52,4 +51,3 @@ final class CourseBundleController extends BaseApiController
         return $this->jsonSuccess(['bundles' => $bundles]);
     }
 }
-// End of file

--- a/equed-lms/Classes/Controller/Api/CourseGoalController.php
+++ b/equed-lms/Classes/Controller/Api/CourseGoalController.php
@@ -27,7 +27,6 @@ final class CourseGoalController extends BaseApiController
         ApiResponseServiceInterface $apiResponseService,
         GptTranslationServiceInterface $translationService,
     ) {
-        parent::__construct($configurationService, $apiResponseService, $translationService);
     }
 
     /**
@@ -77,4 +76,3 @@ final class CourseGoalController extends BaseApiController
         ]);
     }
 }
-// EOF

--- a/equed-lms/Classes/Controller/Api/CourseOverviewController.php
+++ b/equed-lms/Classes/Controller/Api/CourseOverviewController.php
@@ -28,7 +28,6 @@ final class CourseOverviewController extends BaseApiController
         ApiResponseServiceInterface $apiResponseService,
         GptTranslationServiceInterface $translationService,
     ) {
-        parent::__construct($configurationService, $apiResponseService, $translationService);
     }
 
     /**
@@ -54,4 +53,3 @@ final class CourseOverviewController extends BaseApiController
         return $this->jsonSuccess($overview);
     }
 }
-// End of file

--- a/equed-lms/Classes/Controller/Api/DashboardApiController.php
+++ b/equed-lms/Classes/Controller/Api/DashboardApiController.php
@@ -29,7 +29,6 @@ final class DashboardApiController extends BaseApiController
         ApiResponseServiceInterface                     $apiResponseService,
         GptTranslationServiceInterface                  $translationService,
     ) {
-        parent::__construct($configurationService, $apiResponseService, $translationService);
     }
 
     /**
@@ -63,4 +62,3 @@ final class DashboardApiController extends BaseApiController
         ]);
     }
 }
-// End of file

--- a/equed-lms/Classes/Controller/Api/ExamController.php
+++ b/equed-lms/Classes/Controller/Api/ExamController.php
@@ -27,7 +27,6 @@ final class ExamController extends BaseApiController
         ApiResponseServiceInterface                    $apiResponseService,
         GptTranslationServiceInterface                 $translationService,
     ) {
-        parent::__construct($configurationService, $apiResponseService, $translationService);
     }
 
     /**
@@ -85,4 +84,3 @@ final class ExamController extends BaseApiController
         return $this->jsonSuccess($result);
     }
 }
-// EOF

--- a/equed-lms/Classes/Controller/Api/FeedbackController.php
+++ b/equed-lms/Classes/Controller/Api/FeedbackController.php
@@ -28,7 +28,6 @@ final class FeedbackController extends BaseApiController
         ApiResponseServiceInterface $apiResponseService,
         GptTranslationServiceInterface $translationService,
     ) {
-        parent::__construct($configurationService, $apiResponseService, $translationService);
     }
 
     /**
@@ -91,4 +90,3 @@ final class FeedbackController extends BaseApiController
         ]);
     }
 }
-// EOF

--- a/equed-lms/Classes/Controller/Api/InstructorActionController.php
+++ b/equed-lms/Classes/Controller/Api/InstructorActionController.php
@@ -27,7 +27,6 @@ final class InstructorActionController extends BaseApiController
         ApiResponseServiceInterface             $apiResponseService,
         GptTranslationServiceInterface          $translationService,
     ) {
-        parent::__construct($configurationService, $apiResponseService, $translationService);
     }
 
     /**
@@ -95,4 +94,3 @@ final class InstructorActionController extends BaseApiController
         return $this->jsonSuccess([], 'api.instructor.evaluationUploaded');
     }
 }
-// EOF

--- a/equed-lms/Classes/Controller/Api/InstructorDashboardController.php
+++ b/equed-lms/Classes/Controller/Api/InstructorDashboardController.php
@@ -29,7 +29,6 @@ final class InstructorDashboardController extends BaseApiController
         ApiResponseServiceInterface         $apiResponseService,
         GptTranslationServiceInterface      $translationService,
     ) {
-        parent::__construct($configurationService, $apiResponseService, $translationService);
     }
 
     /**
@@ -58,4 +57,3 @@ final class InstructorDashboardController extends BaseApiController
         ]);
     }
 }
-// End of file

--- a/equed-lms/Classes/Controller/Api/LessonController.php
+++ b/equed-lms/Classes/Controller/Api/LessonController.php
@@ -25,7 +25,6 @@ final class LessonController extends BaseApiController
         ApiResponseServiceInterface $apiResponseService,
         GptTranslationServiceInterface $translationService,
     ) {
-        parent::__construct($configurationService, $apiResponseService, $translationService);
     }
 
     public function exportAction(ServerRequestInterface $request): JsonResponse

--- a/equed-lms/Classes/Controller/Api/LessonProgressController.php
+++ b/equed-lms/Classes/Controller/Api/LessonProgressController.php
@@ -28,7 +28,6 @@ final class LessonProgressController extends BaseApiController
         ApiResponseServiceInterface $apiResponseService,
         GptTranslationServiceInterface $translationService,
     ) {
-        parent::__construct($configurationService, $apiResponseService, $translationService);
     }
 
     /**
@@ -91,4 +90,3 @@ final class LessonProgressController extends BaseApiController
         ]);
     }
 }
-// End of file

--- a/equed-lms/Classes/Controller/Api/NotificationController.php
+++ b/equed-lms/Classes/Controller/Api/NotificationController.php
@@ -27,7 +27,6 @@ final class NotificationController extends BaseApiController
         ApiResponseServiceInterface     $apiResponseService,
         GptTranslationServiceInterface  $translationService,
     ) {
-        parent::__construct($configurationService, $apiResponseService, $translationService);
     }
 
     /**
@@ -76,4 +75,3 @@ final class NotificationController extends BaseApiController
         return $this->jsonSuccess([], 'api.notifications.markedAsRead');
     }
 }
-// End of file

--- a/equed-lms/Classes/Controller/Api/ProgressApiController.php
+++ b/equed-lms/Classes/Controller/Api/ProgressApiController.php
@@ -27,7 +27,6 @@ final class ProgressApiController extends BaseApiController
         ApiResponseServiceInterface                    $apiResponseService,
         GptTranslationServiceInterface                 $translationService,
     ) {
-        parent::__construct($configurationService, $apiResponseService, $translationService);
     }
 
     /**
@@ -61,4 +60,3 @@ final class ProgressApiController extends BaseApiController
         return $this->jsonSuccess($data);
     }
 }
-// End of file

--- a/equed-lms/Classes/Controller/Api/ProgressController.php
+++ b/equed-lms/Classes/Controller/Api/ProgressController.php
@@ -27,7 +27,6 @@ final class ProgressController extends BaseApiController
         ApiResponseServiceInterface $apiResponseService,
         GptTranslationServiceInterface $translationService,
     ) {
-        parent::__construct($configurationService, $apiResponseService, $translationService);
     }
 
     /**
@@ -58,4 +57,3 @@ final class ProgressController extends BaseApiController
         return $this->jsonSuccess(['progress' => $progress]);
     }
 }
-// EOF

--- a/equed-lms/Classes/Controller/Api/QmsController.php
+++ b/equed-lms/Classes/Controller/Api/QmsController.php
@@ -30,7 +30,6 @@ final class QmsController extends BaseApiController
         ApiResponseServiceInterface $apiResponseService,
         GptTranslationServiceInterface $translationService,
     ) {
-        parent::__construct($configurationService, $apiResponseService, $translationService);
     }
 
     /**
@@ -112,4 +111,3 @@ final class QmsController extends BaseApiController
         return $this->jsonSuccess([], 'api.qms.closed');
     }
 }
-// EOF

--- a/equed-lms/Classes/Controller/Api/RecognitionAwardController.php
+++ b/equed-lms/Classes/Controller/Api/RecognitionAwardController.php
@@ -27,7 +27,6 @@ final class RecognitionAwardController extends BaseApiController
         ApiResponseServiceInterface $apiResponseService,
         GptTranslationServiceInterface $translationService,
     ) {
-        parent::__construct($configurationService, $apiResponseService, $translationService);
     }
 
     public function listMyAwardsAction(ServerRequestInterface $request): JsonResponse

--- a/equed-lms/Classes/Controller/Api/SearchController.php
+++ b/equed-lms/Classes/Controller/Api/SearchController.php
@@ -24,7 +24,6 @@ final class SearchController extends BaseApiController
         ApiResponseServiceInterface $apiResponseService,
         GptTranslationServiceInterface $translationService,
     ) {
-        parent::__construct($configurationService, $apiResponseService, $translationService);
     }
 
     public function searchAction(ServerRequestInterface $request): JsonResponse

--- a/equed-lms/Classes/Controller/Api/ServiceCenterController.php
+++ b/equed-lms/Classes/Controller/Api/ServiceCenterController.php
@@ -26,7 +26,6 @@ final class ServiceCenterController extends BaseApiController
         ApiResponseServiceInterface $apiResponseService,
         GptTranslationServiceInterface $translationService,
     ) {
-        parent::__construct($configurationService, $apiResponseService, $translationService);
     }
 
     public function listQmsCasesAction(ServerRequestInterface $request): JsonResponse

--- a/equed-lms/Classes/Controller/Api/ServiceCenterDashboardApiController.php
+++ b/equed-lms/Classes/Controller/Api/ServiceCenterDashboardApiController.php
@@ -25,7 +25,6 @@ final class ServiceCenterDashboardApiController extends BaseApiController
         ApiResponseServiceInterface $apiResponseService,
         GptTranslationServiceInterface $translationService,
     ) {
-        parent::__construct($configurationService, $apiResponseService, $translationService);
     }
 
     public function showAction(ServerRequestInterface $request): JsonResponse

--- a/equed-lms/Classes/Controller/Api/SubmissionController.php
+++ b/equed-lms/Classes/Controller/Api/SubmissionController.php
@@ -24,7 +24,6 @@ use Equed\EquedLms\Dto\SubmissionEvaluateRequest;
  */
 final class SubmissionController extends BaseApiController
 {
-
     public function __construct(
         private readonly UserSubmissionRepositoryInterface $submissionRepository,
         private readonly SubmissionService $submissionService,
@@ -33,7 +32,6 @@ final class SubmissionController extends BaseApiController
         GptTranslationServiceInterface $translationService,
         private readonly AccessHelper $accessHelper,
     ) {
-        parent::__construct($configurationService, $apiResponseService, $translationService);
     }
 
     /**
@@ -134,4 +132,3 @@ final class SubmissionController extends BaseApiController
         return $this->jsonSuccess([], 'api.submission.evaluated');
     }
 }
-// EOF

--- a/equed-lms/Classes/Controller/Api/SubmissionRestController.php
+++ b/equed-lms/Classes/Controller/Api/SubmissionRestController.php
@@ -20,7 +20,6 @@ final class SubmissionRestController extends BaseApiController
         ApiResponseServiceInterface $apiResponseService,
         GptTranslationServiceInterface $translationService,
     ) {
-        parent::__construct($configurationService, $apiResponseService, $translationService);
     }
 
     public function exportAction(ServerRequestInterface $request): JsonResponse

--- a/equed-lms/Classes/Controller/Api/SyncController.php
+++ b/equed-lms/Classes/Controller/Api/SyncController.php
@@ -23,7 +23,6 @@ final class SyncController extends BaseApiController
         GptTranslationServiceInterface $translationService,
         private readonly AccessHelper $accessHelper,
     ) {
-        parent::__construct($configurationService, $apiResponseService, $translationService);
     }
 
     public function pushAction(ServerRequestInterface $request): JsonResponse

--- a/equed-lms/Classes/Controller/Api/UserCourseRecordController.php
+++ b/equed-lms/Classes/Controller/Api/UserCourseRecordController.php
@@ -26,7 +26,6 @@ final class UserCourseRecordController extends BaseApiController
         ApiResponseServiceInterface $apiResponseService,
         GptTranslationServiceInterface $translationService,
     ) {
-        parent::__construct($configurationService, $apiResponseService, $translationService);
     }
 
     /**
@@ -104,4 +103,3 @@ final class UserCourseRecordController extends BaseApiController
         return $this->jsonSuccess([], 'api.userCourseRecord.deleted');
     }
 }
-// End of file

--- a/equed-lms/Classes/Controller/Api/UserProfileController.php
+++ b/equed-lms/Classes/Controller/Api/UserProfileController.php
@@ -26,7 +26,6 @@ final class UserProfileController extends BaseApiController
         ApiResponseServiceInterface $apiResponseService,
         GptTranslationServiceInterface $translationService,
     ) {
-        parent::__construct($configurationService, $apiResponseService, $translationService);
     }
 
     /**
@@ -76,4 +75,3 @@ final class UserProfileController extends BaseApiController
         return $this->jsonSuccess([], 'api.userProfile.updated');
     }
 }
-// End of file

--- a/equed-lms/Classes/Controller/Api/UserProgressController.php
+++ b/equed-lms/Classes/Controller/Api/UserProgressController.php
@@ -19,14 +19,12 @@ use Equed\EquedLms\Service\GptTranslationServiceInterface;
  */
 final class UserProgressController extends BaseApiController
 {
-
     public function __construct(
         private readonly ProgressServiceInterface $progressService,
         ConfigurationServiceInterface $configurationService,
         ApiResponseServiceInterface $apiResponseService,
         GptTranslationServiceInterface $translationService,
     ) {
-        parent::__construct($configurationService, $apiResponseService, $translationService);
     }
 
     /**
@@ -70,4 +68,3 @@ final class UserProgressController extends BaseApiController
         return $this->jsonSuccess(['progress' => $data]);
     }
 }
-// EOF

--- a/equed-lms/Classes/Controller/CourseController.php
+++ b/equed-lms/Classes/Controller/CourseController.php
@@ -20,7 +20,6 @@ final class CourseController extends ActionController
     public function __construct(
         private readonly CourseProgressServiceInterface $courseProgressService
     ) {
-        parent::__construct();
     }
 
     /**
@@ -51,4 +50,3 @@ final class CourseController extends ActionController
         return $this->htmlResponse();
     }
 }
-// End of file

--- a/equed-lms/Classes/Controller/GlossaryController.php
+++ b/equed-lms/Classes/Controller/GlossaryController.php
@@ -19,7 +19,6 @@ final class GlossaryController extends ActionController
     public function __construct(
         private readonly GlossaryServiceInterface $glossaryService
     ) {
-        parent::__construct();
     }
 
     public function listAction(ServerRequestInterface $request): ResponseInterface
@@ -35,5 +34,5 @@ final class GlossaryController extends ActionController
         ]);
     }
 
-    
+
 }

--- a/equed-lms/Classes/Controller/MaterialController.php
+++ b/equed-lms/Classes/Controller/MaterialController.php
@@ -20,7 +20,6 @@ final class MaterialController extends ActionController
     public function __construct(
         private readonly MaterialListServiceInterface $listService,
     ) {
-        parent::__construct();
     }
 
     /**
@@ -41,4 +40,3 @@ final class MaterialController extends ActionController
         return $this->htmlResponse();
     }
 }
-// End of file

--- a/equed-lms/Classes/Controller/ProfileController.php
+++ b/equed-lms/Classes/Controller/ProfileController.php
@@ -23,7 +23,6 @@ final class ProfileController extends ActionController
         private readonly ProfileService                 $profileService,
         private readonly GptTranslationServiceInterface $translationService
     ) {
-        parent::__construct();
     }
 
     /**
@@ -60,4 +59,3 @@ final class ProfileController extends ActionController
         return $this->htmlResponse();
     }
 }
-// EOF

--- a/equed-lms/Classes/Controller/QuizController.php
+++ b/equed-lms/Classes/Controller/QuizController.php
@@ -23,7 +23,6 @@ final class QuizController extends ActionController
     public function __construct(
         private readonly QuizManagerInterface $quizManager
     ) {
-        parent::__construct();
     }
 
     /**
@@ -104,4 +103,3 @@ final class QuizController extends ActionController
         return $this->htmlResponse();
     }
 }
-// EOF


### PR DESCRIPTION
## Summary
- drop redundant `parent::__construct()` calls in controllers
- clean up trailing file-end comments
- keep code style in sync with `php-cs-fixer`

## Testing
- `php equed-lms/vendor/bin/php-cs-fixer fix --config=equed-lms/.php-cs-fixer.php $(cat /tmp/changed_files.txt)`

------
https://chatgpt.com/codex/tasks/task_e_68508dc6e5fc8324924f813f27395086