### PR TITLE
Introduce service interfaces for Core

### DIFF
--- a/equed-core/Classes/Domain/Repository/AuditLogRepository.php
+++ b/equed-core/Classes/Domain/Repository/AuditLogRepository.php
@@ -7,7 +7,7 @@ namespace Equed\EquedCore\Domain\Repository;
 use Equed\EquedCore\Domain\Model\AuditLog;
 use TYPO3\CMS\Extbase\Persistence\Repository;
 use Psr\SimpleCache\CacheInterface;
-use Equed\EquedCore\Service\AuthorizationService;
+use Equed\EquedCore\Domain\Service\AuthorizationServiceInterface;
 use TYPO3\CMS\Core\Exception\AccessDeniedException;
 
 /**
@@ -23,11 +23,11 @@ final class AuditLogRepository extends Repository
 {
     protected CacheInterface $cache;
 
-    protected AuthorizationService $authorizationService;
+    protected AuthorizationServiceInterface $authorizationService;
 
     public function __construct(
         CacheInterface $cache,
-        AuthorizationService $authorizationService
+        AuthorizationServiceInterface $authorizationService
     ) {
         parent::__construct();
         $this->cache = $cache;

--- a/equed-core/Classes/Domain/Repository/CountryRepository.php
+++ b/equed-core/Classes/Domain/Repository/CountryRepository.php
@@ -7,7 +7,7 @@ namespace Equed\EquedCore\Domain\Repository;
 use Equed\EquedCore\Domain\Model\Country;
 use TYPO3\CMS\Extbase\Persistence\Repository;
 use Psr\SimpleCache\CacheInterface;
-use Equed\EquedCore\Service\AuthorizationService;
+use Equed\EquedCore\Domain\Service\AuthorizationServiceInterface;
 use TYPO3\CMS\Core\Exception\AccessDeniedException;
 
 /**
@@ -23,11 +23,11 @@ final class CountryRepository extends Repository
 {
     protected CacheInterface $cache;
 
-    protected AuthorizationService $authorizationService;
+    protected AuthorizationServiceInterface $authorizationService;
 
     public function __construct(
         CacheInterface $cache,
-        AuthorizationService $authorizationService
+        AuthorizationServiceInterface $authorizationService
     ) {
         parent::__construct();
         $this->cache = $cache;

--- a/equed-core/Classes/Domain/Repository/DocumentUploadRepository.php
+++ b/equed-core/Classes/Domain/Repository/DocumentUploadRepository.php
@@ -7,7 +7,7 @@ namespace Equed\EquedCore\Domain\Repository;
 use Equed\EquedCore\Domain\Model\DocumentUpload;
 use TYPO3\CMS\Extbase\Persistence\Repository;
 use Psr\SimpleCache\CacheInterface;
-use Equed\EquedCore\Service\AuthorizationService;
+use Equed\EquedCore\Domain\Service\AuthorizationServiceInterface;
 use TYPO3\CMS\Core\Exception\AccessDeniedException;
 
 /**
@@ -23,11 +23,11 @@ final class DocumentUploadRepository extends Repository
 {
     protected CacheInterface $cache;
 
-    protected AuthorizationService $authorizationService;
+    protected AuthorizationServiceInterface $authorizationService;
 
     public function __construct(
         CacheInterface $cache,
-        AuthorizationService $authorizationService
+        AuthorizationServiceInterface $authorizationService
     ) {
         parent::__construct();
         $this->cache = $cache;

--- a/equed-core/Classes/Domain/Repository/ExternalCertificateRepository.php
+++ b/equed-core/Classes/Domain/Repository/ExternalCertificateRepository.php
@@ -7,7 +7,7 @@ namespace Equed\EquedCore\Domain\Repository;
 use Equed\EquedCore\Domain\Model\ExternalCertificate;
 use TYPO3\CMS\Extbase\Persistence\Repository;
 use Psr\SimpleCache\CacheInterface;
-use Equed\EquedCore\Service\AuthorizationService;
+use Equed\EquedCore\Domain\Service\AuthorizationServiceInterface;
 use TYPO3\CMS\Core\Exception\AccessDeniedException;
 
 /**
@@ -23,11 +23,11 @@ final class ExternalCertificateRepository extends Repository
 {
     protected CacheInterface $cache;
 
-    protected AuthorizationService $authorizationService;
+    protected AuthorizationServiceInterface $authorizationService;
 
     public function __construct(
         CacheInterface $cache,
-        AuthorizationService $authorizationService
+        AuthorizationServiceInterface $authorizationService
     ) {
         parent::__construct();
         $this->cache = $cache;

--- a/equed-core/Classes/Domain/Repository/SearchLogRepository.php
+++ b/equed-core/Classes/Domain/Repository/SearchLogRepository.php
@@ -7,7 +7,7 @@ namespace Equed\EquedCore\Domain\Repository;
 use Equed\EquedCore\Domain\Model\SearchLog;
 use TYPO3\CMS\Extbase\Persistence\Repository;
 use Psr\SimpleCache\CacheInterface;
-use Equed\EquedCore\Service\AuthorizationService;
+use Equed\EquedCore\Domain\Service\AuthorizationServiceInterface;
 use TYPO3\CMS\Core\Exception\AccessDeniedException;
 
 /**
@@ -23,11 +23,11 @@ final class SearchLogRepository extends Repository
 {
     protected CacheInterface $cache;
 
-    protected AuthorizationService $authorizationService;
+    protected AuthorizationServiceInterface $authorizationService;
 
     public function __construct(
         CacheInterface $cache,
-        AuthorizationService $authorizationService
+        AuthorizationServiceInterface $authorizationService
     ) {
         parent::__construct();
         $this->cache = $cache;

--- a/equed-core/Classes/Domain/Repository/UserMetaRepository.php
+++ b/equed-core/Classes/Domain/Repository/UserMetaRepository.php
@@ -7,7 +7,7 @@ namespace Equed\EquedCore\Domain\Repository;
 use Equed\EquedCore\Domain\Model\UserMeta;
 use TYPO3\CMS\Extbase\Persistence\Repository;
 use Psr\SimpleCache\CacheInterface;
-use Equed\EquedCore\Service\AuthorizationService;
+use Equed\EquedCore\Domain\Service\AuthorizationServiceInterface;
 use TYPO3\CMS\Core\Exception\AccessDeniedException;
 
 /**
@@ -23,11 +23,11 @@ final class UserMetaRepository extends Repository
 {
     protected CacheInterface $cache;
 
-    protected AuthorizationService $authorizationService;
+    protected AuthorizationServiceInterface $authorizationService;
 
     public function __construct(
         CacheInterface $cache,
-        AuthorizationService $authorizationService
+        AuthorizationServiceInterface $authorizationService
     ) {
         parent::__construct();
         $this->cache = $cache;

--- a/equed-core/Classes/Domain/Service/AuthorizationServiceInterface.php
+++ b/equed-core/Classes/Domain/Service/AuthorizationServiceInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedCore\Domain\Service;
+
+interface AuthorizationServiceInterface
+{
+    public function isCertifier(): bool;
+
+    public function isServiceCenter(): bool;
+
+    public function isInstructor(): bool;
+}

--- a/equed-core/Classes/Domain/Service/GptTranslationServiceInterface.php
+++ b/equed-core/Classes/Domain/Service/GptTranslationServiceInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedCore\Domain\Service;
+
+interface GptTranslationServiceInterface
+{
+    public function getApiKey(): string;
+
+    public function getEndpoint(): string;
+
+    public function translate(string $text, string $targetLang): string;
+}

--- a/equed-core/Classes/Domain/Service/LmsIntegrationServiceInterface.php
+++ b/equed-core/Classes/Domain/Service/LmsIntegrationServiceInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Equed\EquedCore\Domain\Service;
+
+interface LmsIntegrationServiceInterface
+{
+    public function syncInstructorLevel(int $userId, string $level): void;
+}

--- a/equed-core/Classes/Hooks/CertificationHook.php
+++ b/equed-core/Classes/Hooks/CertificationHook.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Equed\EquedCore\Hooks;
 
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use Equed\EquedCore\Service\LmsIntegrationService;
+use Equed\EquedCore\Domain\Service\LmsIntegrationServiceInterface;
 
 class CertificationHook
 {
@@ -22,7 +22,7 @@ class CertificationHook
     ): void {
         // Sync instructor level to LMS if fe_users record was updated
         if ($table === 'fe_users' && array_key_exists('instructor_level', $incomingFieldArray)) {
-            $service = GeneralUtility::makeInstance(LmsIntegrationService::class);
+            $service = GeneralUtility::makeInstance(LmsIntegrationServiceInterface::class);
             $service->syncInstructorLevel($id, (string)$incomingFieldArray['instructor_level']);
         }
     }

--- a/equed-core/Classes/Service/AuthorizationService.php
+++ b/equed-core/Classes/Service/AuthorizationService.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Equed\EquedCore\Service;
 
+use Equed\EquedCore\Domain\Service\AuthorizationServiceInterface;
+
 /**
  * Basic authorization service using simple role arrays.
  *
  * Roles can either be passed in the constructor or provided through the
  * global `$_SESSION['roles']` array. The checks are case insensitive.
  */
-class AuthorizationService
+class AuthorizationService implements AuthorizationServiceInterface
 {
     /**
      * @var string[]

--- a/equed-core/Classes/Service/GptTranslationService.php
+++ b/equed-core/Classes/Service/GptTranslationService.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Equed\EquedCore\Service;
 
+use Equed\EquedCore\Domain\Service\GptTranslationServiceInterface;
+
 use Equed\EquedCore\Service\GptClientInterface;
 
 /**
  * Basic GPT-based translation helper.
  */
-class GptTranslationService
+class GptTranslationService implements GptTranslationServiceInterface
 {
     /** @internal */
     public const ENV_API_KEY = 'GPT_TRANSLATION_API_KEY';

--- a/equed-core/Classes/Service/LmsIntegrationService.php
+++ b/equed-core/Classes/Service/LmsIntegrationService.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Equed\EquedCore\Service;
 
+use Equed\EquedCore\Domain\Service\LmsIntegrationServiceInterface;
+
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
  * Lightweight client for forwarding data to an external LMS.
  */
-class LmsIntegrationService
+class LmsIntegrationService implements LmsIntegrationServiceInterface
 {
     private const DEFAULT_API_URL = 'https://equed-lms.local/api';
     /**

--- a/equed-core/Configuration/Services.yaml
+++ b/equed-core/Configuration/Services.yaml
@@ -9,3 +9,12 @@ services:
 
   Psr\SimpleCache\CacheInterface:
     class: Equed\EquedCore\Cache\ArrayCache
+
+  Equed\EquedCore\Domain\Service\AuthorizationServiceInterface:
+    class: Equed\EquedCore\Service\AuthorizationService
+
+  Equed\EquedCore\Domain\Service\GptTranslationServiceInterface:
+    class: Equed\EquedCore\Service\GptTranslationService
+
+  Equed\EquedCore\Domain\Service\LmsIntegrationServiceInterface:
+    class: Equed\EquedCore\Service\LmsIntegrationService

--- a/equed-core/Tests/Unit/Domain/Repository/AuditLogRepositoryTest.php
+++ b/equed-core/Tests/Unit/Domain/Repository/AuditLogRepositoryTest.php
@@ -7,6 +7,7 @@ use Equed\EquedCore\Domain\Repository\AuditLogRepository;
 use Equed\EquedCore\Domain\Model\AuditLog;
 use Equed\EquedCore\Cache\ArrayCache;
 use Equed\EquedCore\Service\AuthorizationService;
+use Equed\EquedCore\Domain\Service\AuthorizationServiceInterface;
 use TYPO3\CMS\Core\Exception\AccessDeniedException;
 
 class AuditLogRepositoryTest extends UnitTestCase
@@ -17,7 +18,7 @@ class AuditLogRepositoryTest extends UnitTestCase
     {
         parent::setUp();
         $cache = new ArrayCache();
-        $auth = $this->createMock(AuthorizationService::class);
+        $auth = $this->createMock(AuthorizationServiceInterface::class);
         $this->repository = $this->getMockBuilder(AuditLogRepository::class)
             ->setConstructorArgs([$cache, $auth])
             ->onlyMethods(['findByIdentifier'])
@@ -45,5 +46,5 @@ class AuditLogRepositoryTest extends UnitTestCase
 }
 
 /**
- * Mocked Services: AuthorizationService
+ * Mocked Services: AuthorizationServiceInterface
  */

--- a/equed-core/Tests/Unit/Domain/Repository/CountryRepositoryTest.php
+++ b/equed-core/Tests/Unit/Domain/Repository/CountryRepositoryTest.php
@@ -7,6 +7,7 @@ use Equed\EquedCore\Domain\Repository\CountryRepository;
 use Equed\EquedCore\Domain\Model\Country;
 use Equed\EquedCore\Cache\ArrayCache;
 use Equed\EquedCore\Service\AuthorizationService;
+use Equed\EquedCore\Domain\Service\AuthorizationServiceInterface;
 
 class CountryRepositoryTest extends UnitTestCase
 {
@@ -16,7 +17,7 @@ class CountryRepositoryTest extends UnitTestCase
     {
         parent::setUp();
         $cache = new ArrayCache();
-        $auth = $this->createMock(AuthorizationService::class);
+        $auth = $this->createMock(AuthorizationServiceInterface::class);
         $this->repository = $this->getMockBuilder(CountryRepository::class)
             ->setConstructorArgs([$cache, $auth])
             ->onlyMethods(['findByIdentifier'])
@@ -34,5 +35,5 @@ class CountryRepositoryTest extends UnitTestCase
 }
 
 /**
- * Mocked Services: AuthorizationService
+ * Mocked Services: AuthorizationServiceInterface
  */

--- a/equed-core/Tests/Unit/Domain/Repository/DocumentUploadRepositoryTest.php
+++ b/equed-core/Tests/Unit/Domain/Repository/DocumentUploadRepositoryTest.php
@@ -8,6 +8,7 @@ use Equed\EquedCore\Domain\Model\DocumentUpload;
 use TYPO3\CMS\Extbase\Domain\Model\FileReference;
 use Equed\EquedCore\Cache\ArrayCache;
 use Equed\EquedCore\Service\AuthorizationService;
+use Equed\EquedCore\Domain\Service\AuthorizationServiceInterface;
 use TYPO3\CMS\Core\Exception\AccessDeniedException;
 
 class DocumentUploadRepositoryTest extends UnitTestCase
@@ -18,7 +19,7 @@ class DocumentUploadRepositoryTest extends UnitTestCase
     {
         parent::setUp();
         $cache = new ArrayCache();
-        $auth = $this->createMock(AuthorizationService::class);
+        $auth = $this->createMock(AuthorizationServiceInterface::class);
         $this->repository = $this->getMockBuilder(DocumentUploadRepository::class)
             ->setConstructorArgs([$cache, $auth])
             ->onlyMethods(['findByIdentifier'])
@@ -57,5 +58,5 @@ class DocumentUploadRepositoryTest extends UnitTestCase
 }
 
 /**
- * Mocked Services: AuthorizationService
+ * Mocked Services: AuthorizationServiceInterface
  */

--- a/equed-core/Tests/Unit/Domain/Repository/ExternalCertificateRepositoryTest.php
+++ b/equed-core/Tests/Unit/Domain/Repository/ExternalCertificateRepositoryTest.php
@@ -7,6 +7,7 @@ use Equed\EquedCore\Domain\Repository\ExternalCertificateRepository;
 use Equed\EquedCore\Domain\Model\ExternalCertificate;
 use Equed\EquedCore\Cache\ArrayCache;
 use Equed\EquedCore\Service\AuthorizationService;
+use Equed\EquedCore\Domain\Service\AuthorizationServiceInterface;
 
 class ExternalCertificateRepositoryTest extends UnitTestCase
 {
@@ -16,7 +17,7 @@ class ExternalCertificateRepositoryTest extends UnitTestCase
     {
         parent::setUp();
         $cache = new ArrayCache();
-        $auth = $this->createMock(AuthorizationService::class);
+        $auth = $this->createMock(AuthorizationServiceInterface::class);
         $this->repository = $this->getMockBuilder(ExternalCertificateRepository::class)
             ->setConstructorArgs([$cache, $auth])
             ->onlyMethods(['findByIdentifier'])
@@ -34,5 +35,5 @@ class ExternalCertificateRepositoryTest extends UnitTestCase
 }
 
 /**
- * Mocked Services: AuthorizationService
+ * Mocked Services: AuthorizationServiceInterface
  */

--- a/equed-core/Tests/Unit/Domain/Repository/SearchLogRepositoryTest.php
+++ b/equed-core/Tests/Unit/Domain/Repository/SearchLogRepositoryTest.php
@@ -7,6 +7,7 @@ use Equed\EquedCore\Domain\Repository\SearchLogRepository;
 use Equed\EquedCore\Domain\Model\SearchLog;
 use Equed\EquedCore\Cache\ArrayCache;
 use Equed\EquedCore\Service\AuthorizationService;
+use Equed\EquedCore\Domain\Service\AuthorizationServiceInterface;
 
 class SearchLogRepositoryTest extends UnitTestCase
 {
@@ -16,7 +17,7 @@ class SearchLogRepositoryTest extends UnitTestCase
     {
         parent::setUp();
         $cache = new ArrayCache();
-        $auth = $this->createMock(AuthorizationService::class);
+        $auth = $this->createMock(AuthorizationServiceInterface::class);
         $this->repository = $this->getMockBuilder(SearchLogRepository::class)
             ->setConstructorArgs([$cache, $auth])
             ->onlyMethods(['findByIdentifier'])
@@ -34,5 +35,5 @@ class SearchLogRepositoryTest extends UnitTestCase
 }
 
 /**
- * Mocked Services: AuthorizationService
+ * Mocked Services: AuthorizationServiceInterface
  */

--- a/equed-core/Tests/Unit/Domain/Repository/UserMetaRepositoryTest.php
+++ b/equed-core/Tests/Unit/Domain/Repository/UserMetaRepositoryTest.php
@@ -7,6 +7,7 @@ use Equed\EquedCore\Domain\Repository\UserMetaRepository;
 use Equed\EquedCore\Domain\Model\UserMeta;
 use Equed\EquedCore\Cache\ArrayCache;
 use Equed\EquedCore\Service\AuthorizationService;
+use Equed\EquedCore\Domain\Service\AuthorizationServiceInterface;
 
 class UserMetaRepositoryTest extends UnitTestCase
 {
@@ -16,7 +17,7 @@ class UserMetaRepositoryTest extends UnitTestCase
     {
         parent::setUp();
         $cache = new ArrayCache();
-        $auth = $this->createMock(AuthorizationService::class);
+        $auth = $this->createMock(AuthorizationServiceInterface::class);
         $this->repository = $this->getMockBuilder(UserMetaRepository::class)
             ->setConstructorArgs([$cache, $auth])
             ->onlyMethods(['findByIdentifier'])
@@ -34,5 +35,5 @@ class UserMetaRepositoryTest extends UnitTestCase
 }
 
 /**
- * Mocked Services: AuthorizationService
+ * Mocked Services: AuthorizationServiceInterface
  */

--- a/equed-core/Tests/Unit/Hooks/CertificationHookTest.php
+++ b/equed-core/Tests/Unit/Hooks/CertificationHookTest.php
@@ -4,19 +4,19 @@ namespace Equed\EquedCore\Tests\Unit\Hooks;
 
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 use Equed\EquedCore\Hooks\CertificationHook;
-use Equed\EquedCore\Service\LmsIntegrationService;
+use Equed\EquedCore\Domain\Service\LmsIntegrationServiceInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class CertificationHookTest extends UnitTestCase
 {
     public function testSyncInstructorLevelTriggeredForFeUsers(): void
     {
-        $service = $this->createMock(LmsIntegrationService::class);
+        $service = $this->createMock(LmsIntegrationServiceInterface::class);
         $service->expects($this->once())
             ->method('syncInstructorLevel')
             ->with(42, 'basic');
 
-        GeneralUtility::addInstance(LmsIntegrationService::class, $service);
+        GeneralUtility::addInstance(LmsIntegrationServiceInterface::class, $service);
 
         $hook = new CertificationHook();
         $hook->processDatamap_postProcessFieldArray(


### PR DESCRIPTION
## Summary
- define interfaces for AuthorizationService, GptTranslationService and LMS integration
- implement these interfaces in the services
- inject interfaces in repositories, hook and tests
- wire interfaces to implementations in Services.yaml

## Testing
- `composer install` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685264b9b3388324a8070d58b29b9759