### PR TITLE
Introduce SettingsServiceInterface

### DIFF
--- a/equed-lms/Classes/Domain/Service/SettingsServiceInterface.php
+++ b/equed-lms/Classes/Domain/Service/SettingsServiceInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Domain\Service;
+
+/**
+ * Interface for retrieving extension settings.
+ */
+interface SettingsServiceInterface
+{
+    /**
+     * Returns a setting value by key or default if not set.
+     *
+     * @param string $key Setting key
+     * @param mixed $default Default value
+     * @return mixed
+     */
+    public function get(string $key, mixed $default = null): mixed;
+
+    /**
+     * Returns all settings for the extension.
+     *
+     * @return array<string,mixed>
+     */
+    public function all(): array;
+}

--- a/equed-lms/Classes/Service/DocumentService.php
+++ b/equed-lms/Classes/Service/DocumentService.php
@@ -6,7 +6,7 @@ namespace Equed\EquedLms\Service;
 
 use Equed\EquedLms\Exception\InvalidFileTypeException;
 use Equed\EquedLms\Domain\Service\DocumentServiceInterface;
-use Equed\EquedLms\Service\SettingsService;
+use Equed\EquedLms\Domain\Service\SettingsServiceInterface;
 
 /**
  * Service to generate secure download and template URIs for documents.
@@ -18,7 +18,7 @@ final class DocumentService implements DocumentServiceInterface
     public function __construct(
         private readonly string $documentsBaseUri,
         private readonly string $templatesBaseUri,
-        private readonly ?SettingsService $settingsService = null,
+        private readonly ?SettingsServiceInterface $settingsService = null,
         private readonly array $allowedExtensions = self::ALLOWED_EXTENSIONS
     ) {
     }

--- a/equed-lms/Classes/Service/SettingsService.php
+++ b/equed-lms/Classes/Service/SettingsService.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace Equed\EquedLms\Service;
 
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use Equed\EquedLms\Domain\Service\SettingsServiceInterface;
 
 /**
  * Service to retrieve extension settings.
  */
-final class SettingsService
+final class SettingsService implements SettingsServiceInterface
 {
     private readonly array $settings;
     private readonly string $extensionKey;


### PR DESCRIPTION
## Summary
- add `SettingsServiceInterface` in the Domain layer
- make `SettingsService` implement the new interface
- depend on `SettingsServiceInterface` inside `DocumentService`

## Testing
- `php -l equed-lms/Classes/Domain/Service/SettingsServiceInterface.php`
- `php -l equed-lms/Classes/Service/SettingsService.php`
- `php -l equed-lms/Classes/Service/DocumentService.php`
- `php --version`

------
https://chatgpt.com/codex/tasks/task_e_6850f02bef94832498adbdee0b7c7fec