### PR TITLE
Add QmsCaseDto mapping for Service Center cases

### DIFF
--- a/equed-lms/Classes/Dto/QmsCaseDto.php
+++ b/equed-lms/Classes/Dto/QmsCaseDto.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Dto;
+
+/**
+ * Structured QMS case data for Service Center use.
+ */
+final class QmsCaseDto implements \JsonSerializable
+{
+    public function __construct(
+        private readonly int $id,
+        private readonly int $recordId,
+        private readonly string $type,
+        private readonly string $message,
+        private readonly string $status,
+        private readonly int $submittedAt,
+        private readonly ?int $respondedAt = null,
+        private readonly ?int $closedAt = null,
+    ) {
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getRecordId(): int
+    {
+        return $this->recordId;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function getSubmittedAt(): int
+    {
+        return $this->submittedAt;
+    }
+
+    public function getRespondedAt(): ?int
+    {
+        return $this->respondedAt;
+    }
+
+    public function getClosedAt(): ?int
+    {
+        return $this->closedAt;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'id'          => $this->id,
+            'recordId'    => $this->recordId,
+            'type'        => $this->type,
+            'message'     => $this->message,
+            'status'      => $this->status,
+            'submittedAt' => $this->submittedAt,
+            'respondedAt' => $this->respondedAt,
+            'closedAt'    => $this->closedAt,
+        ];
+    }
+}
+
+// EOF

--- a/equed-lms/Classes/Service/ServiceCenterCaseService.php
+++ b/equed-lms/Classes/Service/ServiceCenterCaseService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Equed\EquedLms\Service;
 
 use Equed\EquedLms\Domain\Repository\QmsCaseRecordRepositoryInterface;
+use Equed\EquedLms\Dto\QmsCaseDto;
 
 /**
  * Service to retrieve QMS cases for Service Center API operations.
@@ -18,11 +19,25 @@ final class ServiceCenterCaseService
     /**
      * Fetch all QMS cases ordered by submission date.
      *
-     * @return array<int, array<string, mixed>>
+     * @return array<int, QmsCaseDto>
      */
     public function getQmsCases(): array
     {
-        return $this->repository->findAll();
+        $rows = $this->repository->findAll();
+
+        return array_map(
+            fn (array $row): QmsCaseDto => new QmsCaseDto(
+                (int)$row['uid'],
+                (int)$row['usercourserecord'],
+                (string)$row['type'],
+                (string)$row['message'],
+                (string)$row['status'],
+                (int)$row['submitted_at'],
+                isset($row['responded_at']) ? (int)$row['responded_at'] : null,
+                isset($row['closed_at']) ? (int)$row['closed_at'] : null,
+            ),
+            $rows
+        );
     }
 }
 

--- a/equed-lms/Tests/Unit/Service/ServiceCenterCaseServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/ServiceCenterCaseServiceTest.php
@@ -8,6 +8,7 @@ use Equed\EquedLms\Service\ServiceCenterCaseService;
 use PHPUnit\Framework\TestCase;
 use Equed\EquedLms\Tests\Traits\ProphecyTrait;
 use Equed\EquedLms\Domain\Repository\QmsCaseRecordRepositoryInterface;
+use Equed\EquedLms\Dto\QmsCaseDto;
 
 final class ServiceCenterCaseServiceTest extends TestCase
 {
@@ -16,11 +17,23 @@ final class ServiceCenterCaseServiceTest extends TestCase
     public function testGetQmsCasesDelegatesToRepository(): void
     {
         $repo = $this->prophesize(QmsCaseRecordRepositoryInterface::class);
-        $rows = [['uid' => 1]];
+        $rows = [[
+            'uid'            => 1,
+            'usercourserecord' => 2,
+            'type'           => 'general',
+            'message'        => 'm',
+            'status'         => 'open',
+            'submitted_at'   => 100,
+            'responded_at'   => null,
+            'closed_at'      => null,
+        ]];
         $repo->findAll()->willReturn($rows)->shouldBeCalled();
 
         $service = new ServiceCenterCaseService($repo->reveal());
-        $this->assertSame($rows, $service->getQmsCases());
+        $cases = $service->getQmsCases();
+        $this->assertCount(1, $cases);
+        $this->assertInstanceOf(QmsCaseDto::class, $cases[0]);
+        $this->assertSame(1, $cases[0]->getId());
     }
 
     public function testReturnsEmptyArrayWhenNoRows(): void


### PR DESCRIPTION
## Summary
- create a new `QmsCaseDto`
- return `QmsCaseDto` objects from `ServiceCenterCaseService`
- adjust unit tests for the new DTO

## Testing
- `composer --working-dir=equed-lms install` *(fails: ext-dom missing)*

------
https://chatgpt.com/codex/tasks/task_e_685124f8243083248586e073b401037a