### PR TITLE
Introduce FE user account repository

### DIFF
--- a/equed-lms/Classes/Domain/Repository/FrontendUserAccountRepository.php
+++ b/equed-lms/Classes/Domain/Repository/FrontendUserAccountRepository.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Domain\Repository;
+
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * Default implementation of FrontendUserAccountRepositoryInterface.
+ */
+final class FrontendUserAccountRepository implements FrontendUserAccountRepositoryInterface
+{
+    public function __construct(private readonly ConnectionPool $connectionPool)
+    {
+    }
+
+    public function fetchProfile(int $userId): ?array
+    {
+        $qb = $this->connectionPool->getQueryBuilderForTable('fe_users');
+        $qb->select('uid', 'username', 'name', 'email', 'usergroup')
+            ->from('fe_users')
+            ->where(
+                $qb->expr()->eq('uid', $qb->createNamedParameter($userId, \PDO::PARAM_INT)),
+                $qb->expr()->eq('deleted', 0)
+            );
+
+        $row = $qb->executeQuery()->fetchAssociative();
+
+        return $row === false ? null : $row;
+    }
+
+    public function updateProfile(int $userId, array $fields): void
+    {
+        $connection = $this->connectionPool->getConnectionForTable('fe_users');
+        $connection->update('fe_users', $fields, ['uid' => $userId]);
+    }
+}

--- a/equed-lms/Classes/Domain/Repository/FrontendUserAccountRepositoryInterface.php
+++ b/equed-lms/Classes/Domain/Repository/FrontendUserAccountRepositoryInterface.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Domain\Repository;
+
+/**
+ * Repository interface for accessing frontend user account data.
+ */
+interface FrontendUserAccountRepositoryInterface
+{
+    /**
+     * Fetch profile information for a frontend user.
+     *
+     * @param int $userId FE user identifier
+     * @return array<string,mixed>|null Raw profile data or null if not found
+     */
+    public function fetchProfile(int $userId): ?array;
+
+    /**
+     * Update profile fields for a frontend user.
+     *
+     * @param int $userId FE user identifier
+     * @param array<string,mixed> $fields Fields to update
+     */
+    public function updateProfile(int $userId, array $fields): void;
+}

--- a/equed-lms/Classes/Service/UserAccountService.php
+++ b/equed-lms/Classes/Service/UserAccountService.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Equed\EquedLms\Service;
 
-use TYPO3\CMS\Core\Database\ConnectionPool;
-use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+use Equed\EquedLms\Domain\Repository\FrontendUserAccountRepositoryInterface;
 use Equed\EquedLms\Application\Assembler\UserProfileDtoAssembler;
 use Equed\EquedLms\Application\Dto\UserProfileDto;
 use Equed\EquedLms\Domain\Service\UserAccountServiceInterface;
@@ -18,37 +17,23 @@ use Equed\EquedLms\Dto\ProfileUpdateRequest;
 final class UserAccountService implements UserAccountServiceInterface
 {
     public function __construct(
-        private readonly ConnectionPool $connectionPool,
+        private readonly FrontendUserAccountRepositoryInterface $repository,
         private readonly ClockInterface $clock
     ) {
     }
 
     public function getProfile(int $userId): ?UserProfileDto
     {
-        $qb = $this->getQueryBuilder('fe_users');
-        $qb->select('uid', 'username', 'name', 'email', 'usergroup')
-            ->from('fe_users')
-            ->where(
-                $qb->expr()->eq('uid', $qb->createNamedParameter($userId, \PDO::PARAM_INT)),
-                $qb->expr()->eq('deleted', 0)
-            );
+        $profile = $this->repository->fetchProfile($userId);
 
-        $profile = $qb->executeQuery()->fetchAssociative();
-
-        return $profile === false ? null : UserProfileDtoAssembler::fromArray($profile);
+        return $profile === null ? null : UserProfileDtoAssembler::fromArray($profile);
     }
 
     public function updateProfile(int $userId, ProfileUpdateRequest $request): void
     {
         $fields          = $request->getFields();
         $fields['tstamp'] = $this->clock->now()->getTimestamp();
-        $connection = $this->connectionPool->getConnectionForTable('fe_users');
-        $connection->update('fe_users', $fields, ['uid' => $userId]);
-    }
-
-    private function getQueryBuilder(string $table): QueryBuilder
-    {
-        return $this->connectionPool->getQueryBuilderForTable($table);
+        $this->repository->updateProfile($userId, $fields);
     }
 }
 

--- a/equed-lms/Configuration/Services/Services.yaml
+++ b/equed-lms/Configuration/Services/Services.yaml
@@ -52,6 +52,9 @@ services:
   Equed\EquedLms\Domain\Repository\FrontendUserRepositoryInterface:
     class: Equed\EquedLms\Domain\Repository\FrontendUserRepository
 
+  Equed\EquedLms\Domain\Repository\FrontendUserAccountRepositoryInterface:
+    class: Equed\EquedLms\Domain\Repository\FrontendUserAccountRepository
+
   Equed\EquedLms\Domain\Repository\UserProfileRepositoryInterface:
     class: Equed\EquedLms\Domain\Repository\UserProfileRepository
 


### PR DESCRIPTION
## Summary
- add FrontendUserAccountRepository to encapsulate DB access to `fe_users`
- refactor `UserAccountService` to use the new repository
- register repository implementation as a service

## Testing
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851524c9a4883248707bf0fb45861d4