### PR TITLE
Add service unit tests

### DIFF
--- a/equed-lms/Tests/Unit/Service/AppSyncServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/AppSyncServiceTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Tests\Unit\Service;
+
+use Equed\EquedLms\Service\AppSyncService;
+use PHPUnit\Framework\TestCase;
+
+final class AppSyncServiceTest extends TestCase
+{
+    public function testQueueDataAndFetchPending(): void
+    {
+        $service = new AppSyncService();
+        $service->queueData(1, 'foo', ['a' => 1]);
+        $service->queueData(1, 'bar', ['b' => 2]);
+        $service->queueData(2, 'baz', []);
+
+        $result = $service->fetchPending(1);
+        $this->assertCount(2, $result);
+        $this->assertSame('foo', $result[0]['type']);
+        $this->assertSame(['a' => 1], $result[0]['payload']);
+        $this->assertSame('bar', $result[1]['type']);
+
+        $this->assertSame([], $service->fetchPending(1));
+
+        $other = $service->fetchPending(2);
+        $this->assertCount(1, $other);
+    }
+
+    public function testFetchPendingReturnsEmptyForUnknownUser(): void
+    {
+        $service = new AppSyncService();
+        $this->assertSame([], $service->fetchPending(99));
+    }
+}

--- a/equed-lms/Tests/Unit/Service/ServiceCenterCaseServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/ServiceCenterCaseServiceTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TYPO3\CMS\Core\Database\Query {
+    if (!class_exists(QueryBuilder::class)) {
+        class QueryBuilder
+        {
+            public function select(string $fields): self { return $this; }
+            public function from(string $table): self { return $this; }
+            public function where($expr): self { return $this; }
+            public function orderBy(string $field, string $dir = 'ASC'): self { return $this; }
+            public function expr(): object { return new class { public function eq(string $f, $v) { return [$f, $v]; } }; }
+            public function executeQuery() { return new \Doctrine\DBAL\Result(); }
+        }
+    }
+}
+
+namespace Doctrine\DBAL {
+    if (!class_exists(Result::class)) {
+        class Result { public function fetchAllAssociative(): array { return []; } }
+    }
+}
+
+namespace TYPO3\CMS\Core\Database {
+    if (!class_exists(ConnectionPool::class)) {
+        class ConnectionPool { public function getQueryBuilderForTable(string $table) { return new \TYPO3\CMS\Core\Database\Query\QueryBuilder(); } }
+    }
+}
+
+namespace Equed\EquedLms\Tests\Unit\Service;
+
+use Equed\EquedLms\Service\ServiceCenterCaseService;
+use PHPUnit\Framework\TestCase;
+use Equed\EquedLms\Tests\Traits\ProphecyTrait;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+use Doctrine\DBAL\Result;
+use Prophecy\Argument;
+
+final class ServiceCenterCaseServiceTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testGetQmsCasesReturnsRows(): void
+    {
+        $pool = $this->prophesize(ConnectionPool::class);
+        $qb   = $this->prophesize(QueryBuilder::class);
+        $res  = $this->prophesize(Result::class);
+
+        $pool->getQueryBuilderForTable('tx_equedlms_domain_model_qms')->willReturn($qb->reveal())->shouldBeCalled();
+
+        $expr = new class { public function eq(string $f, $v) { return [$f, $v]; } };
+        $qb->select('*')->willReturn($qb->reveal())->shouldBeCalled();
+        $qb->from('tx_equedlms_domain_model_qms')->willReturn($qb->reveal())->shouldBeCalled();
+        $qb->expr()->willReturn($expr)->shouldBeCalled();
+        $qb->where(Argument::any())->willReturn($qb->reveal())->shouldBeCalled();
+        $qb->orderBy('submitted_at', 'DESC')->willReturn($qb->reveal())->shouldBeCalled();
+        $qb->executeQuery()->willReturn($res->reveal())->shouldBeCalled();
+
+        $rows = [['uid' => 1]];
+        $res->fetchAllAssociative()->willReturn($rows)->shouldBeCalled();
+
+        $service = new ServiceCenterCaseService($pool->reveal());
+        $this->assertSame($rows, $service->getQmsCases());
+    }
+
+    public function testReturnsEmptyArrayWhenNoRows(): void
+    {
+        $pool = $this->prophesize(ConnectionPool::class);
+        $qb   = $this->prophesize(QueryBuilder::class);
+        $res  = $this->prophesize(Result::class);
+
+        $pool->getQueryBuilderForTable('tx_equedlms_domain_model_qms')->willReturn($qb->reveal());
+        $qb->select('*')->willReturn($qb->reveal());
+        $qb->from('tx_equedlms_domain_model_qms')->willReturn($qb->reveal());
+        $qb->expr()->willReturn(new class { public function eq(string $f, $v) { return [$f,$v]; } });
+        $qb->where(Argument::any())->willReturn($qb->reveal());
+        $qb->orderBy('submitted_at', 'DESC')->willReturn($qb->reveal());
+        $qb->executeQuery()->willReturn($res->reveal());
+        $res->fetchAllAssociative()->willReturn([]);
+
+        $service = new ServiceCenterCaseService($pool->reveal());
+        $this->assertSame([], $service->getQmsCases());
+    }
+}

--- a/equed-lms/Tests/Unit/Service/ServiceCenterDashboardServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/ServiceCenterDashboardServiceTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Domain\Model {
+    if (!class_exists(Course::class)) {
+        class Course { public function __construct(private string $title=''){ $this->title=$title; } public function getTitle(): string { return $this->title; } }
+    }
+    if (!class_exists(FrontendUser::class)) {
+        class FrontendUser { public function __construct(private string $name=''){ $this->name=$name; } public function getName(): string { return $this->name; } }
+    }
+    if (!class_exists(Certificate::class)) {
+        class Certificate {
+            public function __construct(private ?Course $course=null, private ?FrontendUser $feUser=null, private ?\DateTimeImmutable $submittedAt=null) {}
+            public function getCourse(): ?Course { return $this->course; }
+            public function getFeUser(): ?FrontendUser { return $this->feUser; }
+            public function getSubmittedAt(): ?\DateTimeImmutable { return $this->submittedAt; }
+        }
+    }
+    if (!class_exists(UserSubmission::class)) {
+        use Equed\EquedLms\Enum\SubmissionStatus;
+        class UserSubmission {
+            public function __construct(private string $type, private ?FrontendUser $user, private SubmissionStatus $status) {}
+            public function getType(): string { return $this->type; }
+            public function getFeUser(): ?FrontendUser { return $this->user; }
+            public function getStatus(): SubmissionStatus { return $this->status; }
+        }
+    }
+    if (!class_exists(QmsCase::class)) {
+        class QmsCase {
+            public function __construct(private string $title, private string $status, private ?\DateTimeImmutable $date) {}
+            public function getTitle(): string { return $this->title; }
+            public function getStatus(): string { return $this->status; }
+            public function getDate(): ?\DateTimeImmutable { return $this->date; }
+        }
+    }
+}
+
+namespace Equed\EquedLms\Domain\Repository {
+    if (!interface_exists(CertificateRepositoryInterface::class)) {
+        interface CertificateRepositoryInterface { public function findPendingByServiceCenter(int $centerId): array; }
+    }
+    if (!interface_exists(UserSubmissionRepositoryInterface::class)) {
+        interface UserSubmissionRepositoryInterface { public function findPendingByServiceCenter(int $centerId): array; }
+    }
+    if (!interface_exists(QmsCaseRepositoryInterface::class)) {
+        interface QmsCaseRepositoryInterface { public function findOpenByServiceCenter(int $centerId): array; }
+    }
+}
+
+namespace Equed\EquedLms\Tests\Unit\Service;
+
+use DateTimeImmutable;
+use Equed\EquedLms\Enum\SubmissionStatus;
+use Equed\EquedLms\Service\ServiceCenterDashboardService;
+use Equed\EquedLms\Domain\Repository\CertificateRepositoryInterface;
+use Equed\EquedLms\Domain\Repository\UserSubmissionRepositoryInterface;
+use Equed\EquedLms\Domain\Repository\QmsCaseRepositoryInterface;
+use Equed\EquedLms\Domain\Service\LanguageServiceInterface;
+use Equed\EquedLms\Domain\Model\Certificate;
+use Equed\EquedLms\Domain\Model\Course;
+use Equed\EquedLms\Domain\Model\FrontendUser;
+use Equed\EquedLms\Domain\Model\UserSubmission;
+use Equed\EquedLms\Domain\Model\QmsCase;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Equed\EquedLms\Tests\Traits\ProphecyTrait;
+
+final class ServiceCenterDashboardServiceTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private $certRepo;
+    private $subRepo;
+    private $qmsRepo;
+    private $lang;
+    private ServiceCenterDashboardService $subject;
+
+    protected function setUp(): void
+    {
+        $this->certRepo = $this->prophesize(CertificateRepositoryInterface::class);
+        $this->subRepo  = $this->prophesize(UserSubmissionRepositoryInterface::class);
+        $this->qmsRepo  = $this->prophesize(QmsCaseRepositoryInterface::class);
+        $this->lang     = $this->prophesize(LanguageServiceInterface::class);
+
+        $this->subject = new ServiceCenterDashboardService(
+            $this->certRepo->reveal(),
+            $this->subRepo->reveal(),
+            $this->qmsRepo->reveal(),
+            $this->lang->reveal(),
+        );
+    }
+
+    public function testMapsEntitiesToDashboardData(): void
+    {
+        $course = new Course('Basics');
+        $user   = new FrontendUser('John');
+        $cert   = new Certificate($course, $user, new DateTimeImmutable('2024-05-01'));
+        $sub    = new UserSubmission('upload', $user, SubmissionStatus::Pending);
+        $case   = new QmsCase('Case A', 'pending', new DateTimeImmutable('2024-04-02'));
+
+        $this->certRepo->findPendingByServiceCenter(5)->willReturn([$cert]);
+        $this->subRepo->findPendingByServiceCenter(5)->willReturn([$sub]);
+        $this->qmsRepo->findOpenByServiceCenter(5)->willReturn([$case]);
+
+        $this->lang->translate('status.pending', Argument::cetera())->willReturn('pending')->shouldBeCalledTimes(2);
+
+        $data = $this->subject->getDashboardDataForServiceCenter(5);
+
+        $this->assertSame(5, $data->getCenterId());
+        $this->assertSame('Basics', $data->getCertificates()[0]['course']);
+        $this->assertSame('John', $data->getCertificates()[0]['user']);
+        $this->assertSame('2024-05-01', $data->getCertificates()[0]['submittedAt']);
+        $this->assertSame('pending', $data->getSubmissions()[0]['status']);
+        $this->assertSame('pending', $data->getQmsCases()[0]['status']);
+    }
+
+    public function testUsesUnknownKeyForUnsupportedStatus(): void
+    {
+        $user = new FrontendUser('Jane');
+        $sub  = new UserSubmission('quiz', $user, SubmissionStatus::Approved);
+        $case = new QmsCase('Case', 'closed', null);
+
+        $this->certRepo->findPendingByServiceCenter(2)->willReturn([]);
+        $this->subRepo->findPendingByServiceCenter(2)->willReturn([$sub]);
+        $this->qmsRepo->findOpenByServiceCenter(2)->willReturn([$case]);
+
+        $this->lang->translate('status.unknown', Argument::cetera())->willReturn('unknown')->shouldBeCalledTimes(2);
+
+        $data = $this->subject->getDashboardDataForServiceCenter(2);
+
+        $this->assertSame('unknown', $data->getSubmissions()[0]['status']);
+        $this->assertSame('unknown', $data->getQmsCases()[0]['status']);
+    }
+}


### PR DESCRIPTION
## Summary
- add AppSyncServiceTest covering queuing behavior
- add ServiceCenterCaseServiceTest verifying DB query build
- add ServiceCenterDashboardServiceTest to map dashboard data

## Testing
- `composer install --no-interaction` *(fails: command not found)*
- `vendor/bin/phpunit --configuration phpunit.xml.dist` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6850ebcc10c883248ca9c7c0d184a96f