### PR TITLE
Fix ORM mapping between FrontendUser and UserProfile

### DIFF
--- a/equed-lms/Classes/Domain/Model/FrontendUser.php
+++ b/equed-lms/Classes/Domain/Model/FrontendUser.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace Equed\EquedLms\Domain\Model;
 
 use TYPO3\CMS\Extbase\Domain\Model\FrontendUser as ExtbaseFrontendUser;
+use TYPO3\CMS\Extbase\Annotation\ORM\Lazy;
+use TYPO3\CMS\Extbase\Annotation\ORM\OneToOne;
 use Equed\EquedLms\Domain\Model\TitleAwareGroupInterface;
+use Equed\EquedLms\Domain\Model\UserProfile;
 
 final class FrontendUser extends ExtbaseFrontendUser
 {
@@ -27,6 +30,10 @@ final class FrontendUser extends ExtbaseFrontendUser
      * @var string|null
      */
     protected ?string $apiToken = null;
+
+    #[OneToOne(mappedBy: 'user')]
+    #[Lazy]
+    protected ?UserProfile $userProfile = null;
 
     public function getApiToken(): ?string
     {
@@ -62,5 +69,15 @@ final class FrontendUser extends ExtbaseFrontendUser
     public function setUsergroup(array $usergroup): void
     {
         $this->usergroup = $usergroup;
+    }
+
+    public function getUserProfile(): ?UserProfile
+    {
+        return $this->userProfile;
+    }
+
+    public function setUserProfile(?UserProfile $userProfile): void
+    {
+        $this->userProfile = $userProfile;
     }
 }


### PR DESCRIPTION
## Summary
- map `FrontendUser::$userProfile` to `UserProfile::$user`
- provide getters and setters for the new relation

## Testing
- `composer install --no-interaction --no-progress --ignore-platform-req=ext-dom --ignore-platform-req=ext-simplexml --ignore-platform-req=ext-gd --ignore-platform-req=ext-xml --ignore-platform-req=ext-xmlwriter --ignore-platform-req=ext-xmlreader`
- `composer test` *(fails: PHPUnit requires missing PHP extensions)*

------
https://chatgpt.com/codex/tasks/task_e_685184aadd508324bc28ce51741307c4