### PR TITLE
Update EventSchedule types

### DIFF
--- a/equed-lms/Classes/Domain/Model/EventSchedule.php
+++ b/equed-lms/Classes/Domain/Model/EventSchedule.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace Equed\EquedLms\Domain\Model;
 
+use DateTimeImmutable;
+use TYPO3\CMS\Extbase\Annotation\ORM\Lazy;
+use TYPO3\CMS\Extbase\Annotation\ORM\ManyToOne;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
+use Equed\EquedLms\Domain\Model\CourseInstance;
 
 /**
  * EventSchedule
@@ -17,17 +21,19 @@ final class EventSchedule extends AbstractEntity
 
     protected string $description = '';
 
-    protected int $courseInstance = 0;
+    #[ManyToOne]
+    #[Lazy]
+    protected ?CourseInstance $courseInstance = null;
 
-    protected string $startDatetime = '';
+    protected ?DateTimeImmutable $startDatetime = null;
 
-    protected string $endDatetime = '';
+    protected ?DateTimeImmutable $endDatetime = null;
 
     protected int $eventType = 0;
 
     protected string $location = '';
 
-    protected string $maxParticipants = '';
+    protected int $maxParticipants = 0;
 
     protected string $notes = '';
 
@@ -37,9 +43,9 @@ final class EventSchedule extends AbstractEntity
 
     protected string $uuid = '';
 
-    protected string $createdAt = '';
+    protected DateTimeImmutable $createdAt;
 
-    protected string $updatedAt = '';
+    protected DateTimeImmutable $updatedAt;
 
     public function getTitle(): string
     {
@@ -61,32 +67,32 @@ final class EventSchedule extends AbstractEntity
         $this->description = $description;
     }
 
-    public function getCourseInstance(): int
+    public function getCourseInstance(): ?CourseInstance
     {
         return $this->courseInstance;
     }
 
-    public function setCourseInstance(int $courseInstance): void
+    public function setCourseInstance(?CourseInstance $courseInstance): void
     {
         $this->courseInstance = $courseInstance;
     }
 
-    public function getStartDatetime(): string
+    public function getStartDatetime(): ?DateTimeImmutable
     {
         return $this->startDatetime;
     }
 
-    public function setStartDatetime(string $startDatetime): void
+    public function setStartDatetime(?DateTimeImmutable $startDatetime): void
     {
         $this->startDatetime = $startDatetime;
     }
 
-    public function getEndDatetime(): string
+    public function getEndDatetime(): ?DateTimeImmutable
     {
         return $this->endDatetime;
     }
 
-    public function setEndDatetime(string $endDatetime): void
+    public function setEndDatetime(?DateTimeImmutable $endDatetime): void
     {
         $this->endDatetime = $endDatetime;
     }
@@ -111,12 +117,12 @@ final class EventSchedule extends AbstractEntity
         $this->location = $location;
     }
 
-    public function getMaxParticipants(): string
+    public function getMaxParticipants(): int
     {
         return $this->maxParticipants;
     }
 
-    public function setMaxParticipants(string $maxParticipants): void
+    public function setMaxParticipants(int $maxParticipants): void
     {
         $this->maxParticipants = $maxParticipants;
     }
@@ -161,22 +167,22 @@ final class EventSchedule extends AbstractEntity
         $this->uuid = $uuid;
     }
 
-    public function getCreatedAt(): string
+    public function getCreatedAt(): DateTimeImmutable
     {
         return $this->createdAt;
     }
 
-    public function setCreatedAt(string $createdAt): void
+    public function setCreatedAt(DateTimeImmutable $createdAt): void
     {
         $this->createdAt = $createdAt;
     }
 
-    public function getUpdatedAt(): string
+    public function getUpdatedAt(): DateTimeImmutable
     {
         return $this->updatedAt;
     }
 
-    public function setUpdatedAt(string $updatedAt): void
+    public function setUpdatedAt(DateTimeImmutable $updatedAt): void
     {
         $this->updatedAt = $updatedAt;
     }


### PR DESCRIPTION
## Summary
- use DateTimeImmutable for date fields
- store `maxParticipants` as int
- relate `EventSchedule` to `CourseInstance`

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851620151c08324a91adf21cde58eb6