### PR TITLE
Remove redundant UserProfile getters

### DIFF
--- a/equed-lms/Classes/Domain/Model/UserProfile.php
+++ b/equed-lms/Classes/Domain/Model/UserProfile.php
@@ -312,22 +312,12 @@ final class UserProfile extends AbstractEntity
         return $this->isInstructor;
     }
 
-    public function getIsInstructor(): bool
-    {
-        return $this->isInstructor();
-    }
-
     public function setIsInstructor(bool $isInstructor): void
     {
         $this->isInstructor = $isInstructor;
     }
 
     public function isOnboardingComplete(): bool
-    {
-        return $this->onboardingComplete;
-    }
-
-    public function getOnboardingComplete(): bool
     {
         return $this->onboardingComplete;
     }

--- a/equed-lms/Classes/Service/UserProfileService.php
+++ b/equed-lms/Classes/Service/UserProfileService.php
@@ -38,6 +38,6 @@ final class UserProfileService
     public function hasCompletedOnboarding(int $userId): bool
     {
         $profile = $this->userProfileRepository->findByUserId($userId);
-        return $profile?->getOnboardingComplete() ?? false;
+        return $profile?->isOnboardingComplete() ?? false;
     }
 }

--- a/equed-lms/phpstan-baseline.neon
+++ b/equed-lms/phpstan-baseline.neon
@@ -6386,16 +6386,6 @@ parameters:
 			path: Classes/Service/UserCourseService.php
 
 		-
-			message: "#^Call to an undefined method Equed\\\\EquedLms\\\\Domain\\\\Model\\\\UserProfile\\:\\:getIsInstructor\\(\\)\\.$#"
-			count: 1
-			path: Classes/Service/UserProfileService.php
-
-		-
-			message: "#^Call to an undefined method Equed\\\\EquedLms\\\\Domain\\\\Model\\\\UserProfile\\:\\:getOnboardingComplete\\(\\)\\.$#"
-			count: 1
-			path: Classes/Service/UserProfileService.php
-
-		-
 			message: "#^Call to an undefined method Equed\\\\EquedLms\\\\Domain\\\\Model\\\\UserCourseRecord\\:\\:getQuizScorePercent\\(\\)\\.$#"
 			count: 1
 			path: Classes/Service/UserProgressService.php


### PR DESCRIPTION
## Summary
- remove redundant `getIsInstructor()` and `getOnboardingComplete()` methods
- update service to use `isOnboardingComplete()`
- clean phpstan baseline

## Testing
- `composer install --no-interaction` *(fails: phpunit fatal error)*
- `composer test` *(fails: cannot declare interface Equed\Core\Service\UuidGeneratorInterface)*

------
https://chatgpt.com/codex/tasks/task_e_68518179810c8324a1e78ac0cb10934e