### PR TITLE
Add filesystem abstraction for training record generator

### DIFF
--- a/equed-lms/Classes/Domain/Service/FilesystemInterface.php
+++ b/equed-lms/Classes/Domain/Service/FilesystemInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Domain\Service;
+
+/**
+ * Abstraction for basic filesystem operations.
+ */
+interface FilesystemInterface
+{
+    /**
+     * Check whether the given path exists.
+     */
+    public function exists(string $path): bool;
+
+    /**
+     * Create directories.
+     *
+     * @param string|array<int,string> $dirs Path or paths to create
+     * @param int                      $mode Permissions for new directories
+     */
+    public function mkdir(string|array $dirs, int $mode = 0777): void;
+
+    /**
+     * Dump the given content into a file.
+     */
+    public function dumpFile(string $path, string $content): void;
+
+    /**
+     * Remove files or directories.
+     *
+     * @param string|array<int,string> $paths Paths to remove
+     */
+    public function remove(string|array $paths): void;
+}

--- a/equed-lms/Classes/Service/SymfonyFilesystem.php
+++ b/equed-lms/Classes/Service/SymfonyFilesystem.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Service;
+
+use Equed\EquedLms\Domain\Service\FilesystemInterface;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * Filesystem implementation using Symfony's component.
+ */
+final class SymfonyFilesystem implements FilesystemInterface
+{
+    public function __construct(private readonly Filesystem $filesystem)
+    {
+    }
+
+    public function exists(string $path): bool
+    {
+        return $this->filesystem->exists($path);
+    }
+
+    public function mkdir(string|array $dirs, int $mode = 0777): void
+    {
+        $this->filesystem->mkdir($dirs, $mode);
+    }
+
+    public function dumpFile(string $path, string $content): void
+    {
+        $this->filesystem->dumpFile($path, $content);
+    }
+
+    public function remove(string|array $paths): void
+    {
+        $this->filesystem->remove($paths);
+    }
+}

--- a/equed-lms/Classes/Service/TrainingRecordGeneratorService.php
+++ b/equed-lms/Classes/Service/TrainingRecordGeneratorService.php
@@ -8,8 +8,8 @@ use Closure;
 use TCPDF;
 use ZipArchive;
 use RuntimeException;
-use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
+use Equed\EquedLms\Domain\Service\FilesystemInterface;
 use Equed\EquedLms\Service\LogService;
 use Equed\EquedLms\Domain\Service\LanguageServiceInterface;
 use Equed\EquedLms\Service\TranslatedLoggerTrait;
@@ -23,7 +23,7 @@ final class TrainingRecordGeneratorService implements TrainingRecordGeneratorInt
 {
     use TranslatedLoggerTrait;
     private readonly string $outputDirectory;
-    private readonly Filesystem $filesystem;
+    private readonly FilesystemInterface $filesystem;
     /** @var callable(): TCPDF */
     private readonly \Closure $pdfFactory;
     /** @var callable(): ZipArchive */
@@ -40,7 +40,7 @@ final class TrainingRecordGeneratorService implements TrainingRecordGeneratorInt
         string $outputDirectory,
         LanguageServiceInterface $translationService,
         LogService $logService,
-        Filesystem $filesystem,
+        FilesystemInterface $filesystem,
         callable $pdfFactory,
         callable $zipFactory
     ) {

--- a/equed-lms/Configuration/Services/Services.yaml
+++ b/equed-lms/Configuration/Services/Services.yaml
@@ -98,6 +98,8 @@ services:
     class: Equed\EquedLms\Service\SystemClock
   Equed\EquedLms\Domain\Service\FileReaderInterface:
     class: Equed\EquedLms\Service\LocalFileReader
+  Equed\EquedLms\Domain\Service\FilesystemInterface:
+    class: Equed\EquedLms\Service\SymfonyFilesystem
   Equed\EquedLms\Domain\Repository\CourseInstanceRepositoryInterface:
     class: Equed\EquedLms\Domain\Repository\CourseInstanceRepository
 
@@ -172,7 +174,7 @@ services:
   Equed\EquedLms\Service\TrainingRecordGeneratorService:
     arguments:
       $outputDirectory: '%equed_lms.training_record_output_path%'
-      $filesystem: '@Symfony\Component\Filesystem\Filesystem'
+      $filesystem: '@Equed\EquedLms\Domain\Service\FilesystemInterface'
       $pdfFactory: '@Equed\EquedLms\Factory\TcpdfFactory'
       $zipFactory: '@Equed\EquedLms\Factory\ZipArchiveFactory'
 

--- a/equed-lms/Tests/Unit/Service/TrainingRecordGeneratorServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/TrainingRecordGeneratorServiceTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace TCPDF { if (!class_exists(\TCPDF::class)) { class TCPDF { public function AddPage(){} public function SetFont($a,$b,$c){} public function Write($a,$b){} public function Ln(){} public function Output($d,$t){ return 'pdf'; } } } }
 namespace ZipArchiveNS { if (!class_exists(\ZipArchive::class)) { class ZipArchive { public $files=[]; public function open($file,$flags){ $this->path=$file; return true; } public function addFile($file,$name){ $this->files[]=$name; } public function close(){} } } }
 
-namespace Symfony\Component\Filesystem { if (!class_exists(Filesystem::class)) { class Filesystem { public array $dumped=[]; public array $mkdir=[]; public array $removed=[]; public function exists($p){return false;} public function mkdir($p,$m=0777){$this->mkdir[]=$p;} public function dumpFile($p,$c){$this->dumped[$p]=$c;} public function remove($p){$this->removed[]=$p;} } class Exception { interface IOExceptionInterface {} } }
+namespace Equed\EquedLms\Service { if (!interface_exists(FilesystemInterface::class)) { interface FilesystemInterface { public function exists(string $p): bool; public function mkdir(string|array $p, int $m=0777): void; public function dumpFile(string $p, string $c): void; public function remove(string|array $p): void; } } if (!class_exists(DummyFilesystem::class)) { class DummyFilesystem implements FilesystemInterface { public array $dumped=[]; public array $mkdir=[]; public array $removed=[]; public function exists(string $p): bool { return false; } public function mkdir(string|array $p, int $m=0777): void { $this->mkdir[]=$p; } public function dumpFile(string $p, string $c): void { $this->dumped[$p]=$c; } public function remove(string|array $p): void { $this->removed[]=$p; } } } }
 namespace Psr\Log { if (!interface_exists(LoggerInterface::class)) { interface LoggerInterface { public function emergency($m,array $c=[]); public function alert($m,array $c=[]); public function critical($m,array $c=[]); public function error($m,array $c=[]); public function warning($m,array $c=[]); public function notice($m,array $c=[]); public function info($m,array $c=[]); public function debug($m,array $c=[]); } } }
 
 namespace Equed\EquedLms\Tests\Unit\Service;
@@ -15,7 +15,7 @@ use Equed\EquedLms\Service\LogService;
 use Equed\EquedLms\Domain\Service\LanguageServiceInterface;
 use Equed\EquedLms\Tests\Traits\ProphecyTrait;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Filesystem\Filesystem;
+use Equed\EquedLms\Service\DummyFilesystem as Filesystem;
 use TCPDF;
 use ZipArchive;
 use DateTimeImmutable;


### PR DESCRIPTION
## Summary
- introduce `FilesystemInterface` and `SymfonyFilesystem` implementation
- use `FilesystemInterface` in `TrainingRecordGeneratorService`
- register new service in DI configuration
- adjust unit tests for new interface

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml.dist tests/Unit/Service/TrainingRecordGeneratorServiceTest.php` *(fails: `No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68512a28c2e08324b22cd5a805215ea0