### PR TITLE
Add configurable TTL to cache services

### DIFF
--- a/equed-lms/Classes/Service/Dashboard/CacheManager.php
+++ b/equed-lms/Classes/Service/Dashboard/CacheManager.php
@@ -14,8 +14,10 @@ final class CacheManager
 {
     public const CACHE_TTL_SECONDS = 600;
 
-    public function __construct(private readonly CacheItemPoolInterface $cachePool)
-    {
+    public function __construct(
+        private readonly CacheItemPoolInterface $cachePool,
+        private int $cacheTtlSeconds = self::CACHE_TTL_SECONDS,
+    ) {
     }
 
     public function fetch(int $userId): ?DashboardData
@@ -34,7 +36,7 @@ final class CacheManager
     {
         $item = $this->cachePool->getItem($this->key($userId));
         $item->set($data);
-        $item->expiresAfter(self::CACHE_TTL_SECONDS);
+        $item->expiresAfter($this->cacheTtlSeconds);
         $this->cachePool->save($item);
     }
 

--- a/equed-lms/Classes/Service/RecognitionAwardService.php
+++ b/equed-lms/Classes/Service/RecognitionAwardService.php
@@ -23,7 +23,8 @@ final class RecognitionAwardService
         private readonly PersistenceManagerInterface $persistenceManager,
         private readonly CacheItemPoolInterface $cachePool,
         private readonly LanguageServiceInterface $languageService,
-        private readonly ClockInterface $clock
+        private readonly ClockInterface $clock,
+        private int $cacheTtlSeconds = self::CACHE_TTL_SECONDS,
     ) {
     }
 
@@ -44,7 +45,7 @@ final class RecognitionAwardService
         $count = $this->userBadgeRepository->countValidBadges($userId);
         $qualifies = $count >= 4;
 
-        $cacheItem->set($qualifies)->expiresAfter(self::CACHE_TTL_SECONDS);
+        $cacheItem->set($qualifies)->expiresAfter($this->cacheTtlSeconds);
         $this->cachePool->save($cacheItem);
 
         return $qualifies;

--- a/equed-lms/Configuration/Services/Services.yaml
+++ b/equed-lms/Configuration/Services/Services.yaml
@@ -1,6 +1,8 @@
 parameters:
   equed_lms.training_record_output_path: '%kernel.project_dir%/var/training_records'
   equed_lms.max_upload_size: 5242880
+  equed_lms.dashboard_cache_ttl: 600
+  equed_lms.recognition_cache_ttl: 3600
 
 services:
   _defaults:
@@ -269,3 +271,11 @@ services:
 
   Equed\EquedLms\Service\TokenServiceInterface:
     class: Equed\EquedLms\Service\TokenService
+
+  Equed\EquedLms\Service\Dashboard\CacheManager:
+    arguments:
+      $cacheTtlSeconds: '%equed_lms.dashboard_cache_ttl%'
+
+  Equed\EquedLms\Service\RecognitionAwardService:
+    arguments:
+      $cacheTtlSeconds: '%equed_lms.recognition_cache_ttl%'

--- a/equed-lms/Tests/Unit/Service/CacheManagerTest.php
+++ b/equed-lms/Tests/Unit/Service/CacheManagerTest.php
@@ -33,12 +33,13 @@ class CacheManagerTest extends TestCase
         $item = $this->prophesize(CacheItemInterface::class);
         $data = new DashboardData([], [], [], [], [], [], []);
 
+        $ttl = 123;
         $pool->getItem('dashboard_user_7')->willReturn($item->reveal());
         $item->set($data)->willReturn($item->reveal())->shouldBeCalled();
-        $item->expiresAfter(CacheManager::CACHE_TTL_SECONDS)->willReturn($item->reveal())->shouldBeCalled();
+        $item->expiresAfter($ttl)->willReturn($item->reveal())->shouldBeCalled();
         $pool->save($item->reveal())->shouldBeCalled();
 
-        $manager = new CacheManager($pool->reveal());
+        $manager = new CacheManager($pool->reveal(), $ttl);
         $manager->save(7, $data);
     }
 }

--- a/equed-lms/Tests/Unit/Service/RecognitionAwardServiceTest.php
+++ b/equed-lms/Tests/Unit/Service/RecognitionAwardServiceTest.php
@@ -39,7 +39,8 @@ class RecognitionAwardServiceTest extends TestCase
             $this->persistence->reveal(),
             $this->cache->reveal(),
             $this->language->reveal(),
-            $this->clock->reveal()
+            $this->clock->reveal(),
+            1800
         );
     }
 
@@ -59,7 +60,7 @@ class RecognitionAwardServiceTest extends TestCase
         $item = $this->prophesize(CacheItemInterface::class);
         $item->isHit()->willReturn(false);
         $item->set(true)->willReturn($item->reveal())->shouldBeCalled();
-        $item->expiresAfter(RecognitionAwardService::CACHE_TTL_SECONDS)->shouldBeCalled();
+        $item->expiresAfter(1800)->shouldBeCalled();
         $this->cache->getItem('qualifyAdvanced_3')->willReturn($item->reveal());
         $this->repo->countValidBadges(3)->willReturn(5);
         $this->cache->save($item->reveal())->shouldBeCalled();


### PR DESCRIPTION
## Summary
- allow dashboard cache manager TTL to be customised
- allow recognition service cache TTL to be customised
- pass TTLs via DI config
- adjust unit tests for new argument

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68512e1fb1e08324869fe6d27c8c0d7b