### PR TITLE
Fix translation sync workflow

### DIFF
--- a/.github/workflows/translation-sync.yml
+++ b/.github/workflows/translation-sync.yml
@@ -17,5 +17,7 @@ jobs:
         with:
           php-version: '8.2'
           extensions: xml, gd
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist
       - name: Synchronize translations
-        run: php bin/console translation:sync
+        run: vendor/bin/typo3 translation:sync


### PR DESCRIPTION
## Summary
- use Composer install to set up dependencies for TYPO3
- run the translation command via `vendor/bin/typo3`

## Testing
- `./bin/act -l`
- `./equed-lms/vendor/bin/typo3 translation:sync` *(fails: `AuditLogRepository::findByUid` signature)*

------
https://chatgpt.com/codex/tasks/task_e_685101f5c0bc8324839d111bf0f5914e