### PR TITLE
Add localized logging for I/O services

### DIFF
--- a/equed-lms/Classes/Service/SubmissionService.php
+++ b/equed-lms/Classes/Service/SubmissionService.php
@@ -13,18 +13,26 @@ use Equed\EquedLms\Domain\Service\ClockInterface;
 use Equed\EquedLms\Dto\SubmissionCreateRequest;
 use Equed\EquedLms\Dto\SubmissionEvaluateRequest;
 use InvalidArgumentException;
+use Equed\EquedLms\Service\LogService;
+use Equed\EquedLms\Domain\Service\LanguageServiceInterface;
+use Equed\EquedLms\Service\TranslatedLoggerTrait;
 
 /**
  * Service for managing user submissions.
  */
 final class SubmissionService
 {
+    use TranslatedLoggerTrait;
+
     public function __construct(
         private readonly UserSubmissionRepositoryInterface $submissionRepository,
         private readonly PersistenceManagerInterface $persistenceManager,
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly ClockInterface $clock,
+        LanguageServiceInterface $translationService,
+        LogService $logService,
     ) {
+        $this->injectTranslatedLogger($translationService, $logService);
     }
 
     /**
@@ -63,6 +71,7 @@ final class SubmissionService
     public function createSubmission(SubmissionCreateRequest $request): void
     {
         if ($request->getRecordId() <= 0 || $request->getFile() === '') {
+            $this->logTranslatedError('submission.create.invalid');
             throw new InvalidArgumentException('Missing required fields');
         }
 
@@ -81,6 +90,7 @@ final class SubmissionService
     public function evaluateSubmission(SubmissionEvaluateRequest $request): void
     {
         if ($request->getSubmissionId() <= 0 || $request->getEvaluationNote() === '') {
+            $this->logTranslatedError('submission.evaluate.invalid');
             throw new InvalidArgumentException('Missing required fields');
         }
 

--- a/equed-lms/Tests/Unit/Service/MediaUploadServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/MediaUploadServiceTest.php
@@ -27,6 +27,7 @@ namespace Equed\EquedLms\Tests\Unit\Service;
 use Equed\EquedLms\Domain\Model\FrontendUser;
 use Equed\EquedLms\Service\LogService;
 use Equed\EquedLms\Service\MediaUploadService;
+use Equed\EquedLms\Domain\Service\LanguageServiceInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Equed\EquedLms\Tests\Traits\ProphecyTrait;
@@ -46,8 +47,9 @@ class MediaUploadServiceTest extends TestCase
         $logger = $this->prophesize(LoggerInterface::class);
         $logger->warning('Upload rejected due to MIME type', Argument::type('array'))->shouldBeCalled();
         $logService = new LogService($logger->reveal());
+        $language = $this->prophesize(LanguageServiceInterface::class);
 
-        $service = new MediaUploadService($storageRepo, $logService, $factory, 1024);
+        $service = new MediaUploadService($storageRepo, $language->reveal(), $logService, $factory, 1024);
 
         $result = $service->handleUpload(['tmp_name'=>'t','name'=>'f','type'=>'text/plain'], new FrontendUser());
         $this->assertNull($result);
@@ -60,8 +62,9 @@ class MediaUploadServiceTest extends TestCase
         $factory = new ResourceFactory();
         $logger = $this->prophesize(LoggerInterface::class);
         $logService = new LogService($logger->reveal());
+        $language = $this->prophesize(LanguageServiceInterface::class);
 
-        $service = new MediaUploadService($storageRepo, $logService, $factory, 1024);
+        $service = new MediaUploadService($storageRepo, $language->reveal(), $logService, $factory, 1024);
 
         $file = ['tmp_name'=>'tmp','name'=>'file.jpg','type'=>'image/jpeg'];
         $ref = $service->handleUpload($file, new FrontendUser());
@@ -75,8 +78,9 @@ class MediaUploadServiceTest extends TestCase
         $logger = $this->prophesize(LoggerInterface::class);
         $logger->warning('Upload rejected due to file size', Argument::type('array'))->shouldBeCalled();
         $logService = new LogService($logger->reveal());
+        $language = $this->prophesize(LanguageServiceInterface::class);
 
-        $service = new MediaUploadService($storageRepo, $logService, $factory, 1);
+        $service = new MediaUploadService($storageRepo, $language->reveal(), $logService, $factory, 1);
 
         $tmp = tempnam(sys_get_temp_dir(), 'u');
         file_put_contents($tmp, str_repeat('x', 2));
@@ -92,8 +96,9 @@ class MediaUploadServiceTest extends TestCase
         $logger = $this->prophesize(LoggerInterface::class);
         $logger->warning('Incomplete upload structure.')->shouldBeCalled();
         $logService = new LogService($logger->reveal());
+        $language = $this->prophesize(LanguageServiceInterface::class);
 
-        $service = new MediaUploadService($storageRepo, $logService, $factory);
+        $service = new MediaUploadService($storageRepo, $language->reveal(), $logService, $factory);
         $this->assertNull($service->handleUpload(['name' => 'file.jpg'], new FrontendUser()));
     }
 
@@ -104,8 +109,9 @@ class MediaUploadServiceTest extends TestCase
         $logger = $this->prophesize(LoggerInterface::class);
         $logger->error('No valid storage available.')->shouldBeCalled();
         $logService = new LogService($logger->reveal());
+        $language = $this->prophesize(LanguageServiceInterface::class);
 
-        $service = new MediaUploadService($storageRepo, $logService, $factory);
+        $service = new MediaUploadService($storageRepo, $language->reveal(), $logService, $factory);
         $file = ['tmp_name' => 't', 'name' => 'file.jpg', 'type' => 'image/jpeg'];
         $this->assertNull($service->handleUpload($file, new FrontendUser()));
     }
@@ -121,8 +127,9 @@ class MediaUploadServiceTest extends TestCase
         $logger = $this->prophesize(LoggerInterface::class);
         $logger->error('Upload failed', Argument::type('array'))->shouldBeCalled();
         $logService = new LogService($logger->reveal());
+        $language = $this->prophesize(LanguageServiceInterface::class);
 
-        $service = new MediaUploadService($storageRepo, $logService, $factory);
+        $service = new MediaUploadService($storageRepo, $language->reveal(), $logService, $factory);
         $file = ['tmp_name' => 't', 'name' => 'file.jpg', 'type' => 'image/jpeg'];
         $this->assertNull($service->handleUpload($file, new FrontendUser()));
     }

--- a/equed-lms/Tests/Unit/Service/SubmissionServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/SubmissionServiceTest.php
@@ -9,6 +9,8 @@ use Equed\EquedLms\Service\SubmissionService;
 use Equed\EquedLms\Dto\SubmissionCreateRequest;
 use Equed\EquedLms\Dto\SubmissionEvaluateRequest;
 use Equed\EquedLms\Domain\Service\ClockInterface;
+use Equed\EquedLms\Service\LogService;
+use Equed\EquedLms\Domain\Service\LanguageServiceInterface;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Equed\EquedLms\Event\Submission\SubmissionReviewedEvent;
@@ -24,6 +26,8 @@ class SubmissionServiceTest extends TestCase
     private $persistence;
     private $eventDispatcher;
     private $clock;
+    private $lang;
+    private $logService;
 
     protected function setUp(): void
     {
@@ -31,12 +35,17 @@ class SubmissionServiceTest extends TestCase
         $this->persistence     = $this->prophesize(PersistenceManagerInterface::class);
         $this->eventDispatcher = $this->prophesize(EventDispatcherInterface::class);
         $this->clock           = $this->prophesize(ClockInterface::class);
+        $this->lang            = $this->prophesize(LanguageServiceInterface::class);
+        $logger                = $this->prophesize(\Psr\Log\LoggerInterface::class);
+        $this->logService      = new LogService($logger->reveal());
 
         $this->subject = new SubmissionService(
             $this->repository->reveal(),
             $this->persistence->reveal(),
             $this->eventDispatcher->reveal(),
-            $this->clock->reveal()
+            $this->clock->reveal(),
+            $this->lang->reveal(),
+            $this->logService
         );
     }
 


### PR DESCRIPTION
## Summary
- localize MediaUploadService log messages
- inject translation and logging into SubmissionService
- add error logging for invalid submissions
- support localized logging in TrainingRecordGeneratorService
- update unit tests for new service dependencies

## Testing
- `composer install` *(fails: composer not found)*
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68510029b7c88324909a9cc208b846c4