### PR TITLE
Fix MaterialListService translation arg bug

### DIFF
--- a/equed-lms/Classes/Service/MaterialListService.php
+++ b/equed-lms/Classes/Service/MaterialListService.php
@@ -28,6 +28,7 @@ final class MaterialListService implements MaterialListServiceInterface
     {
         $language = (string)($this->context->getAspect('frontend.user')->get('language') ?? 'en');
         $mode     = $language === 'easy' ? 'simple' : 'expert';
+        $args     = ['_language' => $language];
 
         $materials = $this->materialRepository->findByTypeAndCategory($type, $category);
 
@@ -37,9 +38,9 @@ final class MaterialListService implements MaterialListServiceInterface
             'category'  => $category,
             'mode'      => $mode,
             'labels'    => [
-                'heading'        => $this->translationService->translate('material.list.heading', $language),
-                'filterType'     => $this->translationService->translate('material.filter.type', $language),
-                'filterCategory' => $this->translationService->translate('material.filter.category', $language),
+                'heading'        => $this->translationService->translate('material.list.heading', $args),
+                'filterType'     => $this->translationService->translate('material.filter.type', $args),
+                'filterCategory' => $this->translationService->translate('material.filter.category', $args),
             ],
         ];
     }

--- a/equed-lms/Tests/Unit/Service/MaterialListServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/MaterialListServiceTest.php
@@ -47,9 +47,10 @@ final class MaterialListServiceTest extends TestCase
         $materials = ['m1'];
 
         $this->repository->findByTypeAndCategory('pdf', 'general')->willReturn($materials);
-        $this->translator->translate('material.list.heading', 'en')->willReturn('h');
-        $this->translator->translate('material.filter.type', 'en')->willReturn('t');
-        $this->translator->translate('material.filter.category', 'en')->willReturn('c');
+        $args = ['_language' => 'en'];
+        $this->translator->translate('material.list.heading', $args)->willReturn('h');
+        $this->translator->translate('material.filter.type', $args)->willReturn('t');
+        $this->translator->translate('material.filter.category', $args)->willReturn('c');
 
         $result = $this->subject->getListData('pdf', 'general');
 


### PR DESCRIPTION
## Summary
- pass translation arguments as array in `MaterialListService`
- update unit test to verify array-based translator calls

## Testing
- `php` *unavailable*
- `composer` *unavailable*

------
https://chatgpt.com/codex/tasks/task_e_6851043e08448324a7fe63e6b27570cf