### PR TITLE
Add SearchRepository and refactor SearchService

### DIFF
--- a/equed-lms/Classes/Domain/Repository/SearchRepository.php
+++ b/equed-lms/Classes/Domain/Repository/SearchRepository.php
@@ -1,0 +1,72 @@
+<?php
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Domain\Repository;
+
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use Equed\EquedLms\Dto\CourseSearchResult;
+use Equed\EquedLms\Dto\GlossarySearchResult;
+
+final class SearchRepository implements SearchRepositoryInterface
+{
+    public function __construct(
+        private readonly ConnectionPool $connectionPool
+    ) {
+    }
+
+    public function searchCourses(string $term): array
+    {
+        $qb   = $this->connectionPool->getQueryBuilderForTable('tx_equedlms_domain_model_course');
+        $expr = $qb->expr();
+        $qb->select('uid', 'title', 'description')
+            ->from('tx_equedlms_domain_model_course')
+            ->where(
+                $expr->orX(
+                    $expr->like('title', $qb->createNamedParameter('%' . $term . '%')),
+                    $expr->like('description', $qb->createNamedParameter('%' . $term . '%')),
+                )
+            )
+            ->setMaxResults(10);
+
+        $rows = $qb->executeQuery()->fetchAllAssociative();
+
+        $results = [];
+        foreach ($rows as $row) {
+            $results[] = new CourseSearchResult(
+                (int) $row['uid'],
+                (string) $row['title'],
+                (string) $row['description'],
+            );
+        }
+
+        return $results;
+    }
+
+    public function searchGlossary(string $term): array
+    {
+        $qb   = $this->connectionPool->getQueryBuilderForTable('tx_equedlms_domain_model_glossaryentry');
+        $expr = $qb->expr();
+        $qb->select('uid', 'term', 'definition')
+            ->from('tx_equedlms_domain_model_glossaryentry')
+            ->where(
+                $expr->orX(
+                    $expr->like('term', $qb->createNamedParameter('%' . $term . '%')),
+                    $expr->like('definition', $qb->createNamedParameter('%' . $term . '%')),
+                )
+            )
+            ->setMaxResults(10);
+
+        $rows = $qb->executeQuery()->fetchAllAssociative();
+
+        $results = [];
+        foreach ($rows as $row) {
+            $results[] = new GlossarySearchResult(
+                (int) $row['uid'],
+                (string) $row['term'],
+                (string) $row['definition'],
+            );
+        }
+
+        return $results;
+    }
+}

--- a/equed-lms/Classes/Domain/Repository/SearchRepositoryInterface.php
+++ b/equed-lms/Classes/Domain/Repository/SearchRepositoryInterface.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Domain\Repository;
+
+use Equed\EquedLms\Dto\CourseSearchResult;
+use Equed\EquedLms\Dto\GlossarySearchResult;
+
+interface SearchRepositoryInterface
+{
+    /**
+     * @return CourseSearchResult[]
+     */
+    public function searchCourses(string $term): array;
+
+    /**
+     * @return GlossarySearchResult[]
+     */
+    public function searchGlossary(string $term): array;
+}

--- a/equed-lms/Classes/Dto/CourseSearchResult.php
+++ b/equed-lms/Classes/Dto/CourseSearchResult.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Dto;
+
+final class CourseSearchResult implements \JsonSerializable
+{
+    public function __construct(
+        private readonly int $uid,
+        private readonly string $title,
+        private readonly string $description,
+    ) {
+    }
+
+    public function getUid(): int
+    {
+        return $this->uid;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'uid' => $this->uid,
+            'title' => $this->title,
+            'description' => $this->description,
+        ];
+    }
+}

--- a/equed-lms/Classes/Dto/GlossarySearchResult.php
+++ b/equed-lms/Classes/Dto/GlossarySearchResult.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Dto;
+
+final class GlossarySearchResult implements \JsonSerializable
+{
+    public function __construct(
+        private readonly int $uid,
+        private readonly string $term,
+        private readonly string $definition,
+    ) {
+    }
+
+    public function getUid(): int
+    {
+        return $this->uid;
+    }
+
+    public function getTerm(): string
+    {
+        return $this->term;
+    }
+
+    public function getDefinition(): string
+    {
+        return $this->definition;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'uid' => $this->uid,
+            'term' => $this->term,
+            'definition' => $this->definition,
+        ];
+    }
+}

--- a/equed-lms/Classes/Service/SearchService.php
+++ b/equed-lms/Classes/Service/SearchService.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace Equed\EquedLms\Service;
 
-use TYPO3\CMS\Core\Database\ConnectionPool;
-use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use Equed\EquedLms\Dto\SearchResults;
+use Equed\EquedLms\Domain\Repository\SearchRepositoryInterface;
 
 /**
  * Provides search capabilities across multiple entities.
@@ -14,7 +13,7 @@ use Equed\EquedLms\Dto\SearchResults;
 final class SearchService implements SearchServiceInterface
 {
     public function __construct(
-        private readonly ConnectionPool $connectionPool
+        private readonly SearchRepositoryInterface $searchRepository
     ) {
     }
 
@@ -29,49 +28,17 @@ final class SearchService implements SearchServiceInterface
             return new SearchResults([], [], 'Search term too short.');
         }
 
-        $courses = $this->searchTable(
-            'tx_equedlms_domain_model_course',
-            ['title', 'description'],
-            $term
+        $courses  = array_map(
+            static fn($dto) => $dto->jsonSerialize(),
+            $this->searchRepository->searchCourses($term)
         );
 
-        $glossary = $this->searchTable(
-            'tx_equedlms_domain_model_glossaryentry',
-            ['term', 'definition'],
-            $term
+        $glossary = array_map(
+            static fn($dto) => $dto->jsonSerialize(),
+            $this->searchRepository->searchGlossary($term)
         );
 
         return new SearchResults($courses, $glossary);
     }
 
-    /**
-     * Generic search within a table.
-     *
-     * @param string $table
-     * @param array<string> $columns
-     * @param string $term
-     * @return array<int, array<string, mixed>>
-     */
-    private function searchTable(string $table, array $columns, string $term): array
-    {
-        $qb = $this->getQueryBuilder($table);
-        $expr = $qb->expr();
-
-        $conditions = [];
-        foreach ($columns as $column) {
-            $conditions[] = $expr->like($column, $qb->createNamedParameter('%' . $term . '%'));
-        }
-
-        $qb->select('*')
-            ->from($table)
-            ->where($expr->orX(...$conditions))
-            ->setMaxResults(10);
-
-        return $qb->executeQuery()->fetchAllAssociative();
-    }
-
-    private function getQueryBuilder(string $table): QueryBuilder
-    {
-        return $this->connectionPool->getQueryBuilderForTable($table);
-    }
 }

--- a/equed-lms/Configuration/Services/Services.yaml
+++ b/equed-lms/Configuration/Services/Services.yaml
@@ -246,8 +246,13 @@ services:
   Equed\EquedLms\Service\ProfileServiceInterface:
     class: Equed\EquedLms\Service\ProfileService
 
+  Equed\EquedLms\Domain\Repository\SearchRepositoryInterface:
+    class: Equed\EquedLms\Domain\Repository\SearchRepository
+
   Equed\EquedLms\Service\SearchServiceInterface:
     class: Equed\EquedLms\Service\SearchService
+    arguments:
+      $searchRepository: '@Equed\EquedLms\Domain\Repository\SearchRepositoryInterface'
 
   Equed\EquedLms\Service\TokenServiceInterface:
     class: Equed\EquedLms\Service\TokenService

--- a/equed-lms/Tests/Unit/Service/SearchServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/SearchServiceTest.php
@@ -2,10 +2,23 @@
 
 declare(strict_types=1);
 
-namespace TYPO3\CMS\Core\Database;
-if (!class_exists(ConnectionPool::class)) {
-    class ConnectionPool {
-        public function getQueryBuilderForTable(string $table) { return null; }
+namespace Equed\EquedLms\Domain\Repository {
+    use Equed\EquedLms\Dto\CourseSearchResult;
+    use Equed\EquedLms\Dto\GlossarySearchResult;
+
+    interface SearchRepositoryInterface
+    {
+        /** @return CourseSearchResult[] */
+        public function searchCourses(string $term): array;
+
+        /** @return GlossarySearchResult[] */
+        public function searchGlossary(string $term): array;
+    }
+
+    class NullSearchRepository implements SearchRepositoryInterface
+    {
+        public function searchCourses(string $term): array { return []; }
+        public function searchGlossary(string $term): array { return []; }
     }
 }
 
@@ -13,13 +26,13 @@ namespace Equed\EquedLms\Tests\Unit\Service;
 
 use Equed\EquedLms\Service\SearchService;
 use PHPUnit\Framework\TestCase;
-use TYPO3\CMS\Core\Database\ConnectionPool;
+use Equed\EquedLms\Domain\Repository\NullSearchRepository;
 
 final class SearchServiceTest extends TestCase
 {
     public function testReturnsErrorForTooShortTerm(): void
     {
-        $service = new SearchService(new ConnectionPool());
+        $service = new SearchService(new NullSearchRepository());
         $result = $service->search('a');
         $this->assertTrue($result->hasError());
         $this->assertSame('Search term too short.', $result->getError());


### PR DESCRIPTION
## Summary
- add DTOs for search results
- implement `SearchRepository` with typed return values
- refactor `SearchService` to use the repository
- wire up the new repository in `Services.yaml`
- update unit test for `SearchService`

## Testing
- `composer lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850fd5074288324804af10eab678262