### PR TITLE
Add cleanup method in repository

### DIFF
--- a/equed-lms/Classes/Domain/Repository/UserCourseRecordRepositoryInterface.php
+++ b/equed-lms/Classes/Domain/Repository/UserCourseRecordRepositoryInterface.php
@@ -52,4 +52,9 @@ interface UserCourseRecordRepositoryInterface
      * @return int
      */
     public function countByCourseInstance(int $instanceId): int;
+
+    /**
+     * Delete abandoned course records older than the given date.
+     */
+    public function deleteAbandonedInProgress(\DateTimeImmutable $before): void;
 }

--- a/equed-lms/Tests/Unit/Domain/Repository/UserCourseRecordRepositoryTest.php
+++ b/equed-lms/Tests/Unit/Domain/Repository/UserCourseRecordRepositoryTest.php
@@ -7,6 +7,8 @@ namespace Equed\EquedLms\Tests\Unit\Domain\Repository;
 use PHPUnit\Framework\TestCase;
 use Equed\EquedLms\Tests\Traits\ProphecyTrait;
 use Equed\EquedLms\Domain\Repository\UserCourseRecordRepository;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Extbase\Persistence\Generic\Query;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
 use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
@@ -20,17 +22,21 @@ class UserCourseRecordRepositoryTest extends TestCase
     private UserCourseRecordRepository $subject;
     private $query;
     private $persistenceManager;
+    private $connectionPool;
 
     protected function setUp(): void
     {
         $this->query = $this->prophesize(Query::class);
         $this->persistenceManager = $this->prophesize(PersistenceManager::class);
+        $this->connectionPool = $this->prophesize(ConnectionPool::class);
+        $this->connectionPool->getConnectionForTable('tx_equedlms_domain_model_usercourserecord')
+            ->willReturn($this->prophesize(Connection::class)->reveal());
 
         $this->persistenceManager
             ->createQueryForType(UserCourseRecord::class)
             ->willReturn($this->query);
 
-        $this->subject = new UserCourseRecordRepository();
+        $this->subject = new UserCourseRecordRepository($this->connectionPool->reveal());
         $this->subject->injectPersistenceManager($this->persistenceManager->reveal());
     }
 


### PR DESCRIPTION
## Summary
- add `deleteAbandonedInProgress()` to user course record repo
- implement deletion logic with DBAL
- refactor ProgressService to use repository method
- adjust related unit tests

## Testing
- `composer test` *(fails: phpunit requires missing PHP extensions)*

------
https://chatgpt.com/codex/tasks/task_e_68515012b2988324bc334b041c0b96f6