### PR TITLE
Remove fe_user from lesson progress

### DIFF
--- a/equed-lms/CHANGELOG.md
+++ b/equed-lms/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 📦 CHANGELOG – EquEd LMS Extension
 
+### [1.1.1] – Lesson progress updates
+
+- Lesson progress now references the related `UserCourseRecord`.
+- Database migration drops the obsolete `fe_user` column.
+
 ### [1.1.0] – Erweiterungen & Vollintegration (SSO, App, QMS)
 
 #### ✅ Neue Features

--- a/equed-lms/Classes/Application/Assembler/LessonProgressDtoAssembler.php
+++ b/equed-lms/Classes/Application/Assembler/LessonProgressDtoAssembler.php
@@ -13,7 +13,7 @@ final class LessonProgressDtoAssembler
     {
         return new LessonProgressDto(
             $progress->getUuid(),
-            $progress->getUserCourseRecord()?->getUser()?->getUid() ?? $progress->getFeUser() ?: null,
+            $progress->getUserCourseRecord()?->getUser()?->getUid(),
             $progress->getLesson()->getUid(),
             $progress->getProgress(),
             $progress->getStatus()->value,

--- a/equed-lms/Classes/Domain/Model/LessonProgress.php
+++ b/equed-lms/Classes/Domain/Model/LessonProgress.php
@@ -18,12 +18,6 @@ use Equed\EquedLms\Domain\Model\UserCourseRecord;
  */
 final class LessonProgress extends AbstractEntity
 {
-    /**
-     * Frontend user identifier
-     *
-     * @deprecated Use $userCourseRecord instead
-     */
-    protected int $feUser = 0;
 
     #[ManyToOne]
     #[Lazy]
@@ -71,21 +65,6 @@ final class LessonProgress extends AbstractEntity
         $this->updatedAt = $now;
     }
 
-    /**
-     * Returns the frontend user UID.
-     */
-    public function getFeUser(): int
-    {
-        return $this->feUser;
-    }
-
-    /**
-     * Sets the frontend user UID.
-     */
-    public function setFeUser(int $feUser): void
-    {
-        $this->feUser = $feUser;
-    }
 
     public function getUserCourseRecord(): ?UserCourseRecord
     {

--- a/equed-lms/Classes/Service/LessonProgressService.php
+++ b/equed-lms/Classes/Service/LessonProgressService.php
@@ -9,6 +9,7 @@ use Equed\EquedLms\Domain\Model\Lesson;
 use Equed\EquedLms\Domain\Model\LessonProgress;
 use Equed\EquedLms\Domain\Repository\LessonProgressRepositoryInterface;
 use Equed\EquedLms\Domain\Repository\LessonRepositoryInterface;
+use Equed\EquedLms\Domain\Repository\UserCourseRecordRepositoryInterface;
 use Equed\EquedLms\Domain\Model\FrontendUser;
 use Equed\EquedLms\Domain\Service\LessonProgressServiceInterface;
 use Equed\EquedLms\Enum\ProgressStatus;
@@ -23,6 +24,7 @@ final class LessonProgressService implements LessonProgressServiceInterface
     public function __construct(
         private readonly LessonProgressRepositoryInterface $progressRepository,
         private readonly LessonRepositoryInterface $lessonRepository,
+        private readonly UserCourseRecordRepositoryInterface $courseRecordRepository,
         private readonly ClockInterface $clock,
         private readonly EventDispatcherInterface $eventDispatcher,
     ) {
@@ -56,7 +58,8 @@ final class LessonProgressService implements LessonProgressServiceInterface
 
         if ($progress === null) {
             $progress = new LessonProgress();
-            $progress->setFeUser((int) $user->getUid());
+            $records = $this->courseRecordRepository->findByUserId((int) $user->getUid());
+            $progress->setUserCourseRecord($records[0] ?? null);
             $progress->setLesson($lesson);
         }
 
@@ -82,7 +85,8 @@ final class LessonProgressService implements LessonProgressServiceInterface
         if ($progress === null) {
             $lesson = $this->lessonRepository->findByUid($lessonId);
             $progress = new LessonProgress();
-            $progress->setFeUser($userId);
+            $records = $this->courseRecordRepository->findByUserId($userId);
+            $progress->setUserCourseRecord($records[0] ?? null);
             if ($lesson instanceof Lesson) {
                 $progress->setLesson($lesson);
             }

--- a/equed-lms/Classes/Service/LessonProgressSyncService.php
+++ b/equed-lms/Classes/Service/LessonProgressSyncService.php
@@ -76,7 +76,6 @@ final class LessonProgressSyncService
             $localUpdated = $entry->getUpdatedAt();
 
             if (!$localUpdated || $remoteUpdated > $localUpdated) {
-                $entry->setFeUser($userId);
                 $entry->setLesson($lesson);
                 $entry->setProgress((int) $item['progress']);
                 $statusValue = $item['status'] ?? 'notStarted';

--- a/equed-lms/Configuration/Schema/Domain/Model/Lessonprogress.yaml
+++ b/equed-lms/Configuration/Schema/Domain/Model/Lessonprogress.yaml
@@ -18,7 +18,7 @@ columns:
     type: integer
   lesson:
     type: integer
-  fe_user:
+  user_course_record:
     type: integer
   progress:
     type: integer

--- a/equed-lms/Configuration/TCA/tx_equedlms_domain_model_lessonprogress.php
+++ b/equed-lms/Configuration/TCA/tx_equedlms_domain_model_lessonprogress.php
@@ -31,7 +31,6 @@ return [
             'l10n_diffsource',
             'hidden',
             'lesson',
-            'fe_user',
             'user_course_record',
             'progress',
             'status',
@@ -112,17 +111,6 @@ return [
                 'maxitems'      => 1,
             ],
         ],
-        'fe_user' => [
-            'exclude' => false,
-            'label'   => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_lessonprogress.fe_user',
-            'config'  => [
-                'type'          => 'select',
-                'renderType'    => 'selectSingle',
-                'foreign_table' => 'fe_users',
-                'minitems'      => 1,
-                'maxitems'      => 1,
-            ],
-        ],
         'user_course_record' => [
             'exclude' => true,
             'label'   => 'LLL:EXT:equed_lms/Resources/Private/Language/locallang_db.xlf:tx_equedlms_domain_model_lessonprogress.user_course_record',
@@ -184,7 +172,7 @@ return [
         '1' => [
             'showitem' => '
                 sys_language_uid, l10n_parent, l10n_diffsource,
-                hidden, lesson, fe_user, user_course_record, progress, status, uuid, created_at, updated_at, completed,
+                hidden, lesson, user_course_record, progress, status, uuid, created_at, updated_at, completed,
                 --div--;LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:tabs.access,
                   starttime, endtime
             ',

--- a/equed-lms/Documentation/PersistedProperties.md
+++ b/equed-lms/Documentation/PersistedProperties.md
@@ -458,7 +458,7 @@
 - updatedAt
 
 ## LessonProgress
-- feUser
+- userCourseRecord
 - lesson
 - progress
 - status

--- a/equed-lms/Migrations/Version20250801019000.php
+++ b/equed-lms/Migrations/Version20250801019000.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250801019000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Drop fe_user column from lesson progress table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        if ($schema->hasTable('tx_equedlms_domain_model_lessonprogress')) {
+            $table = $schema->getTable('tx_equedlms_domain_model_lessonprogress');
+            if ($table->hasColumn('fe_user')) {
+                $table->dropColumn('fe_user');
+            }
+            if (!$table->hasColumn('user_course_record')) {
+                $table->addColumn('user_course_record', 'integer');
+            }
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        if ($schema->hasTable('tx_equedlms_domain_model_lessonprogress')) {
+            $table = $schema->getTable('tx_equedlms_domain_model_lessonprogress');
+            if (!$table->hasColumn('fe_user')) {
+                $table->addColumn('fe_user', 'integer');
+            }
+            if ($table->hasColumn('user_course_record')) {
+                $table->dropColumn('user_course_record');
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- drop `fe_user` from lesson progress data model
- link progress records to the related course record
- note change in changelog
- provide doctrine migration

## Testing
- `composer lint`
- `composer test` *(fails: phpunit not found)*
- `composer phpstan` *(fails: phpstan not found)*
- `composer psalm` *(fails: psalm not found)*

------
https://chatgpt.com/codex/tasks/task_e_685092210424832485a0503f60945469