### PR TITLE
Implement TitleAwareGroupInterface for user groups

### DIFF
--- a/equed-lms/Classes/Domain/Model/FrontendUser.php
+++ b/equed-lms/Classes/Domain/Model/FrontendUser.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Equed\EquedLms\Domain\Model;
 
 use TYPO3\CMS\Extbase\Domain\Model\FrontendUser as ExtbaseFrontendUser;
+use Equed\EquedLms\Domain\Model\TitleAwareGroupInterface;
 
 final class FrontendUser extends ExtbaseFrontendUser
 {
@@ -16,7 +17,7 @@ final class FrontendUser extends ExtbaseFrontendUser
     /**
      * List of user groups.
      *
-     * @var array<int, object>
+     * @var array<int, TitleAwareGroupInterface>
      */
     protected array $usergroup = [];
 
@@ -47,13 +48,16 @@ final class FrontendUser extends ExtbaseFrontendUser
         $this->name = $name;
     }
 
+    /**
+     * @return array<int, TitleAwareGroupInterface>
+     */
     public function getUsergroup(): array
     {
         return $this->usergroup;
     }
 
     /**
-     * @param array<int, object> $usergroup
+     * @param array<int, TitleAwareGroupInterface> $usergroup
      */
     public function setUsergroup(array $usergroup): void
     {

--- a/equed-lms/Classes/Domain/Model/FrontendUserGroup.php
+++ b/equed-lms/Classes/Domain/Model/FrontendUserGroup.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Domain\Model;
+
+use TYPO3\CMS\Extbase\Domain\Model\FrontendUserGroup as ExtbaseFrontendUserGroup;
+
+/**
+ * Frontend user group model implementing {@see TitleAwareGroupInterface}.
+ */
+final class FrontendUserGroup extends ExtbaseFrontendUserGroup implements TitleAwareGroupInterface
+{
+}

--- a/equed-lms/Classes/Domain/Model/TitleAwareGroupInterface.php
+++ b/equed-lms/Classes/Domain/Model/TitleAwareGroupInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedLms\Domain\Model;
+
+/**
+ * Interface for user group models that expose a title.
+ */
+interface TitleAwareGroupInterface
+{
+    public function getTitle(): string;
+}

--- a/equed-lms/Classes/Service/DashboardService.php
+++ b/equed-lms/Classes/Service/DashboardService.php
@@ -92,9 +92,7 @@ final class DashboardService implements DashboardServiceInterface
     {
         $roles = [];
         foreach ($user->getUsergroup() as $group) {
-            if (is_object($group) && method_exists($group, 'getTitle')) {
-                $roles[] = $group->getTitle();
-            }
+            $roles[] = $group->getTitle();
         }
 
         return [


### PR DESCRIPTION
## Summary
- add `TitleAwareGroupInterface`
- implement it in new `FrontendUserGroup` model
- type hint user groups in `FrontendUser`
- simplify `DashboardService::buildUserData()`

## Testing
- `composer phpstan` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851554256b48324905932c4f142dfb5