### PR TITLE
Add LessonProgress factory

### DIFF
--- a/equed-lms/Classes/Domain/Factory/LessonProgressFactoryInterface.php
+++ b/equed-lms/Classes/Domain/Factory/LessonProgressFactoryInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Domain\Factory;
+
+use Equed\EquedLms\Domain\Model\LessonProgress;
+
+interface LessonProgressFactoryInterface
+{
+    public function create(): LessonProgress;
+}

--- a/equed-lms/Classes/Factory/DefaultLessonProgressFactory.php
+++ b/equed-lms/Classes/Factory/DefaultLessonProgressFactory.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Factory;
+
+use Equed\EquedLms\Domain\Factory\LessonProgressFactoryInterface;
+use Equed\EquedLms\Domain\Model\LessonProgress;
+
+final class DefaultLessonProgressFactory implements LessonProgressFactoryInterface
+{
+    public function create(): LessonProgress
+    {
+        return new LessonProgress();
+    }
+}

--- a/equed-lms/Classes/Service/LessonProgressService.php
+++ b/equed-lms/Classes/Service/LessonProgressService.php
@@ -16,6 +16,7 @@ use Equed\EquedLms\Enum\ProgressStatus;
 use Equed\EquedLms\Event\Progress\LessonProgressUpdatedEvent;
 use Equed\EquedLms\Event\Progress\LessonProgressCompletedEvent;
 use Psr\EventDispatcher\EventDispatcherInterface;
+use Equed\EquedLms\Domain\Factory\LessonProgressFactoryInterface;
 
 /**
  * Service to manage lesson progress for users.
@@ -28,6 +29,7 @@ final class LessonProgressService implements LessonProgressServiceInterface
         private readonly UserCourseRecordRepositoryInterface $courseRecordRepository,
         private readonly ClockInterface $clock,
         private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly LessonProgressFactoryInterface $progressFactory,
     ) {
     }
 
@@ -58,7 +60,7 @@ final class LessonProgressService implements LessonProgressServiceInterface
         $progress = $this->getProgressEntity($user, $lesson);
 
         if ($progress === null) {
-            $progress = new LessonProgress();
+            $progress = $this->progressFactory->create();
             $records = $this->courseRecordRepository->findByUserId((int) $user->getUid());
             $progress->setUserCourseRecord($records[0] ?? null);
             $progress->setLesson($lesson);
@@ -86,7 +88,7 @@ final class LessonProgressService implements LessonProgressServiceInterface
 
         if ($progress === null) {
             $lesson = $this->lessonRepository->findByUid($lessonId);
-            $progress = new LessonProgress();
+            $progress = $this->progressFactory->create();
             $records = $this->courseRecordRepository->findByUserId($userId);
             $progress->setUserCourseRecord($records[0] ?? null);
             if ($lesson instanceof Lesson) {

--- a/equed-lms/Configuration/Services/Services.yaml
+++ b/equed-lms/Configuration/Services/Services.yaml
@@ -146,6 +146,9 @@ services:
   Equed\EquedLms\Factory\UserCourseRecordFactoryInterface:
     class: Equed\EquedLms\Factory\DefaultUserCourseRecordFactory
 
+  Equed\EquedLms\Domain\Factory\LessonProgressFactoryInterface:
+    class: Equed\EquedLms\Factory\DefaultLessonProgressFactory
+
   Equed\EquedLms\Domain\Service\UserAccountServiceInterface:
     class: Equed\EquedLms\Service\UserAccountService
 


### PR DESCRIPTION
## Summary
- add `LessonProgressFactoryInterface` for domain use
- implement `DefaultLessonProgressFactory`
- inject factory into `LessonProgressService`
- register factory in DI configuration

## Testing
- `php -l equed-lms/Classes/Domain/Factory/LessonProgressFactoryInterface.php`
- `php -l equed-lms/Classes/Factory/DefaultLessonProgressFactory.php`
- `php -l equed-lms/Classes/Service/LessonProgressService.php`

------
https://chatgpt.com/codex/tasks/task_e_685122c1177c8324a3e4808229aa7e7b