### PR TITLE
Persist record update in CourseStatusUpdaterService

### DIFF
--- a/equed-lms/Classes/Service/CourseStatusUpdaterService.php
+++ b/equed-lms/Classes/Service/CourseStatusUpdaterService.php
@@ -10,6 +10,7 @@ use Equed\EquedLms\Domain\Repository\UserCourseRecordRepositoryInterface;
 use Equed\EquedLms\Enum\CourseStatus;
 use Equed\EquedLms\Domain\Service\CertificateServiceInterface;
 use Equed\EquedLms\Domain\Service\NotificationServiceInterface;
+use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 
 /**
  * Service to finalize a user course record: mark validated, persist changes,
@@ -21,6 +22,7 @@ final class CourseStatusUpdaterService
         private readonly CertificateServiceInterface    $certificateService,
         private readonly NotificationServiceInterface   $notificationService,
         private readonly UserCourseRecordRepositoryInterface $userCourseRecordRepository,
+        private readonly PersistenceManagerInterface    $persistenceManager,
         private readonly ClockInterface        $clock
     ) {
     }
@@ -37,6 +39,7 @@ final class CourseStatusUpdaterService
         $record->setCompletionDate($this->clock->now());
 
         $this->userCourseRecordRepository->update($record);
+        $this->persistenceManager->persistAll();
 
         $certificate = $this->certificateService->issueCertificate($record);
 

--- a/equed-lms/Tests/Unit/Service/CourseStatusUpdaterServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/CourseStatusUpdaterServiceTest.php
@@ -9,6 +9,7 @@ use Equed\EquedLms\Domain\Service\CertificateServiceInterface;
 use Equed\EquedLms\Domain\Service\NotificationServiceInterface;
 use Equed\EquedLms\Domain\Repository\UserCourseRecordRepositoryInterface;
 use Equed\EquedLms\Domain\Service\ClockInterface;
+use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 use Equed\EquedLms\Domain\Model\UserCourseRecord;
 use Equed\EquedLms\Domain\Model\CertificateDispatch;
 use Equed\EquedLms\Domain\Model\FrontendUser;
@@ -26,19 +27,22 @@ class CourseStatusUpdaterServiceTest extends TestCase
     private $certificateService;
     private $notificationService;
     private $repository;
+    private $persistence;
     private $clock;
 
     protected function setUp(): void
     {
         $this->certificateService = $this->prophesize(CertificateServiceInterface::class);
         $this->notificationService = $this->prophesize(NotificationServiceInterface::class);
-        $this->repository = $this->prophesize(UserCourseRecordRepositoryInterface::class);
-        $this->clock = $this->prophesize(ClockInterface::class);
+        $this->repository  = $this->prophesize(UserCourseRecordRepositoryInterface::class);
+        $this->persistence = $this->prophesize(PersistenceManagerInterface::class);
+        $this->clock       = $this->prophesize(ClockInterface::class);
 
         $this->subject = new CourseStatusUpdaterService(
             $this->certificateService->reveal(),
             $this->notificationService->reveal(),
             $this->repository->reveal(),
+            $this->persistence->reveal(),
             $this->clock->reveal()
         );
     }
@@ -55,6 +59,7 @@ class CourseStatusUpdaterServiceTest extends TestCase
         $this->clock->now()->willReturn($now);
         $record->setCompletionDate($now)->shouldBeCalled();
         $this->repository->update($record->reveal())->shouldBeCalled();
+        $this->persistence->persistAll()->shouldBeCalled();
 
         $this->certificateService->issueCertificate($record->reveal())->willReturn($certificate->reveal())->shouldBeCalled();
         $certificate->getQrCodeUrl()->willReturn('qr');


### PR DESCRIPTION
## Summary
- inject `PersistenceManagerInterface` into `CourseStatusUpdaterService`
- persist course status updates
- cover new behavior in unit test

## Testing
- `phpunit -c equed-lms/phpunit.xml.dist --testsuite unit` *(fails: phpunit not found)*
- `vendor/bin/phpunit -c equed-lms/phpunit.xml.dist --testsuite unit` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6851294c889883248efb69b74fe03285