### PR TITLE
Fix unintended cascading on LessonProgress

### DIFF
--- a/equed-lms/Classes/Domain/Model/LessonProgress.php
+++ b/equed-lms/Classes/Domain/Model/LessonProgress.php
@@ -6,7 +6,6 @@ namespace Equed\EquedLms\Domain\Model;
 
 use DateTimeImmutable;
 use Ramsey\Uuid\Uuid;
-use TYPO3\CMS\Extbase\Annotation\ORM\Cascade;
 use TYPO3\CMS\Extbase\Annotation\ORM\Lazy;
 use TYPO3\CMS\Extbase\Annotation\ORM\ManyToOne;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
@@ -28,7 +27,6 @@ final class LessonProgress extends AbstractEntity
      */
     #[ManyToOne]
     #[Lazy]
-    #[Cascade('remove')]
     protected Lesson $lesson;
 
     /**


### PR DESCRIPTION
## Summary
- remove `Cascade('remove')` from `LessonProgress::$lesson`
- drop unused import

## Testing
- `composer install --no-interaction` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851b1bdbda08324a21eab06c39d84d7