### PR TITLE
Use DATE_ATOM for updatedAt parsing

### DIFF
--- a/equed-lms/Classes/Service/LessonProgressSyncService.php
+++ b/equed-lms/Classes/Service/LessonProgressSyncService.php
@@ -64,9 +64,10 @@ final class LessonProgressSyncService
             }
 
             $entry = $this->progressRepository->findByUserAndLesson($userId, $lesson->getUid()) ?? new LessonProgress();
-            try {
-                $remoteUpdated = new \DateTimeImmutable($item['updatedAt'] ?? 'now');
-            } catch (\Exception $e) {
+            $remoteUpdated = isset($item['updatedAt'])
+                ? \DateTimeImmutable::createFromFormat(DATE_ATOM, $item['updatedAt'])
+                : new \DateTimeImmutable();
+            if ($remoteUpdated === false) {
                 $this->logService->logWarning(
                     'Invalid timestamp for progress sync',
                     ['value' => $item['updatedAt'] ?? null, 'lessonId' => $item['lessonId'] ?? null]

--- a/equed-lms/Classes/Service/SubmissionSyncService.php
+++ b/equed-lms/Classes/Service/SubmissionSyncService.php
@@ -93,7 +93,14 @@ final class SubmissionSyncService
             $submission->setUuid(Uuid::uuid4()->toString());
         }
 
-        $remoteUpdated = new \DateTimeImmutable($data['updatedAt'] ?? 'now');
+        if (isset($data['updatedAt'])) {
+            $remoteUpdated = \DateTimeImmutable::createFromFormat(DATE_ATOM, $data['updatedAt']);
+            if ($remoteUpdated === false) {
+                $remoteUpdated = new \DateTimeImmutable();
+            }
+        } else {
+            $remoteUpdated = new \DateTimeImmutable();
+        }
         $localUpdated = $submission->getUpdatedAt();
 
         if (!$localUpdated || $remoteUpdated > $localUpdated) {

--- a/equed-lms/Classes/Service/SyncService.php
+++ b/equed-lms/Classes/Service/SyncService.php
@@ -77,9 +77,8 @@ final class SyncService
 
         // Conflict resolution via updatedAt timestamp
         if (isset($data['updatedAt'])) {
-            try {
-                $remoteUpdated = new \DateTimeImmutable($data['updatedAt']);
-            } catch (\Exception $e) {
+            $remoteUpdated = \DateTimeImmutable::createFromFormat(DATE_ATOM, $data['updatedAt']);
+            if ($remoteUpdated === false) {
                 $this->logService->logWarning(
                     'Invalid timestamp for profile sync',
                     ['value' => $data['updatedAt'], 'userId' => $userId]

--- a/equed-lms/Classes/Service/UserProgressSyncService.php
+++ b/equed-lms/Classes/Service/UserProgressSyncService.php
@@ -57,9 +57,8 @@ final class UserProgressSyncService
                 continue;
             }
 
-            try {
-                $remoteTime = new \DateTimeImmutable($data['updatedAt']);
-            } catch (\Exception $e) {
+            $remoteTime = \DateTimeImmutable::createFromFormat(DATE_ATOM, $data['updatedAt']);
+            if ($remoteTime === false) {
                 $this->logService->logWarning(
                     'Invalid timestamp for progress sync',
                     ['value' => $data['updatedAt'], 'recordId' => $data['recordId']]

--- a/equed-lms/Tests/Unit/Service/SubmissionSyncServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/SubmissionSyncServiceTest.php
@@ -93,7 +93,7 @@ class SubmissionSyncServiceTest extends TestCase
             'userId' => 1,
             'course' => 2,
             'status' => 'approved',
-            'updatedAt' => '2024-01-01',
+            'updatedAt' => '2024-01-01T00:00:00+00:00',
         ]);
     }
 
@@ -123,7 +123,7 @@ class SubmissionSyncServiceTest extends TestCase
             'status' => 'submitted',
             'score' => 2.0,
             'gptFeedback' => 'fb',
-            'updatedAt' => '2024-01-02',
+            'updatedAt' => '2024-01-02T00:00:00+00:00',
         ]);
     }
 }

--- a/equed-lms/Tests/Unit/Service/UserProgressSyncServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/UserProgressSyncServiceTest.php
@@ -67,7 +67,7 @@ class UserProgressSyncServiceTest extends TestCase
             [
                 'recordId' => 8,
                 'status' => 'passed',
-                'updatedAt' => '2024-01-02 00:00:00',
+                'updatedAt' => '2024-01-02T00:00:00+00:00',
             ],
         ]);
 


### PR DESCRIPTION
## Summary
- parse incoming timestamps using `DateTimeImmutable::createFromFormat`
- fallback gracefully when parsing fails
- adjust tests to use ISO 8601 timestamps

## Testing
- `./vendor/bin/phpunit --configuration phpunit.xml.dist Tests/Unit` *(fails: Cannot declare interface Equed\Core\Service\UuidGeneratorInterface)*

------
https://chatgpt.com/codex/tasks/task_e_685126193a548324a6073eacbf640234