### PR TITLE
Require explicit FrontendUser for uploads

### DIFF
--- a/equed-lms/Classes/Controller/Api/AppUploadController.php
+++ b/equed-lms/Classes/Controller/Api/AppUploadController.php
@@ -8,6 +8,7 @@ use Equed\Core\Service\ConfigurationServiceInterface;
 use Equed\EquedLms\Service\GptTranslationServiceInterface;
 use Equed\EquedLms\Domain\Service\ApiResponseServiceInterface;
 use Equed\EquedLms\Domain\Service\MediaUploadServiceInterface;
+use Equed\EquedLms\Factory\FrontendUserFactoryInterface;
 use Equed\EquedLms\Dto\UploadFileRequest;
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Http\JsonResponse;
@@ -24,6 +25,7 @@ final class AppUploadController extends BaseApiController
 {
     public function __construct(
         private readonly MediaUploadServiceInterface $mediaUploadService,
+        private readonly FrontendUserFactoryInterface $frontendUserFactory,
         ConfigurationServiceInterface $configurationService,
         ApiResponseServiceInterface $apiResponseService,
         GptTranslationServiceInterface $translationService,
@@ -53,7 +55,8 @@ final class AppUploadController extends BaseApiController
             return $this->jsonError('api.upload.unauthorized', JsonResponse::HTTP_UNAUTHORIZED);
         }
 
-        $result = $this->mediaUploadService->upload($dto);
+        $user = $this->frontendUserFactory->createWithUid($dto->getUserId());
+        $result = $this->mediaUploadService->upload($dto, $user);
 
         if ($result->hasError()) {
             return $this->jsonError('api.upload.invalidFile', JsonResponse::HTTP_BAD_REQUEST);

--- a/equed-lms/Classes/Domain/Service/MediaUploadServiceInterface.php
+++ b/equed-lms/Classes/Domain/Service/MediaUploadServiceInterface.php
@@ -23,5 +23,5 @@ interface MediaUploadServiceInterface
     /**
      * Handle a PSR-7 upload request.
      */
-    public function upload(UploadFileRequest $request): UploadFileResult;
+    public function upload(UploadFileRequest $request, FrontendUser $user): UploadFileResult;
 }

--- a/equed-lms/Classes/Service/MediaUploadService.php
+++ b/equed-lms/Classes/Service/MediaUploadService.php
@@ -106,7 +106,7 @@ final class MediaUploadService implements MediaUploadServiceInterface
         }
     }
 
-    public function upload(UploadFileRequest $request): UploadFileResult
+    public function upload(UploadFileRequest $request, FrontendUser $user): UploadFileResult
     {
         $file = $request->getFile();
         $tmpPath = $file->getStream()->getMetadata('uri');
@@ -122,11 +122,6 @@ final class MediaUploadService implements MediaUploadServiceInterface
             'name' => $file->getClientFilename() ?? 'upload',
             'type' => $file->getClientMediaType() ?? ''
         ];
-
-        $user = new FrontendUser();
-        if (method_exists($user, 'setUid')) {
-            $user->setUid($request->getUserId());
-        }
 
         $result = $this->handleUpload($payload, $user);
 


### PR DESCRIPTION
## Summary
- inject FrontendUser directly into `MediaUploadService::upload`
- adjust interface and controller

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml.dist` *(fails: Cannot declare interface Equed\Core\Service\UuidGeneratorInterface)*

------
https://chatgpt.com/codex/tasks/task_e_6851110a41e883249fd5fca41b5483c1